### PR TITLE
Prototype headless mode

### DIFF
--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -23,16 +23,16 @@ import (
 )
 
 type headlessConfigForFile struct {
-	FilePath string
-	Rules    []string
+	FilePath string   `json:"file_path"`
+	Rules    []string `json:"rules"`
 }
 type headlessConfig struct {
-	Files []headlessConfigForFile
+	Files []headlessConfigForFile `json:"files"`
 }
 
 type headlessRange struct {
-	Pos int
-	End int
+	Pos int `json:"pos"`
+	End int `json:"end"`
 }
 
 func headlessRangeFromRange(r core.TextRange) headlessRange {
@@ -43,8 +43,8 @@ func headlessRangeFromRange(r core.TextRange) headlessRange {
 }
 
 type headlessRuleMessage struct {
-	Id          string
-	Description string
+	Id          string `json:"id"`
+	Description string `json:"description"`
 }
 
 func headlessRuleMessageFromRuleMessage(msg rule.RuleMessage) headlessRuleMessage {
@@ -55,20 +55,20 @@ func headlessRuleMessageFromRuleMessage(msg rule.RuleMessage) headlessRuleMessag
 }
 
 type headlessFix struct {
-	Text  string
-	Range headlessRange
+	Text  string        `json:"text"`
+	Range headlessRange `json:"range"`
 }
 type headlessSuggestion struct {
-	Message headlessRuleMessage
-	Fixes   []headlessFix
+	Message headlessRuleMessage `json:"message"`
+	Fixes   []headlessFix       `json:"fixes"`
 }
 type headlessDiagnostic struct {
-	Range       headlessRange
-	RuleName    string
-	Message     headlessRuleMessage
-	Fixes       []headlessFix
-	Suggestions []headlessSuggestion
-	FilePath    string
+	Range       headlessRange        `json:"range"`
+	Rule        string               `json:"rule"`
+	Message     headlessRuleMessage  `json:"message"`
+	Fixes       []headlessFix        `json:"fixes"`
+	Suggestions []headlessSuggestion `json:"suggestions"`
+	FilePath    string               `json:"file_path"`
 }
 
 type headlessMessageType uint8
@@ -174,7 +174,7 @@ func runHeadless(args []string) int {
 		for d := range diagnosticsChan {
 			hd := headlessDiagnostic{
 				Range:       headlessRangeFromRange(d.Range),
-				RuleName:    d.RuleName,
+				Rule:        d.RuleName,
 				Message:     headlessRuleMessageFromRuleMessage(d.Message),
 				Fixes:       make([]headlessFix, len(d.Fixes())),
 				Suggestions: make([]headlessSuggestion, len(d.GetSuggestions())),

--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"sync"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/typescript-eslint/tsgolint/internal/linter"
+	"github.com/typescript-eslint/tsgolint/internal/rule"
+	"github.com/typescript-eslint/tsgolint/internal/utils"
+)
+
+type headlessConfigForFile struct {
+	FilePath string
+	Rules    []string
+}
+type headlessConfig struct {
+	Files []headlessConfigForFile
+}
+
+type headlessRange struct {
+	Pos int
+	End int
+}
+
+func headlessRangeFromRange(r core.TextRange) headlessRange {
+	return headlessRange{
+		Pos: r.Pos(),
+		End: r.End(),
+	}
+}
+
+type headlessRuleMessage struct {
+	Id          string
+	Description string
+}
+
+func headlessRuleMessageFromRuleMessage(msg rule.RuleMessage) headlessRuleMessage {
+	return headlessRuleMessage{
+		Id:          msg.Id,
+		Description: msg.Description,
+	}
+}
+
+type headlessFix struct {
+	Text  string
+	Range headlessRange
+}
+type headlessSuggestion struct {
+	Message headlessRuleMessage
+	Fixes   []headlessFix
+}
+type headlessDiagnostic struct {
+	Range       headlessRange
+	RuleName    string
+	Message     headlessRuleMessage
+	Fixes       []headlessFix
+	Suggestions []headlessSuggestion
+	FilePath    string
+}
+
+type headlessMessageType uint8
+
+const (
+	headlessMessageTypeError headlessMessageType = iota
+	headlessMessageTypeDiagnostic
+)
+
+type headlessMessagePayloadError struct {
+	Error string `json:"error"`
+}
+
+func writeMessage(w io.Writer, messageType headlessMessageType, payload any) error {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	var header [5]byte
+	binary.LittleEndian.PutUint32(header[:], uint32(len(payloadBytes)))
+	header[4] = byte(messageType)
+	w.Write(header[:])
+	w.Write(payloadBytes)
+	return nil
+}
+
+func writeErrorMessage(text string) error {
+	return writeMessage(os.Stdout, headlessMessageTypeError, headlessMessagePayloadError{
+		Error: text,
+	})
+}
+
+func runHeadless(args []string) int {
+	var (
+		tsconfig string
+		cwd      string
+	)
+
+	flag.StringVar(&tsconfig, "tsconfig", "", "which tsconfig to use")
+	flag.StringVar(&cwd, "cwd", "", "current directory")
+	flag.CommandLine.Parse(args)
+
+	if tsconfig == "" {
+		fmt.Fprint(os.Stderr, "--tsconfig is required\n")
+		return 1
+	}
+	if cwd == "" {
+		fmt.Fprint(os.Stderr, "--cwd is required\n")
+		return 1
+	}
+
+	cwd = tspath.NormalizePath(cwd)
+	tsconfig = tspath.NormalizePath(tsconfig)
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+
+	host := utils.CreateCompilerHost(cwd, fs)
+
+	program, err := utils.CreateProgram(false, fs, cwd, tsconfig, host)
+	if err != nil {
+		writeErrorMessage(fmt.Sprintf("error creating TS program: %v", err))
+		return 1
+	}
+
+	configRaw, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		writeErrorMessage(fmt.Sprintf("error reading from stdin: %v", err))
+		return 1
+	}
+
+	var config headlessConfig
+
+	if err := json.Unmarshal(configRaw, &config); err != nil {
+		writeErrorMessage(fmt.Sprintf("error parsing config: %v", err))
+		return 1
+	}
+
+	fileConfigs := make(map[*ast.SourceFile]headlessConfigForFile, len(config.Files))
+	files := make([]*ast.SourceFile, len(config.Files))
+	for i, fileConfig := range config.Files {
+		file := program.GetSourceFile(fileConfig.FilePath)
+		if file == nil {
+			writeErrorMessage(fmt.Sprintf("file %v is not matched by tsconfig", fileConfig.FilePath))
+			return 1
+		}
+		files[i] = file
+		fileConfigs[file] = fileConfig
+	}
+
+	slices.SortFunc(files, func(a *ast.SourceFile, b *ast.SourceFile) int {
+		return len(b.Text()) - len(a.Text())
+	})
+
+	var wg sync.WaitGroup
+
+	diagnosticsChan := make(chan rule.RuleDiagnostic, 4096)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w := bufio.NewWriterSize(os.Stdout, 4096*100)
+		defer w.Flush()
+		for d := range diagnosticsChan {
+			hd := headlessDiagnostic{
+				Range:       headlessRangeFromRange(d.Range),
+				RuleName:    d.RuleName,
+				Message:     headlessRuleMessageFromRuleMessage(d.Message),
+				Fixes:       make([]headlessFix, len(d.Fixes())),
+				Suggestions: make([]headlessSuggestion, len(d.GetSuggestions())),
+				FilePath:    d.SourceFile.FileName(),
+			}
+			for i, fix := range d.Fixes() {
+				hd.Fixes[i] = headlessFix{
+					Text:  fix.Text,
+					Range: headlessRangeFromRange(fix.Range),
+				}
+			}
+			for i, suggestion := range d.GetSuggestions() {
+				hd.Suggestions[i] = headlessSuggestion{
+					Message: headlessRuleMessageFromRuleMessage(d.Message),
+					Fixes:   make([]headlessFix, len(suggestion.Fixes())),
+				}
+				for j, fix := range suggestion.Fixes() {
+					hd.Suggestions[i].Fixes[j] = headlessFix{
+						Text:  fix.Text,
+						Range: headlessRangeFromRange(fix.Range),
+					}
+				}
+			}
+			writeMessage(w, headlessMessageTypeDiagnostic, hd)
+			if w.Available() < 4096 {
+				w.Flush()
+			}
+		}
+	}()
+
+	err = linter.RunLinter(
+		program,
+		false,
+		files,
+		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+			cfg := fileConfigs[sourceFile]
+			rules := make([]linter.ConfiguredRule, len(cfg.Rules))
+
+			for i, ruleName := range cfg.Rules {
+				r, ok := allRulesByName[ruleName]
+				if !ok {
+					panic(fmt.Sprintf("unknown rule: %v", ruleName))
+				}
+				rules[i] = linter.ConfiguredRule{
+					Name: r.Name,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return r.Run(ctx, nil)
+					},
+				}
+			}
+
+			return rules
+		},
+		func(d rule.RuleDiagnostic) {
+			diagnosticsChan <- d
+		},
+	)
+
+	close(diagnosticsChan)
+	if err != nil {
+		writeErrorMessage(fmt.Sprintf("error running linter: %v", err))
+		return 1
+	}
+
+	wg.Wait()
+
+	return 0
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -101,6 +101,12 @@ func (d RuleDiagnostic) Fixes() []RuleFix {
 	}
 	return *d.FixesPtr
 }
+func (d RuleDiagnostic) GetSuggestions() []RuleSuggestion {
+	if d.Suggestions == nil {
+		return []RuleSuggestion{}
+	}
+	return *d.Suggestions
+}
 
 type RuleContext struct {
 	SourceFile                 *ast.SourceFile


### PR DESCRIPTION
Fixes #7, #8, #14

This PR adds a new `tsgolint headless` subcommand. It takes two required arguments: `--tsconfig`, `--cwd`.

Config should be written to the STDIN of the tsgolint process in the JSON format:

```json
{
  "files": [
    {
      "file_path": "/absolute/path/to/file.ts",
      "rules": ["rule-1", "another-rule"]
    }
  ]
}
```

tsgolint will write messages back to the calling party via STDOUT. The format of the messages is as follows:

```
| Payload Size (uint32 LE) - 4 bytes | Message Type (uint8) - 1 byte | Payload |
```

Currently there are two types of message:

- Error - type:`0` ([payload structure](https://github.com/oxc-project/tsgolint/blob/bb0eea711f8804115a7286c7cdcc7916884766c8/cmd/tsgolint/headless.go#L81-L83))
- Diagnostic - type:`1` ([payload structure](https://github.com/oxc-project/tsgolint/blob/bb0eea711f8804115a7286c7cdcc7916884766c8/cmd/tsgolint/headless.go#L33-L72))

Diagnostic messages are issued immediately after the linter has reported them. Therefore they can be read from STDOUT and deserialized while the linter is still running.

---

Example:

```shell
echo "{\"files\":[{\"file_path\":\"$(pwd)/file.ts\",\"rules\":[\"no-unsafe-member-access\",\"require-await\"]}]}" | ./tsgolint headless --tsconfig $(pwd)/tsconfig.json --cwd $(pwd)
```

One of the reported diagnostics:

```json
{
  "range": {
    "pos": 1475,
    "end": 1496
  },
  "rule": "no-unsafe-member-access",
  "message": {
    "id": "unsafeMemberExpression",
    "description": "Unsafe member access .queryResultCacheTable on an `any` value."
  },
  "fixes": [],
  "suggestions": [],
  "file_path": "/<omitted>/tsgolint/benchmarks/typeorm/test/functional/cache/custom-cache-provider.ts"
}

```