### PR TITLE
fix(prefer-return-this-type): check class expressions return `this`

### DIFF
--- a/internal/rules/prefer_return_this_type/prefer_return_this_type_test.go
+++ b/internal/rules/prefer_return_this_type/prefer_return_this_type_test.go
@@ -93,6 +93,13 @@ class Foo {
   f?: string;
 }
     `},
+		{Code: `
+const Foo = class {
+	bar(): this {
+    return this;
+  }
+};
+    `},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `
@@ -398,6 +405,30 @@ class Animal<T> {
 					Line:      3,
 					Column:    10,
 					EndColumn: 19,
+				},
+			},
+		},
+		{
+			Code: `
+const Foo = class FooClass {
+  f(): FooClass {
+    return this;
+  }
+}
+      `,
+			Output: []string{`
+const Foo = class FooClass {
+  f(): this {
+    return this;
+  }
+}
+      `,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "useThisType",
+					Line:      3,
+					Column:    8,
 				},
 			},
 		},


### PR DESCRIPTION
Class expressions are not currently visited but can encounter this
situation:

```ts
const Foo = class FooClass {
  fn(): FooClass {
    return this;
  }
}
```

This change makes the rule visit such expressions and report the
`FooClass` usage.

If there's a cleaner way to do the conditional stuff around declarations vs
expressions, let me know. In go, afaict, it is inevitable that we have to
have two branches to check the two types.
