### PR TITLE
test(only-throw-error): add tests for yield/await errors

### DIFF
--- a/internal/rules/only_throw_error/only_throw_error.go
+++ b/internal/rules/only_throw_error/only_throw_error.go
@@ -50,14 +50,6 @@ var OnlyThrowErrorRule = rule.Rule{
 		return rule.RuleListeners{
 			ast.KindThrowStatement: func(node *ast.Node) {
 				expr := node.Expression()
-				// TODO(port): why do we ignore await and yield here??
-				// if (
-				//   node.type === AST_NODE_TYPES.AwaitExpression ||
-				//   node.type === AST_NODE_TYPES.YieldExpression
-				// ) {
-				//   return;
-				// }
-
 				t := ctx.TypeChecker.GetTypeAtLocation(expr)
 
 				if utils.TypeMatchesSomeSpecifier(t, opts.Allow, opts.AllowInline, ctx.Program) {

--- a/internal/rules/only_throw_error/only_throw_error_test.go
+++ b/internal/rules/only_throw_error/only_throw_error_test.go
@@ -179,6 +179,26 @@ throw new Map();
 				AllowThrowingUnknown: utils.Ref(false),
 			},
 		},
+		{
+			Code: `
+async function foo() {
+  throw await Promise.resolve(new Error('error'));
+}
+      `,
+			Options: OnlyThrowErrorOptions{
+				AllowThrowingAny: utils.Ref(false),
+			},
+		},
+		{
+			Code: `
+function *foo(): Generator<number, void, Error> {
+  throw yield 303;
+}
+      `,
+			Options: OnlyThrowErrorOptions{
+				AllowThrowingAny: utils.Ref(false),
+			},
+		},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: "throw undefined;",
@@ -557,6 +577,48 @@ throw new UnknownError();
 				Allow:                []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"CustomError"}}},
 				AllowThrowingAny:     utils.Ref(false),
 				AllowThrowingUnknown: utils.Ref(false),
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "object",
+				},
+			},
+		},
+		{
+			Code: `
+async function foo() {
+  throw await bar;
+}
+			`,
+			Options: OnlyThrowErrorOptions{
+				AllowThrowingAny: utils.Ref(false),
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "object",
+				},
+			},
+		},
+		{
+			Code: `
+async function foo() {
+  throw await Promise.resolve<number>(303);
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "object",
+				},
+			},
+		},
+		{
+			Code: `
+function *foo(): Generator<number, void, string> {
+  throw yield 303;
+}
+      `,
+			Options: OnlyThrowErrorOptions{
+				AllowThrowingAny: utils.Ref(false),
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{


### PR DESCRIPTION
We can drop this `TODO` since we do actually infer types of yields and
awaits correctly.

It seems typescript will already give us the awaited type when we try
retrieve the type of an `AwaitExpression`. So we're already checking
those correctly.

Similarly, a `yield` evaluates to whatever gets passed to `next(value)`.
So if we have a `Generator<T, void, Error>`, we know it will evaluate as
an `Error`. This is already happening too.

So I have removed the `TODO` and added tests to ensure it keeps working.
