### PR TITLE
perf(tspath): add patch to avoid string allocations when lowercasing paths

### DIFF
--- a/patches/0005-perf-tspath-use-unsafe.String-to-avoid-allocations-w.patch
+++ b/patches/0005-perf-tspath-use-unsafe.String-to-avoid-allocations-w.patch
@@ -1,0 +1,44 @@
+From e978a5e409e5660859b1f96cdd71e3f7653e79d1 Mon Sep 17 00:00:00 2001
+From: Cameron Clark <cameron.clark@hey.com>
+Date: Fri, 15 Aug 2025 16:06:42 +0100
+Subject: [PATCH] perf(tspath): use `unsafe.String` to avoid allocations when
+ lower casing string
+
+---
+ internal/tspath/path.go | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/internal/tspath/path.go b/internal/tspath/path.go
+index 43d7bb6ea..4c62c817b 100644
+--- a/internal/tspath/path.go
++++ b/internal/tspath/path.go
+@@ -4,6 +4,7 @@ import (
+ 	"cmp"
+ 	"strings"
+ 	"unicode"
++	"unsafe"
+ 
+ 	"github.com/microsoft/typescript-go/internal/stringutil"
+ )
+@@ -606,7 +607,17 @@ func ToFileNameLowerCase(fileName string) string {
+ 			}
+ 			b[i] = c
+ 		}
+-		return string(b)
++		// SAFETY: We construct a string that aliases b's backing array without copying.
++		// (1) Lifetime: The address of b's elements escapes via the returned string,
++		//     so escape analysis allocates b's backing array on the heap. The string
++		//     header points to that heap allocation, ensuring it remains live for the
++		//     string's lifetime.
++		// (2) Initialization: We assign to every b[i] before creating the string.
++		//     (Note: Go zeroes all allocated memory, so “uninitialized” bytes cannot occur.)
++		// (3) Immutability: We do not modify b after this point, so the string view
++		//     observes immutable data.
++		// (4) Non-empty: On this path len(b) > 0, so &b[0] is a valid, non-nil pointer.
++		return unsafe.String(&b[0], len(b))
+ 	}
+ 
+ 	return strings.Map(func(r rune) rune {
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
This reduces an allocation when converting strings to lower case.
With how we are currently using project services, this function is called a ridiculous number of times, so avoiding an allocation here, allows for much less GC pressure, improving the perf of the linter.

Ref: https://github.com/microsoft/typescript-go/pull/1575