### PR TITLE
feat: add debug logging

### DIFF
--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -210,7 +210,9 @@ func runHeadless(args []string) int {
 		})
 	}
 
-	log.Printf("Starting linter with %d workers", runtime.GOMAXPROCS(0))
+	if logLevel == LogLevelDebug {
+		log.Printf("Starting linter with %d workers", runtime.GOMAXPROCS(0))
+	}
 	log.Printf("Workload distribution: %d programs", len(workload))
 
 	var wg sync.WaitGroup

--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -196,7 +196,11 @@ func runHeadless(args []string) int {
 	if logLevel == LogLevelDebug {
 		log.Printf("Done assigning files to programs. Total programs: %d", len(workload))
 		for program, files := range workload {
-			log.Printf("  Program %s: %d files", program.Options().ConfigFilePath, len(files))
+			configPath := program.Options().ConfigFilePath
+			if configPath == "" {
+				configPath = "<no tsconfig associated>"
+			}
+			log.Printf("  Program %s: %d files", configPath, len(files))
 		}
 	}
 

--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -212,8 +212,8 @@ func runHeadless(args []string) int {
 
 	if logLevel == LogLevelDebug {
 		log.Printf("Starting linter with %d workers", runtime.GOMAXPROCS(0))
+		log.Printf("Workload distribution: %d programs", len(workload))
 	}
-	log.Printf("Workload distribution: %d programs", len(workload))
 
 	var wg sync.WaitGroup
 

--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"runtime"
 	"slices"
@@ -104,6 +105,8 @@ func writeErrorMessage(text string) error {
 }
 
 func runHeadless(args []string) int {
+	logLevel := getLogLevel()
+
 	var (
 		traceOut   string
 		cpuprofOut string
@@ -115,6 +118,12 @@ func runHeadless(args []string) int {
 	flag.StringVar(&heapOut, "heap", "", "file to put heap profiling to")
 	flag.StringVar(&allocsOut, "allocs", "", "file to put allocs profiling to")
 	flag.CommandLine.Parse(args)
+
+	log.SetOutput(os.Stderr)
+	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
+	if logLevel == LogLevelDebug {
+		log.Printf("Starting tsgolint")
+	}
 
 	if done, err := recordTrace(traceOut); err != nil {
 		os.Stderr.WriteString(err.Error())
@@ -154,12 +163,22 @@ func runHeadless(args []string) int {
 
 	fileConfigs := make(map[*ast.SourceFile]headlessConfigForFile, len(config.Files))
 	workload := linter.Workload{}
-	for _, fileConfig := range config.Files {
+
+	if logLevel == LogLevelDebug {
+		log.Printf("Starting to assign files to programs. Total files: %d", len(config.Files))
+	}
+
+	for idx, fileConfig := range config.Files {
+		if logLevel == LogLevelDebug {
+			log.Printf("[%d/%d] Processing file: %s", idx+1, len(config.Files), fileConfig.FilePath)
+		}
+
 		source, err := os.ReadFile(fileConfig.FilePath)
 		if err != nil {
 			writeErrorMessage(fmt.Sprintf("error reading %v file: %v", fileConfig.FilePath, err))
 			return 1
 		}
+
 		service.OpenFile(fileConfig.FilePath, string(source), core.GetScriptKindFromFileName(fileConfig.FilePath), "")
 		_, project := service.EnsureDefaultProjectForFile(fileConfig.FilePath)
 		program := project.GetProgram()
@@ -173,11 +192,22 @@ func runHeadless(args []string) int {
 		workload[program] = append(workload[program], file)
 	}
 
+	// Log final summary
+	if logLevel == LogLevelDebug {
+		log.Printf("Done assigning files to programs. Total programs: %d", len(workload))
+		for program, files := range workload {
+			log.Printf("  Program %s: %d files", program.Options().ConfigFilePath, len(files))
+		}
+	}
+
 	for _, files := range workload {
 		slices.SortFunc(files, func(a *ast.SourceFile, b *ast.SourceFile) int {
 			return len(b.Text()) - len(a.Text())
 		})
 	}
+
+	log.Printf("Starting linter with %d workers", runtime.GOMAXPROCS(0))
+	log.Printf("Workload distribution: %d programs", len(workload))
 
 	var wg sync.WaitGroup
 
@@ -222,6 +252,10 @@ func runHeadless(args []string) int {
 		}
 	}()
 
+	if logLevel == LogLevelDebug {
+		log.Printf("Running Linter")
+	}
+
 	err = linter.RunLinter(
 		workload,
 		runtime.GOMAXPROCS(0),
@@ -251,11 +285,16 @@ func runHeadless(args []string) int {
 
 	close(diagnosticsChan)
 	if err != nil {
+		log.Printf("ERROR: Linter failed: %v", err)
 		writeErrorMessage(fmt.Sprintf("error running linter: %v", err))
 		return 1
 	}
 
 	wg.Wait()
+
+	if logLevel == LogLevelDebug {
+		log.Printf("Linting Complete")
+	}
 
 	writeMemProfiles(heapOut, allocsOut)
 

--- a/cmd/tsgolint/log.go
+++ b/cmd/tsgolint/log.go
@@ -1,0 +1,21 @@
+package main
+
+import "os"
+
+type LogLevel uint8
+
+const (
+	LogLevelNormal LogLevel = iota
+	LogLevelDebug
+)
+
+func getLogLevel() LogLevel {
+	logLevel := os.Getenv("OXC_LOG")
+
+	if logLevel == "debug" {
+		return LogLevelDebug
+	}
+
+	return LogLevelNormal
+
+}


### PR DESCRIPTION
Closes #66

This writes to stderr, and doens't interfere with oxlint <-> tsgolint stdin/stdout communication

e.g:
```
[2m2025-08-19T14:21:42.790824Z[0m [34mDEBUG[0m [2mignore::gitignore[0m[2m:[0m opened gitignore file: /Users/cameron/.gitignore    
[2m2025-08-19T14:21:42.791010Z[0m [34mDEBUG[0m [2mglobset[0m[2m:[0m built glob set; 2 literals, 1 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 0 regexes    
[2m2025-08-19T14:21:42.791543Z[0m [34mDEBUG[0m [2mignore::gitignore[0m[2m:[0m opened gitignore file: /Users/cameron/github/microsoft/vscode/.gitignore    
[2m2025-08-19T14:21:42.791898Z[0m [34mDEBUG[0m [2mglobset[0m[2m:[0m glob converted to regex: Glob { glob: ".vscode/extensions/**/out", re: "(?-u)^\\.vscode/extensions(?:/|/.*/)out$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([Literal('.'), Literal('v'), Literal('s'), Literal('c'), Literal('o'), Literal('d'), Literal('e'), Literal('/'), Literal('e'), Literal('x'), Literal('t'), Literal('e'), Literal('n'), Literal('s'), Literal('i'), Literal('o'), Literal('n'), Literal('s'), RecursiveZeroOrMore, Literal('o'), Literal('u'), Literal('t')]) }    
[2m2025-08-19T14:21:42.791918Z[0m [34mDEBUG[0m [2mglobset[0m[2m:[0m glob converted to regex: Glob { glob: "extensions/**/dist", re: "(?-u)^extensions(?:/|/.*/)dist$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([Literal('e'), Literal('x'), Literal('t'), Literal('e'), Literal('n'), Literal('s'), Literal('i'), Literal('o'), Literal('n'), Literal('s'), RecursiveZeroOrMore, Literal('d'), Literal('i'), Literal('s'), Literal('t')]) }    
[2m2025-08-19T14:21:42.791929Z[0m [34mDEBUG[0m [2mglobset[0m[2m:[0m glob converted to regex: Glob { glob: "out*", re: "(?-u)^out[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([Literal('o'), Literal('u'), Literal('t'), ZeroOrMore]) }    
[2m2025-08-19T14:21:42.791941Z[0m [34mDEBUG[0m [2mglobset[0m[2m:[0m glob converted to regex: Glob { glob: "extensions/**/out", re: "(?-u)^extensions(?:/|/.*/)out$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([Literal('e'), Literal('x'), Literal('t'), Literal('e'), Literal('n'), Literal('s'), Literal('i'), Literal('o'), Literal('n'), Literal('s'), RecursiveZeroOrMore, Literal('o'), Literal('u'), Literal('t')]) }    
[2m2025-08-19T14:21:42.791988Z[0m [34mDEBUG[0m [2mglobset[0m[2m:[0m built glob set; 4 literals, 14 basenames, 1 extensions, 0 prefixes, 0 suffixes, 1 required extensions, 4 regexes    
[2m2025-08-19T14:21:42.793308Z[0m [34mDEBUG[0m [2mignore::gitignore[0m[2m:[0m opened gitignore file: /Users/cameron/github/microsoft/vscode/.git/info/exclude    
2025/08/19 15:21:42.912370 Starting tsgolint
2025/08/19 15:21:42.926323 Starting to assign files to programs. Total files: 4926
2025/08/19 15:21:42.926350 [1/4926] Processing file: /Users/cameron/github/microsoft/vscode/src/vscode-dts/vscode.proposed.documentFiltersExclusive.d.ts
2025/08/19 15:21:43.722770 [2/4926] Processing file: /Users/cameron/github/microsoft/vscode/src/vscode-dts/vscode.proposed.nativeWindowHandle.d.ts
2025/08/19 15:21:43.722851 [3/4926] Processing file: /Users/cameron/github/microsoft/vscode/src/vscode-dts/vscode.proposed.contribLabelFormatterWorkspaceTooltip.d.ts
2025/08/19 15:21:43.722882 [4/4926] Processing file: /Users/cameron/github/microsoft/vscode/src/vscode-dts/vscode.proposed.contribMenuBarHome.d.ts
2025/08/19 15:21:43.722913 [5/4926] Processing file: /Users/cameron/github/microsoft/vscode/src/vscode-dts/vscode.proposed.notebookReplDocument.d.ts
2025/08/19 15:21:43.722935 [6/4926] Processing file: /Users/cameron/github/microsoft/vscode/src/vscode-dts/vscode.proposed.textDocumentChangeReason.d.ts
...
...
...
2025/08/19 15:21:44.364565 Done assigning files to programs. Total programs: 41
2025/08/19 15:21:44.364568   Program : 1 files
2025/08/19 15:21:44.364571   Program : 1 files
2025/08/19 15:21:44.364573   Program : 1 files
2025/08/19 15:21:44.364575   Program : 1 files
2025/08/19 15:21:44.364577   Program : 1 files
2025/08/19 15:21:44.364579   Program : 1 files
2025/08/19 15:21:44.364581   Program : 1 files
2025/08/19 15:21:44.364584   Program : 1 files
2025/08/19 15:21:44.364586   Program : 1 files
2025/08/19 15:21:44.364589   Program : 1 files
2025/08/19 15:21:44.364591   Program : 1 files
2025/08/19 15:21:44.364594   Program : 1 files
2025/08/19 15:21:44.364595   Program : 1 files
2025/08/19 15:21:44.364598   Program : 1 files
2025/08/19 15:21:44.364607   Program : 1 files
2025/08/19 15:21:44.364608   Program : 1 files
2025/08/19 15:21:44.364610   Program : 1 files
2025/08/19 15:21:44.364612   Program : 1 files
2025/08/19 15:21:44.364614   Program : 1 files
2025/08/19 15:21:44.364616   Program : 1 files
2025/08/19 15:21:44.364618   Program : 1 files
2025/08/19 15:21:44.364620   Program : 1 files
2025/08/19 15:21:44.364622   Program : 1 files
2025/08/19 15:21:44.364626   Program : 1 files
2025/08/19 15:21:44.364628   Program : 1 files
2025/08/19 15:21:44.364630   Program : 1 files
2025/08/19 15:21:44.364632   Program : 1 files
2025/08/19 15:21:44.364634   Program : 1 files
2025/08/19 15:21:44.364636   Program : 1 files
2025/08/19 15:21:44.364638   Program : 1 files
2025/08/19 15:21:44.364640   Program : 1 files
2025/08/19 15:21:44.364642   Program : 1 files
2025/08/19 15:21:44.364643   Program : 1 files
2025/08/19 15:21:44.364645   Program : 1 files
2025/08/19 15:21:44.364647   Program : 1 files
2025/08/19 15:21:44.364649   Program /Users/cameron/github/microsoft/vscode/src/tsconfig.json: 4886 files
2025/08/19 15:21:44.364651   Program : 1 files
2025/08/19 15:21:44.364653   Program : 1 files
2025/08/19 15:21:44.364655   Program : 1 files
2025/08/19 15:21:44.364657   Program : 1 files
2025/08/19 15:21:44.364659   Program : 1 files
2025/08/19 15:21:44.365162 Starting linter with 12 workers
2025/08/19 15:21:44.365165 Workload distribution: 41 programs
2025/08/19 15:21:44.365176 Running Linter
2025/08/19 15:21:50.469254 Linting Complete

Found 0 warnings and 4294 errors.
Finished in 8.7s on 4926 files with 1 rules using 12 threads.

```