### PR TITLE
fix: report an error if no files were specified in headless config

### DIFF
--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -160,6 +160,10 @@ func runHeadless(args []string) int {
 		writeErrorMessage(fmt.Sprintf("error parsing config: %v", err))
 		return 1
 	}
+	if len(config.Files) == 0 {
+		writeErrorMessage("no files specified in config")
+		return 1
+	}
 
 	fileConfigs := make(map[*ast.SourceFile]headlessConfigForFile, len(config.Files))
 	workload := linter.Workload{}


### PR DESCRIPTION
Go's langage means that if i have:
```
type headlessConfig struct {
	Files []headlessConfigForFile `json:"files"`
}
```

and pass in 
```
{} // an empty object with `files property` missing or mis-spelt for example
```

it will successfully deserialize into: (without using a custom deserializer)
```
{
    files: []
}
```

Since, if there're no files needing type aware linting, we should bail out in the oxlint side, this can be a fatal error to highlight to users that something is wrong