### PR TITLE
feat: lint files in inferred programs

### DIFF
--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -268,6 +268,7 @@ func runHeadless(args []string) int {
 	}
 
 	err = linter.RunLinter(
+		cwd,
 		workload,
 		runtime.GOMAXPROCS(0),
 		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {

--- a/internal/utils/create_program.go
+++ b/internal/utils/create_program.go
@@ -46,3 +46,34 @@ func CreateProgram(singleThreaded bool, fs vfs.FS, cwd string, tsconfigPath stri
 
 	return program, nil
 }
+
+func CreateInferredProjectProgram(singleThreaded bool, fs vfs.FS, cwd string, host compiler.CompilerHost, fileNames []string) (*compiler.Program, error) {
+	program := compiler.NewProgram(compiler.ProgramOptions{
+		Config: &tsoptions.ParsedCommandLine{
+			ParsedConfig: &core.ParsedOptions{
+				CompilerOptions: &core.CompilerOptions{
+					AllowJs:                    core.TSTrue,
+					Module:                     core.ModuleKindESNext,
+					ModuleResolution:           core.ModuleResolutionKindBundler,
+					Target:                     core.ScriptTargetES2022,
+					Jsx:                        core.JsxEmitReactJSX,
+					AllowImportingTsExtensions: core.TSTrue,
+					StrictNullChecks:           core.TSTrue,
+					StrictFunctionTypes:        core.TSTrue,
+					SourceMap:                  core.TSTrue,
+					ESModuleInterop:            core.TSTrue,
+					AllowNonTsExtensions:       core.TSTrue,
+					ResolveJsonModule:          core.TSTrue,
+				},
+				FileNames: fileNames,
+			},
+		},
+		SingleThreaded: core.TSTrue,
+		Host:           host,
+	})
+
+	// TODO: report syntactic diagnostics?
+
+	program.BindSourceFiles()
+	return program, nil
+}


### PR DESCRIPTION
For every file we couldn't match to a tsconfig, we create an inferred program for, so that they can be linted

Part of https://github.com/oxc-project/tsgolint/issues/107