### PR TITLE
fix: tsconfig for file being incorrectly resolved

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`TSGoLint E2E Snapshot Tests > should correctly evaluate project references 1`] = `[]`;
+
 exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics snapshot 1`] = `
 [
   {

--- a/e2e/fixtures/project-references/img/typescript/subdir/enum.ts
+++ b/e2e/fixtures/project-references/img/typescript/subdir/enum.ts
@@ -1,0 +1,3 @@
+export enum EnumValue {
+  Value = 'value',
+}

--- a/e2e/fixtures/project-references/img/typescript/subdir/index.ts
+++ b/e2e/fixtures/project-references/img/typescript/subdir/index.ts
@@ -1,0 +1,5 @@
+import { EnumValue } from '~/subdir/enum';
+
+const key = EnumValue.Value;
+
+console.log(key);

--- a/e2e/fixtures/project-references/img/typescript/tsconfig.app.json
+++ b/e2e/fixtures/project-references/img/typescript/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "**/*"
+  ],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.test.ts"
+  ]
+}

--- a/e2e/fixtures/project-references/img/typescript/tsconfig.base.json
+++ b/e2e/fixtures/project-references/img/typescript/tsconfig.base.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noEmit": true,
+    "paths": {
+      "~/*": ["./*"]
+    }
+  }
+}

--- a/e2e/fixtures/project-references/img/typescript/tsconfig.json
+++ b/e2e/fixtures/project-references/img/typescript/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/e2e/fixtures/project-references/img/typescript/tsconfig.spec.json
+++ b/e2e/fixtures/project-references/img/typescript/tsconfig.spec.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["**/*"]
+}

--- a/e2e/fixtures/project-references/package.json
+++ b/e2e/fixtures/project-references/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "tsgolint-test-project-references"
+}

--- a/internal/utils/find_tsconfig.go
+++ b/internal/utils/find_tsconfig.go
@@ -93,6 +93,7 @@ func (r *TsConfigResolver) findConfigWithReferences(
 			if config == nil {
 				return false, false
 			}
+			configs.Store(configFilePath, config)
 			if len(config.FileNames()) == 0 {
 				return false, false
 			}
@@ -125,7 +126,7 @@ func (r *TsConfigResolver) findConfigWithReferences(
 
 	tsconfig := ""
 	if len(search.Path) > 0 {
-		tsconfig = search.Path[len(search.Path)-1].configFileName
+		tsconfig = search.Path[0].configFileName
 	} else {
 		tsconfig = ""
 	}


### PR DESCRIPTION
previously we were not resolving project references correctly, this meant that the correct ts config paths were not being used, this resulted in the types being `any` which caused `no-unsafe-argument` to (correctly) flag an error.

this PR fixes the bug, and adds a snapshot test to prevent regression