### PR TITLE
test: add test for linting files outside a project

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -2,6 +2,39 @@
 
 exports[`TSGoLint E2E Snapshot Tests > should correctly evaluate project references 1`] = `[]`;
 
+exports[`TSGoLint E2E Snapshot Tests > should correctly lint files not inside a project 1`] = `
+[
+  {
+    "file_path": "fixtures/with-unmatched-files/src/index.ts",
+    "fixes": [],
+    "message": {
+      "description": "Unsafe argument of type any assigned to a parameter of type string.",
+      "id": "unsafeArgument",
+    },
+    "range": {
+      "end": 45,
+      "pos": 36,
+    },
+    "rule": "no-unsafe-argument",
+    "suggestions": [],
+  },
+  {
+    "file_path": "fixtures/with-unmatched-files/test.ts",
+    "fixes": [],
+    "message": {
+      "description": "Unsafe argument of type any assigned to a parameter of type string.",
+      "id": "unsafeArgument",
+    },
+    "range": {
+      "end": 45,
+      "pos": 36,
+    },
+    "rule": "no-unsafe-argument",
+    "suggestions": [],
+  },
+]
+`;
+
 exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics snapshot 1`] = `
 [
   {

--- a/e2e/fixtures/with-unmatched-files/src/index.ts
+++ b/e2e/fixtures/with-unmatched-files/src/index.ts
@@ -1,0 +1,3 @@
+function foo(_arg0: string) {}
+
+foo('' as any);

--- a/e2e/fixtures/with-unmatched-files/test.ts
+++ b/e2e/fixtures/with-unmatched-files/test.ts
@@ -1,0 +1,3 @@
+function foo(_arg0: string) {}
+
+foo('' as any);

--- a/e2e/fixtures/with-unmatched-files/tsconfig.json
+++ b/e2e/fixtures/with-unmatched-files/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "include": ["src/**/*"]
+}

--- a/e2e/snapshot.test.ts
+++ b/e2e/snapshot.test.ts
@@ -233,4 +233,23 @@ describe('TSGoLint E2E Snapshot Tests', () => {
 
     expect(diagnostics).toMatchSnapshot();
   });
+
+  it('should correctly lint files not inside a project', async () => {
+    const testFiles = await getTestFiles('with-unmatched-files');
+    expect(testFiles.length).toBeGreaterThan(0);
+
+    const config = generateConfig(testFiles, ['no-unsafe-argument']);
+
+    const env = { ...process.env, GOMAXPROCS: '1' };
+
+    const output = execFileSync(TSGOLINT_BIN, ['headless'], {
+      input: config,
+      env,
+    });
+
+    let diagnostics = parseHeadlessOutput(output);
+    diagnostics = sortDiagnostics(diagnostics);
+
+    expect(diagnostics).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
This adds a test to prevent regressions.



While `e2e/fixtures/with-unmatched-files/src/index.ts`​ is in the project, `e2e/fixtures/with-unmatched-files/test.ts`​ is not. We are expecting both to have the same diagnostics printed for both.