### PR TITLE
perf: only lint included files, not all project files

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -94,7 +94,17 @@ func RunLinter(logLevel utils.LogLevel, currentDirectory string, workload Worklo
 			return err
 		}
 
-		err = RunLinterOnProgram(program, program.SourceFiles(), workers, getRulesForFile, onDiagnostic)
+
+		files := make([]*ast.SourceFile, 0, len(workload.UnmatchedFiles))
+		for _, f := range workload.UnmatchedFiles {
+			sf := program.GetSourceFile(f)
+			if sf == nil {
+				panic(fmt.Sprintf("Expected file '%s' to be in inferred program", f))
+			}
+			files = append(files, sf)
+		}
+
+		err = RunLinterOnProgram(program, files, workers, getRulesForFile, onDiagnostic)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`Program.SourceFiles()` includes **all** source files, including those
from node_modules, builtin libs ect. However we don't need to lint these
files. This PR changes the logic to only lint included files (over
linting all files).