### PR TITLE
chore: do not watch tests when running `just test`

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ build:
   $env:GOEXPERIMENT="greenteagc"; $env:GOOS="windows"; $env:GOARCH="amd64"; go build -o tsgolint.exe ./cmd/tsgolint
 
 test: build
-  cd e2e && pnpm run test && cd ..
+  cd e2e && pnpm run test --run && cd ..
   go test ./internal/...
 
 lint:


### PR DESCRIPTION
Tests were waiting for file changes when running `just test`. Now it runs all tests then exits. https://vitest.dev/guide/cli.html#run