### PR TITLE
feat: expose program diagnostics 

### DIFF
--- a/internal/utils/create_program.go
+++ b/internal/utils/create_program.go
@@ -40,6 +40,11 @@ func CreateProgram(singleThreaded bool, fs vfs.FS, cwd string, tsconfigPath stri
 		return nil, errors.New("couldn't create program")
 	}
 
+	programDiagnostics := program.GetProgramDiagnostics()
+	if len(programDiagnostics) != 0 {
+		return nil, fmt.Errorf("found %v configuration errors. Run `tsgo --noEmit` to see details", len(programDiagnostics))
+	}
+
 	// TODO: report syntactic diagnostics?
 
 	program.BindSourceFiles()


### PR DESCRIPTION
We ran into an issue where our `tsconfig.json` included the baseUrl option, which has been deprecated and removed in tsgo. However `oxlint --type-aware` would still happily try to lint and report confusing type errors like
```bash
⚠ typescript-eslint(no-redundant-type-constituents): 'Property' is an 'error' type that acts as 'any' and overrides all other types in this union type.
```
This made is unclear that the issue was simply due to path not being resolved correctly. 

Running `tsgo` directly immediately reveals the issue
```bash
tsconfig.json:12:5 - error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
  Use '"paths": {"*": ["./*"]}' instead.

12     "baseUrl": "."
       ~~~~~~~~~


Found 1 error in tsconfig.json:12
```
Unfortunately `tsgolint` was silently swallowing these configuration errors making it difficult to identify the problem. 

Given that there's 1000x more users of `tsgolint` compared to `tsgo` (statistics out of my ass), it makes sense to notify user about configuration errors related to tsgo incompatibility in the linter.


Program diagnostics are populated during program creation so it shouldn't have any performance overhead.
So theoretically it should be as simple as this
```go
programDiagnostics := program.GetProgramDiagnostics()
if len(programDiagnostics) != 0 {
	return nil, fmt.Errorf("found %v configuration errors. Run `tsgo --noEmit` to see details", len(programDiagnostics))
}
```

The output of `oxlint --type-aware` after this change:
```bash
Error running tsgolint: "exit status: exit status: 1, error: error running linter: found 1 configuration errors. Run `tsgo --noEmit` to see details
```
