### PR TITLE
perf: `no-array-delete`: only get token ranges when fixing

### DIFF
--- a/internal/rules/no_array_delete/no_array_delete.go
+++ b/internal/rules/no_array_delete/no_array_delete.go
@@ -65,14 +65,14 @@ var NoArrayDeleteRule = rule.Rule{
 					return
 				}
 
-				expressionRange := utils.TrimNodeTextRange(ctx.SourceFile, expression.Expression)
-				argumentRange := utils.TrimNodeTextRange(ctx.SourceFile, expression.ArgumentExpression)
-
-				deleteTokenRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, node.Pos())
-				leftBracketTokenRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, expressionRange.End())
-				rightBracketTokenRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, argumentRange.End())
-
 				ctx.ReportNodeWithSuggestions(node, buildNoArrayDeleteMessage(), func() []rule.RuleSuggestion {
+					expressionRange := utils.TrimNodeTextRange(ctx.SourceFile, expression.Expression)
+					argumentRange := utils.TrimNodeTextRange(ctx.SourceFile, expression.ArgumentExpression)
+
+					deleteTokenRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, node.Pos())
+					leftBracketTokenRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, expressionRange.End())
+					rightBracketTokenRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, argumentRange.End())
+
 					return []rule.RuleSuggestion{{
 						Message: buildUseSpliceMessage(),
 						FixesArr: []rule.RuleFix{


### PR DESCRIPTION
Less work when not fixing: only get the token ranges when fixes should be generated, rather than doing it everytime.