### PR TITLE
feat: report error when failure in creating program

### DIFF
--- a/cmd/tsgolint/main.go
+++ b/cmd/tsgolint/main.go
@@ -404,31 +404,14 @@ func runMain() int {
 		UseCaseSensitiveFileNames: host.FS().UseCaseSensitiveFileNames(),
 	}
 
-	program, diagnostics, err := utils.CreateProgram(singleThreaded, fs, currentDirectory, configFileName, host)
+	program, _, err := utils.CreateProgram(singleThreaded, fs, currentDirectory, configFileName, host)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error creating TS program: %v", err)
 		return 1
 	}
 
 	if program == nil {
-		// Handle diagnostics from program creation
-		fmt.Fprintf(os.Stderr, "error creating TS program:\n")
-		for _, diag := range diagnostics {
-			if diag.File() != nil {
-				// TODO use diagnostic printer
-				fmt.Fprintf(
-					os.Stderr,
-					"  %s: %s\n",
-					diag.File().FileName(),
-					diag.Message(),
-				)
-			} else {
-				fmt.Fprintf(os.Stderr, "  %s\n", diag.Message())
-			}
-		}
-		if len(diagnostics) == 0 {
-			fmt.Fprintf(os.Stderr, "  unknown error creating program\n")
-		}
+		fmt.Fprintf(os.Stderr, "error creating TS program")
 		return 1
 	}
 


### PR DESCRIPTION
When `tsgo` fails to parse the `tsconfig`, it displays an error and, if fatal, returns `nil` when creating the program. However, we didn't implement it, leading to a segfault.

```bash
(base) ethangoh@ethanwu mobile % ./tsgolint
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104dba570]

goroutine 1 [running]:
github.com/microsoft/typescript-go/internal/compiler.(*Program).Host(0x140001e0300?)
        /Users/ethangoh/Developer/tsgolint/typescript-go/internal/compiler/program.go:292
main.runMain()
        /Users/ethangoh/Developer/tsgolint/cmd/tsgolint/main.go:412 +0x6f8
main.main()
        /Users/ethangoh/Developer/tsgolint/cmd/tsgolint/main.go:525 +0x1c
```

The `tsgo` reports:

```
(base) ethangoh@ethanwu mobile % pnpm tsgo
tsconfig.json:23:5 - error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
  Use '"paths": {"*": ["./*"]}' instead.

23     "baseUrl": ".",
       ~~~~~~~~~


Found 1 error in tsconfig.json:23
```

I added the logic to handle the TypeScript error, but I'm new to Go and don't have a clear idea of how those modules work. I wanted to implement a diagnostic report similar to the lint result, but I couldn't successfully understand it.

Now it looks like:


```
(base) ethangoh@ethanwu mobile % ./tsgolint
error creating TS program:
  ***/tsconfig.json: Option 'baseUrl' has been removed. Please remove it from your configuration.
```

If there are any problems, I'm happy to fix!