### PR TITLE
perf: use minimal tsconfig to make tests 2-3x faster

### DIFF
--- a/internal/rules/fixtures/tsconfig.minimal.json
+++ b/internal/rules/fixtures/tsconfig.minimal.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["esnext"],
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true
+  }
+}

--- a/internal/rules/no_base_to_string/no_base_to_string_test.go
+++ b/internal/rules/no_base_to_string/no_base_to_string_test.go
@@ -80,7 +80,7 @@ func TestNoBaseToStringRule(t *testing.T) {
 		}
 	})
 
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoBaseToStringRule, slices.Concat(
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoBaseToStringRule, slices.Concat(
 		extraValid,
 		[]rule_tester.ValidTestCase{
 

--- a/internal/rules/no_duplicate_type_constituents/no_duplicate_type_constituents_test.go
+++ b/internal/rules/no_duplicate_type_constituents/no_duplicate_type_constituents_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoDuplicateTypeConstituentsRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDuplicateTypeConstituentsRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoDuplicateTypeConstituentsRule, []rule_tester.ValidTestCase{
 		{
 			Code: "type T = 1 | 2;",
 		},

--- a/internal/rules/no_meaningless_void_operator/no_meaningless_void_operator_test.go
+++ b/internal/rules/no_meaningless_void_operator/no_meaningless_void_operator_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoMeaninglessVoidOperatorRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoMeaninglessVoidOperatorRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoMeaninglessVoidOperatorRule, []rule_tester.ValidTestCase{
 		{Code: `
 (() => {})();
 

--- a/internal/rules/no_misused_spread/no_misused_spread_test.go
+++ b/internal/rules/no_misused_spread/no_misused_spread_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNoMisusedSpreadRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoMisusedSpreadRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoMisusedSpreadRule, []rule_tester.ValidTestCase{
 		{Code: "const a = [...[1, 2, 3]];"},
 		{Code: "const a = [...([1, 2, 3] as const)];"},
 		{Code: `

--- a/internal/rules/no_mixed_enums/no_mixed_enums_test.go
+++ b/internal/rules/no_mixed_enums/no_mixed_enums_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoMixedEnumsRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoMixedEnumsRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoMixedEnumsRule, []rule_tester.ValidTestCase{
 		{Code: `
       enum Fruit {}
     `},

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoRedundantTypeConstituentsRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRedundantTypeConstituentsRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoRedundantTypeConstituentsRule, []rule_tester.ValidTestCase{
 		{Code: `
       type T = any;
       type U = T;

--- a/internal/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare_test.go
+++ b/internal/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNoUnnecessaryBooleanLiteralCompareRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryBooleanLiteralCompareRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnnecessaryBooleanLiteralCompareRule, []rule_tester.ValidTestCase{
 		{Code: `
       declare const varAny: any;
       varAny === true;

--- a/internal/rules/no_unsafe_argument/no_unsafe_argument_test.go
+++ b/internal/rules/no_unsafe_argument/no_unsafe_argument_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoUnsafeArgumentRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeArgumentRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeArgumentRule, []rule_tester.ValidTestCase{
 		{Code: `
 doesNotExist(1 as any);
     `},

--- a/internal/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison_test.go
+++ b/internal/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoUnsafeEnumComparisonRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeEnumComparisonRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeEnumComparisonRule, []rule_tester.ValidTestCase{
 		{Code: "'a' > 'b';"},
 		{Code: "'a' < 'b';"},
 		{Code: "'a' == 'b';"},

--- a/internal/rules/no_unsafe_type_assertion/no_unsafe_type_assertion_test.go
+++ b/internal/rules/no_unsafe_type_assertion/no_unsafe_type_assertion_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoUnsafeTypeAssertionRule_BasicAssertions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
 		{Code: `
 declare const a: string;
 a as string | number;
@@ -170,7 +170,7 @@ const bar = foo as number[];
 }
 
 func TestNoUnsafeTypeAssertionRule_AnyAssertions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
 		{Code: `
 declare const _any_: any;
 _any_ as any;
@@ -286,7 +286,7 @@ const bar = 'foo' as errorType;
 }
 
 func TestNoUnsafeTypeAssertionRule_NeverAssertions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
 		{Code: `
 declare const _never_: never;
 _never_ as never;
@@ -330,7 +330,7 @@ _string_ as never;
 }
 
 func TestNoUnsafeTypeAssertionRule_FunctionAssertions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
 		{Code: `
 declare const _function_: Function;
 _function_ as Function;
@@ -389,7 +389,7 @@ _function_ as never;
 }
 
 func TestNoUnsafeTypeAssertionRule_ObjectAssertions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
 		{Code: `
 // additional properties should be allowed
 export const foo = { bar: 1, bazz: 1 } as {
@@ -464,7 +464,7 @@ a as { hello: string };
 }
 
 func TestNoUnsafeTypeAssertionRule_ArrayAssertions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
 		{Code: `
 declare const a: string[];
 a as (string | number)[];
@@ -557,7 +557,7 @@ a as never[];
 }
 
 func TestNoUnsafeTypeAssertionRule_TupleAssertions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
 		{Code: `
 declare const a: [string];
 a as [string | number];
@@ -729,7 +729,7 @@ a as [Promise<string>];
 }
 
 func TestNoUnsafeTypeAssertionRule_PromiseAssertions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
 		{Code: `
 declare const a: Promise<string>;
 a as Promise<string | number>;
@@ -841,7 +841,7 @@ a as Promise<never>;
 }
 
 func TestNoUnsafeTypeAssertionRule_ClassAssertions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
 		{Code: `
 class Foo {}
 declare const a: Foo;
@@ -903,7 +903,7 @@ a as Bar;
 }
 
 func TestNoUnsafeTypeAssertionRule_GenericAssertions(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeTypeAssertionRule, []rule_tester.ValidTestCase{
 		{Code: `
 type Obj = { foo: string };
 function func<T extends Obj>(a: T) {

--- a/internal/rules/no_unsafe_unary_minus/no_unsafe_unary_minus_test.go
+++ b/internal/rules/no_unsafe_unary_minus/no_unsafe_unary_minus_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoUnsafeUnaryMinusRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnsafeUnaryMinusRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NoUnsafeUnaryMinusRule, []rule_tester.ValidTestCase{
 		{Code: "+42;"},
 		{Code: "-42;"},
 		{Code: "-42n;"},

--- a/internal/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style_test.go
+++ b/internal/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNonNullableTypeAssertionStyleRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NonNullableTypeAssertionStyleRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &NonNullableTypeAssertionStyleRule, []rule_tester.ValidTestCase{
 		{Code: `
 declare const original: number | string;
 const cast = original as string;

--- a/internal/rules/only_throw_error/only_throw_error_test.go
+++ b/internal/rules/only_throw_error/only_throw_error_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOnlyThrowErrorRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &OnlyThrowErrorRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &OnlyThrowErrorRule, []rule_tester.ValidTestCase{
 		{Code: "throw new Error();"},
 		{Code: "throw new Error('error');"},
 		{Code: "throw Error('error');"},

--- a/internal/rules/prefer_reduce_type_parameter/prefer_reduce_type_parameter_test.go
+++ b/internal/rules/prefer_reduce_type_parameter/prefer_reduce_type_parameter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPreferReduceTypeParameterRule(t *testing.T) {
-	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferReduceTypeParameterRule, []rule_tester.ValidTestCase{
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &PreferReduceTypeParameterRule, []rule_tester.ValidTestCase{
 		{Code: `
       new (class Mine {
         reduce() {}


### PR DESCRIPTION
I had Copilot/Claude think about making tests faster. It came up with a benchmark for the tests and was able to identify that program creation is the bottleneck. By using a trimmed down tsconfig that doesn't include so many libs by default, this reduces the program creation time quite a lot. For the `no-base-to-string` tests, it was 3x faster:

After (~1.5s):
<img width="681" height="39" alt="Screenshot 2025-11-11 at 4 35 23 PM" src="https://github.com/user-attachments/assets/e235259d-f6e6-4d89-98bd-a3bcf5cdba7f" />

Before (~4.5s):
<img width="626" height="21" alt="Screenshot 2025-11-11 at 4 35 36 PM" src="https://github.com/user-attachments/assets/a0057b06-3e4b-49a3-a5ff-ad77fa732ec2" />
