### PR TITLE
docs: add reference to non-type-aware TypeScript rules in oxlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Configure type-aware rules in `.oxlintrc.json`:
 
 Over 30 TypeScript-specific type-aware rules are available. For detailed setup and configuration, see the [Oxlint Type-Aware Linting guide](https://oxc.rs/blog/2025-08-17-oxlint-type-aware.html).
 
+> [!NOTE]
+> Non-type-aware TypeScript rules can be found in [Oxlint's TypeScript rules](https://oxc.rs/docs/guide/usage/linter/rules.html) under the TypeScript source.
+
 ## Performance
 
 **tsgolint** is **20-40 times faster** than ESLint + typescript-eslint.


### PR DESCRIPTION
## Summary

- Adds a note in the README directing users to non-type-aware TypeScript rules available in Oxlint

## Context

Users may not be aware that Oxlint already includes many non-type-aware TypeScript rules. This note helps them discover the full range of TypeScript linting capabilities available across both tsgolint (type-aware) and Oxlint (non-type-aware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)