### PR TITLE
fix(return-await): correct schema to accept string options instead of object

### DIFF
--- a/internal/rules/return_await/options.go
+++ b/internal/rules/return_await/options.go
@@ -6,22 +6,14 @@ import "encoding/json"
 import "fmt"
 import "reflect"
 
-type ReturnAwaitOptions struct {
-	// Configures when to require or disallow returning awaited values: 'always'
-	// requires await, 'never' disallows it, 'in-try-catch' requires it in try/catch
-	// blocks, 'error-handling-correctness-only' requires it only when it affects
-	// error handling
-	Option ReturnAwaitOptionsOption `json:"option,omitempty"`
-}
+type ReturnAwaitOptions string
 
-type ReturnAwaitOptionsOption string
+const ReturnAwaitOptionsAlways ReturnAwaitOptions = "always"
+const ReturnAwaitOptionsErrorHandlingCorrectnessOnly ReturnAwaitOptions = "error-handling-correctness-only"
+const ReturnAwaitOptionsInTryCatch ReturnAwaitOptions = "in-try-catch"
+const ReturnAwaitOptionsNever ReturnAwaitOptions = "never"
 
-const ReturnAwaitOptionsOptionAlways ReturnAwaitOptionsOption = "always"
-const ReturnAwaitOptionsOptionErrorHandlingCorrectnessOnly ReturnAwaitOptionsOption = "error-handling-correctness-only"
-const ReturnAwaitOptionsOptionInTryCatch ReturnAwaitOptionsOption = "in-try-catch"
-const ReturnAwaitOptionsOptionNever ReturnAwaitOptionsOption = "never"
-
-var enumValues_ReturnAwaitOptionsOption = []interface{}{
+var enumValues_ReturnAwaitOptions = []interface{}{
 	"always",
 	"error-handling-correctness-only",
 	"in-try-catch",
@@ -29,39 +21,27 @@ var enumValues_ReturnAwaitOptionsOption = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *ReturnAwaitOptionsOption) UnmarshalJSON(value []byte) error {
+func (j *ReturnAwaitOptions) UnmarshalJSON(value []byte) error {
+	// Handle null value by setting default (schema specifies "in-try-catch" as default)
+	if string(value) == "null" {
+		*j = ReturnAwaitOptionsInTryCatch
+		return nil
+	}
+
 	var v string
 	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
-	for _, expected := range enumValues_ReturnAwaitOptionsOption {
+	for _, expected := range enumValues_ReturnAwaitOptions {
 		if reflect.DeepEqual(v, expected) {
 			ok = true
 			break
 		}
 	}
 	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_ReturnAwaitOptionsOption, v)
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_ReturnAwaitOptions, v)
 	}
-	*j = ReturnAwaitOptionsOption(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ReturnAwaitOptions) UnmarshalJSON(value []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(value, &raw); err != nil {
-		return err
-	}
-	type Plain ReturnAwaitOptions
-	var plain Plain
-	if err := json.Unmarshal(value, &plain); err != nil {
-		return err
-	}
-	if v, ok := raw["option"]; !ok || v == nil {
-		plain.Option = "in-try-catch"
-	}
-	*j = ReturnAwaitOptions(plain)
+	*j = ReturnAwaitOptions(v)
 	return nil
 }

--- a/internal/rules/return_await/return_await.go
+++ b/internal/rules/return_await/return_await.go
@@ -60,24 +60,24 @@ const (
 	whetherToAwaitNoAwait
 )
 
-func getWhetherToAwait(affectsErrorHandling bool, option ReturnAwaitOptionsOption) whetherToAwait {
+func getWhetherToAwait(affectsErrorHandling bool, option ReturnAwaitOptions) whetherToAwait {
 	switch option {
-	case ReturnAwaitOptionsOptionAlways:
+	case ReturnAwaitOptionsAlways:
 		return whetherToAwaitAwait
-	case ReturnAwaitOptionsOptionErrorHandlingCorrectnessOnly:
+	case ReturnAwaitOptionsErrorHandlingCorrectnessOnly:
 		if affectsErrorHandling {
 			return whetherToAwaitAwait
 		}
 		return whetherToAwaitDontCare
-	case ReturnAwaitOptionsOptionInTryCatch:
+	case ReturnAwaitOptionsInTryCatch:
 		if affectsErrorHandling {
 			return whetherToAwaitAwait
 		}
 		return whetherToAwaitNoAwait
-	case ReturnAwaitOptionsOptionNever:
+	case ReturnAwaitOptionsNever:
 		return whetherToAwaitNoAwait
 	default:
-		panic("unexpected ReturnAwaitOptionsOption")
+		panic("unexpected ReturnAwaitOptions")
 	}
 }
 
@@ -240,7 +240,7 @@ var ReturnAwaitRule = rule.Rule{
 			affectsErrorHandling := affectsExplicitErrorHandling(node) || affectsExplicitResourceManagement(node)
 			useAutoFix := !affectsErrorHandling
 
-			shouldAwaitInCurrentContext := getWhetherToAwait(affectsErrorHandling, opts.Option)
+			shouldAwaitInCurrentContext := getWhetherToAwait(affectsErrorHandling, opts)
 
 			switch shouldAwaitInCurrentContext {
 			case whetherToAwaitAwait:

--- a/internal/rules/return_await/return_await_test.go
+++ b/internal/rules/return_await/return_await_test.go
@@ -87,7 +87,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "error-handling-correctness-only"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"error-handling-correctness-only"`),
 		},
 		{Code: `
       async function test() {
@@ -108,7 +108,7 @@ async function test(unknownParam: unknown) {
           return 1;
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code: `
@@ -116,15 +116,15 @@ async function test(unknownParam: unknown) {
           return 1;
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code:    "const test = () => 1;",
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code:    "const test = async () => 1;",
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code: `
@@ -132,7 +132,7 @@ async function test(unknownParam: unknown) {
           return Promise.resolve(1);
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code: `
@@ -146,7 +146,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code: `
@@ -158,7 +158,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code: `
@@ -172,7 +172,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code: `
@@ -188,7 +188,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code: `
@@ -196,11 +196,11 @@ async function test(unknownParam: unknown) {
           return Promise.resolve(1);
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "never"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"never"`),
 		},
 		{
 			Code:    "const test = async () => Promise.resolve(1);",
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "never"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"never"`),
 		},
 		{
 			Code: `
@@ -214,7 +214,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "never"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"never"`),
 		},
 		{
 			Code: `
@@ -222,11 +222,11 @@ async function test(unknownParam: unknown) {
           return await Promise.resolve(1);
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 		},
 		{
 			Code:    "const test = async () => await Promise.resolve(1);",
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 		},
 		{
 			Code: `
@@ -240,7 +240,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 		},
 		{
 			Code: `
@@ -254,7 +254,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 		},
 		{
 			Code: `
@@ -371,7 +371,7 @@ async function f() {
   using something = bleh;
 }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 		},
 		{
 			Code: `
@@ -386,7 +386,7 @@ async function returnAwait() {
   return await asyncFn();
 }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code: `
@@ -403,7 +403,7 @@ async function outerFunction() {
   }
 }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code: `
@@ -418,7 +418,7 @@ async function outerFunction() {
   const innerFunction = async () => asyncFn();
 }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 		},
 		{
 			Code: `
@@ -586,7 +586,7 @@ class C<R extends unknown> {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "error-handling-correctness-only"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"error-handling-correctness-only"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -642,7 +642,7 @@ class C<R extends unknown> {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -698,7 +698,7 @@ class C<R extends unknown> {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -773,7 +773,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "nonPromiseAwait",
@@ -784,7 +784,7 @@ class C<R extends unknown> {
 		{
 			Code:    "const test = async () => await 1;",
 			Output:  []string{"const test = async () =>  1;"},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "nonPromiseAwait",
@@ -795,7 +795,7 @@ class C<R extends unknown> {
 		{
 			Code:    "const test = async () => await Promise.resolve(1);",
 			Output:  []string{"const test = async () =>  Promise.resolve(1);"},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",
@@ -815,7 +815,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",
@@ -835,7 +835,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "never"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"never"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "nonPromiseAwait",
@@ -855,7 +855,7 @@ class C<R extends unknown> {
           }
         }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "never"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"never"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",
@@ -911,7 +911,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "never"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"never"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",
@@ -931,7 +931,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "nonPromiseAwait",
@@ -951,7 +951,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -962,7 +962,7 @@ class C<R extends unknown> {
 		{
 			Code:    "const test = async () => Promise.resolve(1);",
 			Output:  []string{"const test = async () => await Promise.resolve(1);"},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -990,7 +990,7 @@ async function buzz() {
 }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1028,7 +1028,7 @@ async function buzz() {
 }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1064,7 +1064,7 @@ async function buzz() {
 }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1090,7 +1090,7 @@ async function baz() {}
 const buzz = async () => ((await foo()) ? await bar() : await baz());
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1114,7 +1114,7 @@ async function bar() {}
 const buzz = async () => ((await foo()) ?  1 : await bar());
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1548,7 +1548,7 @@ async function f() {
   }
 }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1584,7 +1584,7 @@ async function f() {
   }
 }
       `,
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1630,7 +1630,7 @@ async function f() {
 }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "always"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1668,7 +1668,7 @@ async function outerFunction() {
 }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",
@@ -1702,7 +1702,7 @@ async function outerFunction() {
 }
       `,
 			},
-			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`{"option": "in-try-catch"}`),
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"in-try-catch"`),
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",

--- a/internal/rules/return_await/schema.json
+++ b/internal/rules/return_await/schema.json
@@ -2,20 +2,15 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "definitions": {
     "return_await_options": {
-      "type": "object",
-      "properties": {
-        "option": {
-          "type": "string",
-          "enum": [
-            "always",
-            "error-handling-correctness-only",
-            "in-try-catch",
-            "never"
-          ],
-          "default": "in-try-catch",
-          "description": "Configures when to require or disallow returning awaited values: 'always' requires await, 'never' disallows it, 'in-try-catch' requires it in try/catch blocks, 'error-handling-correctness-only' requires it only when it affects error handling"
-        }
-      }
+      "type": "string",
+      "enum": [
+        "always",
+        "error-handling-correctness-only",
+        "in-try-catch",
+        "never"
+      ],
+      "default": "in-try-catch",
+      "description": "Configures when to require or disallow returning awaited values: 'always' requires await, 'never' disallows it, 'in-try-catch' requires it in try/catch blocks, 'error-handling-correctness-only' requires it only when it affects error handling"
     }
   }
 }


### PR DESCRIPTION
The return-await rule schema incorrectly defined options as an object
with an 'option' property, but typescript-eslint's return-await rule
accepts a plain string value directly (e.g., 'always', 'never').

Changes:
- Fixed schema.json to define return_await_options as a string enum
- Updated generator to add null handling for default value
- Regenerated options.go (now ReturnAwaitOptions is a string type)
- Updated rule code to use opts directly instead of opts.Option
- Simplified test cases to use string format with OptionsFromJSON