### PR TITLE
perf: reduce calls to `string(path)`

### DIFF
--- a/internal/utils/find_tsconfig.go
+++ b/internal/utils/find_tsconfig.go
@@ -75,6 +75,8 @@ func (r *TsConfigResolver) findConfigWithReferences(
 		visited = &collections.SyncSet[searchNode]{}
 	}
 
+	pathString := string(path)
+
 	search := BreadthFirstSearchParallelEx(
 		searchNode{configFileName: configFileName},
 		func(node searchNode) []searchNode {
@@ -116,17 +118,17 @@ func (r *TsConfigResolver) findConfigWithReferences(
 				// If we're on a case-insensitive FS and the strings are equal, we can return true immediately,
 				// no need to allocate and do any path conversions.
 				if r.fs.UseCaseSensitiveFileNames() {
-					if file == string(path) {
+					if file == pathString {
 						return true
 					}
 				} else {
-					if strings.EqualFold(file, string(path)) {
+					if strings.EqualFold(file, pathString) {
 						return true
 					}
 				}
 
 				// If the base names don't match, we can return false immediately.
-				pathBaseName := filepath.Base(string(path))
+				pathBaseName := filepath.Base(pathString)
 				fileBaseName := filepath.Base(file)
 				if r.fs.UseCaseSensitiveFileNames() {
 					if fileBaseName != pathBaseName {


### PR DESCRIPTION
asking copilot to do this took longer than me doing it

https://github.com/oxc-project/tsgolint/pull/440/commits/c31cc88f5caad5c195cbb30e4f2ab0396aa78a12


Hmm my assumption was going to be that going from `tspath` -> `string` allocates. But `tspath` is just a wrapper around string, so I don't think this change will have any (noticable) effect .