### PR TITLE
refactor(ci): split up CI tests to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
-  test:
+  test-go:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -29,6 +29,19 @@ jobs:
 
       - name: Run go tests
         run: go test ./internal/...
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0 # required for git am --3way to work properly
+          submodules: true
+          persist-credentials: false
+
+      - uses: oxc-project/setup-node@fdbf0dfd334c4e6d56ceeb77d91c76339c2a0885 # v1.0.4
+
+      - uses: ./.github/actions/setup
 
       - name: Build
         run: just build


### PR DESCRIPTION
test CI takes ~15+ minutes which is ridiculously slow.

This PR splits up the go tests/e2e tests to speed it up.


@Boshen if we don't have the CI resources to use, we can just close this PR.