### PR TITLE
fix: skip serializing invalid TextRange (-1, -1) in diagnostics

### DIFF
--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -31,8 +31,11 @@ type headlessRange struct {
 	End int `json:"end"`
 }
 
-func headlessRangeFromRange(r core.TextRange) headlessRange {
-	return headlessRange{
+func headlessRangeFromRange(r core.TextRange) *headlessRange {
+	if !r.IsValid() {
+		return nil
+	}
+	return &headlessRange{
 		Pos: r.Pos(),
 		End: r.End(),
 	}
@@ -71,7 +74,7 @@ const (
 
 type headlessDiagnostic struct {
 	Kind     headlessDiagnosticKind `json:"kind"`
-	Range    headlessRange          `json:"range"`
+	Range    *headlessRange         `json:"range,omitempty"`
 	Message  headlessRuleMessage    `json:"message"`
 	FilePath *string                `json:"file_path"`
 
@@ -289,7 +292,7 @@ func runHeadless(args []string) int {
 					for i, fix := range rd.Fixes() {
 						hd.Fixes[i] = headlessFix{
 							Text:  fix.Text,
-							Range: headlessRangeFromRange(fix.Range),
+							Range: *headlessRangeFromRange(fix.Range),
 						}
 					}
 				}
@@ -303,7 +306,7 @@ func runHeadless(args []string) int {
 						for j, fix := range suggestion.Fixes() {
 							hd.Suggestions[i].Fixes[j] = headlessFix{
 								Text:  fix.Text,
-								Range: headlessRangeFromRange(fix.Range),
+								Range: *headlessRangeFromRange(fix.Range),
 							}
 						}
 					}

--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -11,10 +11,6 @@ exports[`TSGoLint E2E Snapshot Tests > should correctly evaluate project referen
 See https://github.com/oxc-project/tsgolint/issues/351 for more information.",
       "id": "tsconfig-error",
     },
-    "range": {
-      "end": -1,
-      "pos": -1,
-    },
   },
 ]
 `;


### PR DESCRIPTION
Fixes #452