### PR TITLE
fix(prefer-includes): prevent false positive on regex metacharacters like \d, \w, \s

### DIFF
--- a/internal/rules/prefer_includes/prefer_includes.go
+++ b/internal/rules/prefer_includes/prefer_includes.go
@@ -38,13 +38,21 @@ var PreferIncludesRule = rule.Rule{
 
 		// Check if a pattern string contains only simple literal characters
 		// The TypeScript version uses a proper ECMAScript regex parser (@eslint-community/regexpp),
-		// but we just check for unescaped metacharacters.
+		// but we just check for unescaped metacharacters and escaped special sequences.
 		isSimpleLiteralPattern := func(pattern string) bool {
 			prevRune := rune(0)
 			for _, ch := range pattern {
 				if prevRune != '\\' {
+					// Unescaped regex metacharacters
 					switch ch {
 					case '.', '*', '+', '?', '|', '^', '$', '[', ']', '(', ')', '{', '}':
+						return false
+					}
+				} else {
+					// Escaped sequences that are regex metacharacters (not simple literals)
+					// \d, \D, \w, \W, \s, \S, \b, \B, \0, \n, \r, \t, \v, \f, \cX, \xHH, \uHHHH, \u{HHHH}
+					switch ch {
+					case 'd', 'D', 'w', 'W', 's', 'S', 'b', 'B', 'c', 'x', 'u':
 						return false
 					}
 				}

--- a/internal/rules/prefer_includes/prefer_includes_test.go
+++ b/internal/rules/prefer_includes/prefer_includes_test.go
@@ -90,6 +90,29 @@ func TestPreferIncludesRule(t *testing.T) {
         return pattern.test(a);
       }
     `},
+		{Code: `
+      const numbers = /\d/;
+      function f(password: string): void {
+        if (numbers.test(password)) {
+          // Should not be flagged - \d is a regex metacharacter
+        }
+      }
+    `},
+		{Code: `
+      function f(password: string): void {
+        /\d/.test(password);
+      }
+    `},
+		{Code: `
+      function f(text: string): void {
+        /\w+/.test(text);
+      }
+    `},
+		{Code: `
+      function f(text: string): void {
+        /\s/.test(text);
+      }
+    `},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/16001