### PR TITLE
fix: nil interface type crash in getBaseTypes (#502)

### DIFF
--- a/patches/0007-fix-nil-interface-type-crash-in-getBaseTypes.patch
+++ b/patches/0007-fix-nil-interface-type-crash-in-getBaseTypes.patch
@@ -1,0 +1,36 @@
+From 7cf3b2d467e97607365d4845c6df7a20006dcf23 Mon Sep 17 00:00:00 2001
+From: Cameron Clark <cameron.clark@hey.com>
+Date: Thu, 11 Dec 2025 21:35:43 +0000
+Subject: [PATCH] fix: nil interface type crash in getBaseTypes
+
+---
+ internal/checker/checker.go | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/internal/checker/checker.go b/internal/checker/checker.go
+index 047517630..2c2b3b046 100644
+--- a/internal/checker/checker.go
++++ b/internal/checker/checker.go
+@@ -11381,6 +11381,9 @@ func (c *Checker) isPropertyDeclaredInAncestorClass(prop *ast.Symbol) bool {
+ 			return false
+ 		}
+ 		classType = baseTypes[0]
++		if classType.symbol == nil || classType.symbol.Flags&(ast.SymbolFlagsClass|ast.SymbolFlagsInterface) == 0 {
++			return false
++		}
+ 		superProperty := c.getPropertyOfType(classType, prop.Name)
+ 		if superProperty != nil && superProperty.ValueDeclaration != nil {
+ 			return true
+@@ -18562,6 +18565,9 @@ func findIndexInfo(indexInfos []*IndexInfo, keyType *Type) *IndexInfo {
+ 
+ func (c *Checker) getBaseTypes(t *Type) []*Type {
+ 	data := t.AsInterfaceType()
++	if data == nil {
++		return nil
++	}
+ 	if !data.baseTypesResolved {
+ 		if !c.pushTypeResolution(t, TypeSystemPropertyNameResolvedBaseTypes) {
+ 			return data.resolvedBaseTypes
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
Fixes a nil pointer dereference when a class extends an unresolved base type that becomes 'any' (an IntrinsicType rather than InterfaceType).

The crash occurs in isPropertyDeclaredInAncestorClass when iterating base types, and getBaseTypes calls AsInterfaceType() on a non-interface type.

This bug only manifests in tsgolint, not in typescript-go's type checker, because it requires:
1. useDefineForClassFields: false (triggers isPropertyDeclaredInAncestorClass)
2. A property initializer referencing 'this'
3. An unresolved base class (common with unmatched files)

Writing a minimal test case is difficult because the crash depends on specific module resolution failures that are hard to reproduce in isolation - the original issue was found in bitwarden/clients where path aliases and complex tsconfig inheritance create unresolved types.

hopefully fixes #502