### PR TITLE
fix(no-base-to-string): remove leading trivia from error message text

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -212,10 +212,7 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-base-to-string/index.ts",
     "kind": 0,
     "message": {
-      "description": "'// Examples of incorrect code for no-base-to-string rule
-
-// These will evaluate to '[object Object]'
-({})' will use Object's default stringification format ('[object Object]') when stringified.",
+      "description": "'({})' will use Object's default stringification format ('[object Object]') when stringified.",
       "id": "baseToString",
     },
     "range": {
@@ -228,8 +225,7 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-base-to-string/index.ts",
     "kind": 0,
     "message": {
-      "description": "'
-({foo: 'bar'})' will use Object's default stringification format ('[object Object]') when stringified.",
+      "description": "'({foo: 'bar'})' will use Object's default stringification format ('[object Object]') when stringified.",
       "id": "baseToString",
     },
     "range": {
@@ -242,8 +238,7 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-base-to-string/index.ts",
     "kind": 0,
     "message": {
-      "description": "'
-({foo: 'bar'})' will use Object's default stringification format ('[object Object]') when stringified.",
+      "description": "'({foo: 'bar'})' will use Object's default stringification format ('[object Object]') when stringified.",
       "id": "baseToString",
     },
     "range": {

--- a/internal/rules/no_base_to_string/no_base_to_string.go
+++ b/internal/rules/no_base_to_string/no_base_to_string.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/typescript-eslint/tsgolint/internal/rule"
 	"github.com/typescript-eslint/tsgolint/internal/utils"
 )
@@ -76,7 +77,7 @@ var NoBaseToStringRule = rule.Rule{
 				return
 			}
 
-			ctx.ReportNode(node, buildBaseToStringMessage(ctx.SourceFile.Text()[node.Pos():node.End()], certainty))
+			ctx.ReportNode(node, buildBaseToStringMessage(scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, node, false /* includeTrivia */), certainty))
 		}
 
 		checkExpressionForArrayJoin := func(
@@ -89,7 +90,7 @@ var NoBaseToStringRule = rule.Rule{
 				return
 			}
 
-			ctx.ReportNode(node, buildBaseArrayJoinMessage(ctx.SourceFile.Text()[node.Pos():node.End()], certainty))
+			ctx.ReportNode(node, buildBaseArrayJoinMessage(scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, node, false /* includeTrivia */), certainty))
 		}
 
 		collectUnionTypeCertainty := func(


### PR DESCRIPTION
Use `scanner.GetSourceTextOfNodeFromSourceFile` with `includeTrivia=false` to exclude leading comments and whitespace from the expression text shown in error messages.

🤖 generated with help from Claude Opus 4.5