### PR TITLE
fix: add mutex to prevent data race in ForEachCheckerParallel callback

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/typescript-eslint/tsgolint/internal/diagnostic"
 	"github.com/typescript-eslint/tsgolint/internal/rule"
@@ -203,8 +204,11 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 		}
 	}
 
+	var flatQueueMu sync.Mutex
 	program.ForEachCheckerParallel(func(idx int, ch *checker.Checker) {
+		flatQueueMu.Lock()
 		flatQueue = append(flatQueue, checkerWorkload{ch, program, queue})
+		flatQueueMu.Unlock()
 	})
 
 	workloadQueue := make(chan checkerWorkload, len(flatQueue))


### PR DESCRIPTION
ForEachCheckerParallel runs its callback in parallel goroutines, but the callback was appending to flatQueue without synchronization. This data race could corrupt the slice, resulting in zero-valued checkerWorkload structs where the queue channel is nil.

When workers later tried to receive from the nil queue channel (line 234: `for file := range w.queue`), they would block forever, causing a deadlock:

    fatal error: all goroutines are asleep - deadlock!
    goroutine 1286 [chan receive (nil chan)]:

The fix adds a mutex around the append operation to ensure thread-safe access to the flatQueue slice.


Ref https://github.com/oxc-project/oxc/issues/17070