### PR TITLE
chore(ci): skip GO test on windows (only run e2e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,6 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Run go tests
-        run: go test ./internal/...
-
       - name: Build
         run: go build -o tsgolint.exe ./cmd/tsgolint
 


### PR DESCRIPTION
windows go tests are too slow. This windows job is more of a sanity check that we haven't done anything stupid with paths/backshashes ect, so the e2e tests are more suited for this