### PR TITLE
fix: defer debug logging to prevent nil pointer access

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -69,16 +69,16 @@ func RunLinter(
 			return err
 		}
 
-		if logLevel == utils.LogLevelDebug {
-			log.Printf("Program created with %d source files", len(program.GetSourceFiles()))
-		}
-
 		if len(diagnostics) > 0 {
 			for _, d := range diagnostics {
 				onInternalDiagnostic(d)
 			}
 			idx++
 			continue
+		}
+
+		if logLevel == utils.LogLevelDebug {
+			log.Printf("Program created with %d source files", len(program.GetSourceFiles()))
 		}
 
 		fileSet := make(map[string]struct{}, len(filePaths))


### PR DESCRIPTION
_Disclosure: I used ChatGPT to improve my writings and English_

---
Fix nil dereference in debug logging.

`utils.CreateProgram` may return a nil program with internal diagnostics.
When debugging is enabled, we log `program.GetSourceFiles()` before checking diagnostics,
causing a nil pointer dereference.
Move the debug log after the internal diagnostics check.
