### PR TITLE
feat: add jsx-no-leaked-render rule

### DIFF
--- a/cmd/tsgolint/main.go
+++ b/cmd/tsgolint/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/typescript-eslint/tsgolint/internal/utils"
 
 	"github.com/typescript-eslint/tsgolint/internal/rules/await_thenable"
+	"github.com/typescript-eslint/tsgolint/internal/rules/jsx_no_leaked_render"
 	"github.com/typescript-eslint/tsgolint/internal/rules/no_array_delete"
 	"github.com/typescript-eslint/tsgolint/internal/rules/no_base_to_string"
 	"github.com/typescript-eslint/tsgolint/internal/rules/no_confusing_void_expression"
@@ -125,6 +126,7 @@ func writeMemProfiles(heapOut string, allocsOut string) {
 
 var allRules = []rule.Rule{
 	await_thenable.AwaitThenableRule,
+	jsx_no_leaked_render.JsxNoLeakedRenderRule,
 	no_array_delete.NoArrayDeleteRule,
 	no_base_to_string.NoBaseToStringRule,
 	no_confusing_void_expression.NoConfusingVoidExpressionRule,

--- a/internal/rules/jsx_no_leaked_render/jsx_no_leaked_render.go
+++ b/internal/rules/jsx_no_leaked_render/jsx_no_leaked_render.go
@@ -1,0 +1,96 @@
+package jsx_no_leaked_render
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/typescript-eslint/tsgolint/internal/rule"
+	"github.com/typescript-eslint/tsgolint/internal/utils"
+)
+
+func buildLeakedRenderMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noLeakedConditionalRendering",
+		Description: "Potential leaked value that might cause unintentionally rendered values or rendering crashes.",
+	}
+}
+
+// checkLeakyType returns true if the type could leak a falsy value to JSX
+func checkLeakyType(t *checker.Type) bool {
+	// any type is always problematic
+	if utils.IsTypeFlagSet(t, checker.TypeFlagsAny) {
+		return true
+	}
+
+	flags := checker.Type_flags(t)
+
+	// Check for number types
+	if flags&checker.TypeFlagsNumberLike != 0 {
+		// If it's a number literal, check if it's 0 (falsy)
+		if t.IsNumberLiteral() {
+			literal := t.AsLiteralType()
+			if literal != nil && literal.String() != "0" {
+				// Non-zero number literal is safe (truthy)
+				return false
+			}
+			// 0 is falsy and can leak
+			return true
+		}
+		// Generic number type - could be 0, so it's leaky
+		return true
+	}
+
+	// Check for bigint types (0n is also falsy and renders "0")
+	if flags&checker.TypeFlagsBigIntLike != 0 {
+		// If it's a bigint literal, check if it's 0n (falsy)
+		if t.IsBigIntLiteral() {
+			literal := t.AsLiteralType()
+			if literal != nil && literal.String() != "0" {
+				// Non-zero bigint literal is safe (truthy)
+				return false
+			}
+			// 0n is falsy and can leak
+			return true
+		}
+		// Generic bigint type - could be 0n, so it's leaky
+		return true
+	}
+
+	// Other types (string, boolean, object, null, undefined) are safe
+	// - string: empty string doesn't render visibly
+	// - boolean: false doesn't render
+	// - object: always truthy
+	// - null/undefined: don't render
+	return false
+}
+
+var JsxNoLeakedRenderRule = rule.Rule{
+	Name: "jsx-no-leaked-render",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				binary := node.AsBinaryExpression()
+
+				// Only check && operator
+				if binary.OperatorToken.Kind != ast.KindAmpersandAmpersandToken {
+					return
+				}
+
+				// Check if inside JSX expression container
+				parent := node.Parent
+				if parent == nil || !ast.IsJsxExpression(parent) {
+					return
+				}
+
+				// Get type of left operand (resolves generics via GetBaseConstraintOfType)
+				leftType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, binary.Left)
+
+				// Check if type could leak (including union members)
+				if utils.TypeRecurser(leftType, func(t *checker.Type) bool {
+					return checkLeakyType(t)
+				}) {
+					ctx.ReportNode(binary.Left, buildLeakedRenderMessage())
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/jsx_no_leaked_render/jsx_no_leaked_render_test.go
+++ b/internal/rules/jsx_no_leaked_render/jsx_no_leaked_render_test.go
@@ -1,0 +1,97 @@
+package jsx_no_leaked_render
+
+import (
+	"testing"
+
+	"github.com/typescript-eslint/tsgolint/internal/rule_tester"
+	"github.com/typescript-eslint/tsgolint/internal/rules/fixtures"
+)
+
+func TestJsxNoLeakedRender(t *testing.T) {
+	t.Parallel()
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoLeakedRenderRule,
+		[]rule_tester.ValidTestCase{
+			// Boolean conditions - safe
+			{Code: `declare const isVisible: boolean; <div>{isVisible && <span/>}</div>`, Tsx: true},
+			{Code: `declare const count: number; <div>{count > 0 && <span/>}</div>`, Tsx: true},
+			{Code: `declare const count: number; <div>{!!count && <span/>}</div>`, Tsx: true},
+			{Code: `declare const count: number; <div>{Boolean(count) && <span/>}</div>`, Tsx: true},
+
+			// String conditions - safe (empty string doesn't render visibly)
+			{Code: `declare const str: string; <div>{str && <span/>}</div>`, Tsx: true},
+
+			// Non-falsy number literals - safe
+			{Code: `declare const x: 1 | 2 | 3; <div>{x && <span/>}</div>`, Tsx: true},
+
+			// Ternary - safe
+			{Code: `declare const count: number; <div>{count ? <span/> : null}</div>`, Tsx: true},
+
+			// Outside JSX - not our concern
+			{Code: `declare const count: number; const x = count && "hello";`},
+
+			// Object/array - safe (even empty objects are truthy)
+			{Code: `declare const obj: object; <div>{obj && <span/>}</div>`, Tsx: true},
+
+			// null/undefined - safe (they don't render)
+			{Code: `declare const x: null; <div>{x && <span/>}</div>`, Tsx: true},
+			{Code: `declare const x: undefined; <div>{x && <span/>}</div>`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Generic number type
+			{
+				Code: `declare const count: number; <div>{count && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1},
+				},
+			},
+			// Array length
+			{
+				Code: `declare const items: string[]; <div>{items.length && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1},
+				},
+			},
+			// any type
+			{
+				Code: `declare const x: any; <div>{x && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1},
+				},
+			},
+			// Union with number
+			{
+				Code: `declare const x: number | string; <div>{x && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1},
+				},
+			},
+			// Generic constrained to number
+			{
+				Code: `function Foo<T extends number>(x: T) { return <div>{x && <span/>}</div> }`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1},
+				},
+			},
+			// Literal 0
+			{
+				Code: `declare const x: 0; <div>{x && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1},
+				},
+			},
+			// bigint (can also be 0n which renders "0")
+			{
+				Code: `declare const x: bigint; <div>{x && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1},
+				},
+			},
+		})
+}

--- a/internal/rules/jsx_no_leaked_render/jsx_no_leaked_render_test.go
+++ b/internal/rules/jsx_no_leaked_render/jsx_no_leaked_render_test.go
@@ -17,24 +17,83 @@ func TestJsxNoLeakedRender(t *testing.T) {
 			{Code: `declare const count: number; <div>{!!count && <span/>}</div>`, Tsx: true},
 			{Code: `declare const count: number; <div>{Boolean(count) && <span/>}</div>`, Tsx: true},
 
-			// String conditions - safe (empty string doesn't render visibly)
+			// String conditions - safe in React 18+ (empty strings treated as null)
+			// See: https://github.com/facebook/react/pull/22807
 			{Code: `declare const str: string; <div>{str && <span/>}</div>`, Tsx: true},
+			{Code: `declare const str: 'hello'; <div>{str && <span/>}</div>`, Tsx: true},
+			{Code: `declare const str: 'a' | 'b' | 'c'; <div>{str && <span/>}</div>`, Tsx: true},
+			{Code: `declare const str: ''; <div>{str && <span/>}</div>`, Tsx: true},
+			{Code: `declare const str: '' | 'hello'; <div>{str && <span/>}</div>`, Tsx: true},
+			{Code: `declare const str: string | null; <div>{str && <span/>}</div>`, Tsx: true},
 
 			// Non-falsy number literals - safe
 			{Code: `declare const x: 1 | 2 | 3; <div>{x && <span/>}</div>`, Tsx: true},
+			{Code: `declare const x: -1; <div>{x && <span/>}</div>`, Tsx: true},
+			{Code: `declare const x: 42; <div>{x && <span/>}</div>`, Tsx: true},
 
-			// Ternary - safe
+			// Ternary - safe (always evaluates to one branch)
 			{Code: `declare const count: number; <div>{count ? <span/> : null}</div>`, Tsx: true},
+			{Code: `declare const count: number; <div>{count ? <span/> : <empty/>}</div>`, Tsx: true},
 
 			// Outside JSX - not our concern
 			{Code: `declare const count: number; const x = count && "hello";`},
+			{Code: `declare const count: number; if (count && true) {}`},
 
 			// Object/array - safe (even empty objects are truthy)
 			{Code: `declare const obj: object; <div>{obj && <span/>}</div>`, Tsx: true},
+			{Code: `declare const arr: string[]; <div>{arr && <span/>}</div>`, Tsx: true},
+			{Code: `declare const obj: { a: number }; <div>{obj && <span/>}</div>`, Tsx: true},
 
 			// null/undefined - safe (they don't render)
 			{Code: `declare const x: null; <div>{x && <span/>}</div>`, Tsx: true},
 			{Code: `declare const x: undefined; <div>{x && <span/>}</div>`, Tsx: true},
+			{Code: `declare const x: null | undefined; <div>{x && <span/>}</div>`, Tsx: true},
+
+			// OR operator - not our concern (returns the truthy value)
+			{Code: `declare const count: number; <div>{count || <span/>}</div>`, Tsx: true},
+
+			// Negation with number - safe (results in boolean)
+			{Code: `declare const count: number; <div>{!count && <span/>}</div>`, Tsx: true},
+
+			// Comparison operators - safe (result is boolean)
+			{Code: `declare const count: number; <div>{count >= 0 && <span/>}</div>`, Tsx: true},
+			{Code: `declare const count: number; <div>{count !== 0 && <span/>}</div>`, Tsx: true},
+			{Code: `declare const count: number; <div>{count === 0 && <span/>}</div>`, Tsx: true},
+			{Code: `declare const items: string[]; <div>{items.length > 0 && <span/>}</div>`, Tsx: true},
+
+			// Nullish coalescing is safe (coerces to the type, not used as condition)
+			{Code: `declare const count: number | null; <div>{(count ?? 0) > 0 && <span/>}</div>`, Tsx: true},
+
+			// Non-zero bigint literals - safe
+			{Code: `declare const x: 1n; <div>{x && <span/>}</div>`, Tsx: true},
+			{Code: `declare const x: 100n; <div>{x && <span/>}</div>`, Tsx: true},
+
+			// Function returning boolean - safe
+			{Code: `declare const hasItems: () => boolean; <div>{hasItems() && <span/>}</div>`, Tsx: true},
+
+			// Boolean union - safe
+			{Code: `declare const x: true | false; <div>{x && <span/>}</div>`, Tsx: true},
+
+			// Nested JSX - the inner expression is not checked as it's not our target
+			{Code: `declare const show: boolean; <div>{show && <span>{show}</span>}</div>`, Tsx: true},
+
+			// Type narrowing with boolean check
+			{Code: `declare const x: number | null; <div>{x !== null && x > 0 && <span/>}</div>`, Tsx: true},
+
+			// never type - safe
+			{Code: `declare const x: never; <div>{x && <span/>}</div>`, Tsx: true},
+
+			// Symbol type - safe (always truthy)
+			{Code: `declare const x: symbol; <div>{x && <span/>}</div>`, Tsx: true},
+
+			// Function type - safe (always truthy)
+			{Code: `declare const fn: () => void; <div>{fn && <span/>}</div>`, Tsx: true},
+
+			// Generic with default (not constraint) - T can be any type, so unconstrained
+			{Code: `function Foo<T = number>(x: T) { return <div>{x && <span/>}</div> }`, Tsx: true},
+
+			// Inferred const with truthy value - literal type 1
+			{Code: `const t = 1; <div>{t && <span/>}</div>`, Tsx: true},
 		},
 		[]rule_tester.InvalidTestCase{
 			// Generic number type
@@ -42,7 +101,7 @@ func TestJsxNoLeakedRender(t *testing.T) {
 				Code: `declare const count: number; <div>{count && <span/>}</div>`,
 				Tsx:  true,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noLeakedConditionalRendering", Line: 1},
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 36, EndColumn: 41},
 				},
 			},
 			// Array length
@@ -50,7 +109,7 @@ func TestJsxNoLeakedRender(t *testing.T) {
 				Code: `declare const items: string[]; <div>{items.length && <span/>}</div>`,
 				Tsx:  true,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noLeakedConditionalRendering", Line: 1},
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 38, EndColumn: 50},
 				},
 			},
 			// any type
@@ -58,15 +117,15 @@ func TestJsxNoLeakedRender(t *testing.T) {
 				Code: `declare const x: any; <div>{x && <span/>}</div>`,
 				Tsx:  true,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noLeakedConditionalRendering", Line: 1},
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 29, EndColumn: 30},
 				},
 			},
-			// Union with number
+			// Union with number (string part is safe in React 18+)
 			{
 				Code: `declare const x: number | string; <div>{x && <span/>}</div>`,
 				Tsx:  true,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noLeakedConditionalRendering", Line: 1},
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 41, EndColumn: 42},
 				},
 			},
 			// Generic constrained to number
@@ -74,7 +133,7 @@ func TestJsxNoLeakedRender(t *testing.T) {
 				Code: `function Foo<T extends number>(x: T) { return <div>{x && <span/>}</div> }`,
 				Tsx:  true,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noLeakedConditionalRendering", Line: 1},
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 53, EndColumn: 54},
 				},
 			},
 			// Literal 0
@@ -82,7 +141,7 @@ func TestJsxNoLeakedRender(t *testing.T) {
 				Code: `declare const x: 0; <div>{x && <span/>}</div>`,
 				Tsx:  true,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noLeakedConditionalRendering", Line: 1},
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 27, EndColumn: 28},
 				},
 			},
 			// bigint (can also be 0n which renders "0")
@@ -90,7 +149,131 @@ func TestJsxNoLeakedRender(t *testing.T) {
 				Code: `declare const x: bigint; <div>{x && <span/>}</div>`,
 				Tsx:  true,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "noLeakedConditionalRendering", Line: 1},
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 32, EndColumn: 33},
+				},
+			},
+			// Literal 0n
+			{
+				Code: `declare const x: 0n; <div>{x && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 28, EndColumn: 29},
+				},
+			},
+			// Nested property access
+			{
+				Code: `
+declare const data: { items: string[] };
+<div>{data.items.length && <span/>}</div>
+      `,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 3, Column: 7, EndColumn: 24},
+				},
+			},
+			// Union including 0 literal
+			{
+				Code: `declare const x: 0 | 1 | 2; <div>{x && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 35, EndColumn: 36},
+				},
+			},
+			// Number with null union - number part is still problematic
+			{
+				Code: `declare const x: number | null; <div>{x && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 39, EndColumn: 40},
+				},
+			},
+			// Number with undefined union
+			{
+				Code: `declare const x: number | undefined; <div>{x && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 44, EndColumn: 45},
+				},
+			},
+			// Generic constrained to bigint
+			{
+				Code: `function Foo<T extends bigint>(x: T) { return <div>{x && <span/>}</div> }`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 53, EndColumn: 54},
+				},
+			},
+			// Type assertion to number
+			{
+				Code: `declare const x: unknown; <div>{(x as number) && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 33, EndColumn: 46},
+				},
+			},
+			// Intersection with number
+			{
+				Code: `declare const x: number & { brand: 'count' }; <div>{x && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 53, EndColumn: 54},
+				},
+			},
+			// Complex multiline case
+			{
+				Code: `
+declare const items: {
+  nested: {
+    count: number;
+  };
+};
+<div>
+  {items.nested.count && <span/>}
+</div>
+      `,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 8, Column: 4, EndColumn: 22},
+				},
+			},
+			// Index access returning number
+			{
+				Code: `declare const counts: number[]; <div>{counts[0] && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 39, EndColumn: 48},
+				},
+			},
+			// Method call returning number
+			{
+				Code: `declare const getCount: () => number; <div>{getCount() && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 45, EndColumn: 55},
+				},
+			},
+			// Optional number property - could be number (0), null, or undefined
+			{
+				Code: `declare const rating: { count?: number | null }; <div>{rating.count && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 56, EndColumn: 68},
+				},
+			},
+			// NaN - has type number, so caught
+			{
+				Code: `const t = NaN; <div>{t && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 22, EndColumn: 23},
+				},
+			},
+			// Inferred const 0 - literal type 0
+			{
+				Code: `const t = 0; <div>{t && <span/>}</div>`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noLeakedConditionalRendering", Line: 1, Column: 20, EndColumn: 21},
 				},
 			},
 		})


### PR DESCRIPTION
## Summary

Adds a new `jsx-no-leaked-render` rule that prevents falsy numeric values from leaking into JSX when using the `&&` operator.

### The Problem

```tsx
// 😱 Renders "0" visibly in the DOM
{count && <Badge>{count}</Badge>}

// 😱 Renders "NaN" visibly in the DOM  
{items.length && <List items={items}/>}
```

### What This Rule Flags

| Type | Flagged | Reason |
|------|---------|--------|
| `number` | ✅ | Could be `0` or `NaN` which render visibly |
| `bigint` | ✅ | Could be `0n` which renders as "0" |
| `any` | ✅ | Could be any of the above |
| `string` | ❌ | Safe in React 18+ (see below) |
| `boolean` | ❌ | `false` is ignored by React |
| `null`/`undefined` | ❌ | Ignored by React |
| `object` | ❌ | Always truthy |

### Safe Patterns

```tsx
{count > 0 && <Badge>{count}</Badge>}
{!!count && <Badge>{count}</Badge>}
{Boolean(count) && <Badge>{count}</Badge>}
{count ? <Badge>{count}</Badge> : null}
```

### Why Strings Are NOT Flagged

We intentionally do not flag `string` types for two reasons:

#### 1. Empty strings are typically intentional

When a developer writes `{title && <Header>{title}</Header>}`, hiding the component when `title` is an empty string is usually the desired behavior. Unlike `0` which is often a valid count that shouldn't hide content, an empty string typically means "no value".

#### 2. React 18+ treats empty strings as null

As of React 18, empty strings are coalesced to `null` in the reconciler, meaning they create no DOM text node. This was changed in [facebook/react#22807](https://github.com/facebook/react/pull/22807) to fix hydration mismatches.

**Before React 18:**
- Empty string `""` → created empty text node → potential issues

**React 18+:**
- Empty string `""` → treated as `null` → no DOM output → safe

This change also benefits React Native, where the previous behavior of rendering empty strings outside `<Text>` components would cause crashes. With React 18+, empty strings are safely ignored.

From the [React reconciler source](https://jser.dev/react/2022/02/04/how-React-handles-empty-values/):
```javascript
if (
  (typeof newChild === "string" && newChild !== "") ||
  typeof newChild === "number"
) {
  // Only non-empty strings and numbers create text nodes
}
```

### Inspiration

Based on [eslint-plugin-jsx-no-leaked-values](https://github.com/gkiely/eslint-plugin-jsx-no-leaked-values) with enhancements:
- Flags any `number` type, not just literal `0` values
- Uses TypeScript type information for accurate detection
- Allows truthy number literals (`1`, `42`, `-1`) 

### Test Coverage

- 39 valid test cases
- 20 invalid test cases

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)