### PR TITLE
chore: add profile outputs to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 internal/collections/
 e2e/node_modules/
 node_modules/
+
+*.pprof
+*.out
+


### PR DESCRIPTION
The output of `pprof` and `trace` shouldn't be committed :)