### PR TITLE
fix(no-unsafe-return): prevent false positives for contextually-typed arrow functions

### DIFF
--- a/internal/rules/no_unsafe_return/no_unsafe_return.go
+++ b/internal/rules/no_unsafe_return/no_unsafe_return.go
@@ -29,6 +29,140 @@ func buildUnsafeReturnThisMessage(t string) rule.RuleMessage {
 	}
 }
 
+// containsExplicitAny checks if a node or its descendants contain an explicit `any` type annotation.
+// This is used to distinguish between:
+// - Explicit `any` usage (e.g., `x as any`, `[] as any[]`, `new Set<any>()`) - intentional
+// - Inferred `any` due to type resolution issues - potentially false positive
+func containsExplicitAny(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	// Check if this node is an `any` keyword
+	if node.Kind == ast.KindAnyKeyword {
+		return true
+	}
+
+	// Check type assertions: `x as any` or `x as any[]`
+	if node.Kind == ast.KindAsExpression {
+		asExpr := node.AsAsExpression()
+		if containsExplicitAny(asExpr.Type) {
+			return true
+		}
+		// Also check the expression in case of nested assertions
+		return containsExplicitAny(asExpr.Expression)
+	}
+
+	// Check type assertions: `<any>x`
+	if node.Kind == ast.KindTypeAssertionExpression {
+		typeAssertion := node.AsTypeAssertion()
+		if containsExplicitAny(typeAssertion.Type) {
+			return true
+		}
+		return containsExplicitAny(typeAssertion.Expression)
+	}
+
+	// Check call expressions with type arguments: `foo<any>()`
+	if ast.IsCallExpression(node) {
+		callExpr := node.AsCallExpression()
+		if callExpr.TypeArguments != nil {
+			for _, typeArg := range callExpr.TypeArguments.Nodes {
+				if containsExplicitAny(typeArg) {
+					return true
+				}
+			}
+		}
+		// Check the callee and arguments
+		if containsExplicitAny(callExpr.Expression) {
+			return true
+		}
+		for _, arg := range callExpr.Arguments.Nodes {
+			if containsExplicitAny(arg) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Check new expressions with type arguments: `new Set<any>()`
+	if ast.IsNewExpression(node) {
+		newExpr := node.AsNewExpression()
+		if newExpr.TypeArguments != nil {
+			for _, typeArg := range newExpr.TypeArguments.Nodes {
+				if containsExplicitAny(typeArg) {
+					return true
+				}
+			}
+		}
+		if containsExplicitAny(newExpr.Expression) {
+			return true
+		}
+		if newExpr.Arguments != nil {
+			for _, arg := range newExpr.Arguments.Nodes {
+				if containsExplicitAny(arg) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Check array type: `any[]`
+	if node.Kind == ast.KindArrayType {
+		arrayType := node.AsArrayTypeNode()
+		return containsExplicitAny(arrayType.ElementType)
+	}
+
+	// Check type reference with type arguments: `Array<any>`, `Set<any>`, etc.
+	if node.Kind == ast.KindTypeReference {
+		typeRef := node.AsTypeReferenceNode()
+		if typeRef.TypeArguments != nil {
+			for _, typeArg := range typeRef.TypeArguments.Nodes {
+				if containsExplicitAny(typeArg) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Check property access: `obj.prop`
+	if ast.IsPropertyAccessExpression(node) {
+		propAccess := node.AsPropertyAccessExpression()
+		return containsExplicitAny(propAccess.Expression)
+	}
+
+	// Check element access: `obj[key]`
+	if ast.IsElementAccessExpression(node) {
+		elemAccess := node.AsElementAccessExpression()
+		return containsExplicitAny(elemAccess.Expression) || containsExplicitAny(elemAccess.ArgumentExpression)
+	}
+
+	// Check array literals
+	if ast.IsArrayLiteralExpression(node) {
+		arrayLit := node.AsArrayLiteralExpression()
+		for _, elem := range arrayLit.Elements.Nodes {
+			if containsExplicitAny(elem) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Check object literals
+	if ast.IsObjectLiteralExpression(node) {
+		objLit := node.AsObjectLiteralExpression()
+		for _, prop := range objLit.Properties.Nodes {
+			if containsExplicitAny(prop) {
+				return true
+			}
+		}
+		return false
+	}
+
+	return false
+}
+
 var NoUnsafeReturnRule = rule.Rule{
 	Name: "no-unsafe-return",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
@@ -116,6 +250,26 @@ var NoUnsafeReturnRule = rule.Rule{
 
 				if anyType == utils.DiscriminatedAnyTypePromiseAny && !ast.HasSyntacticModifier(functionNode, ast.ModifierFlagsAsync) {
 					return
+				}
+
+				// For arrow functions/function expressions without explicit type annotations:
+				// If the type is inferred as `any` but the source code doesn't contain explicit `any`,
+				// and there's contextual typing with a concrete return type, trust TypeScript's
+				// type inference. This prevents false positives when typescript-go's type resolution
+				// differs from TypeScript's for complex types (e.g., conditional types, mapped types).
+				if anyType == utils.DiscriminatedAnyTypeAny &&
+					functionNode.Type() == nil &&
+					(ast.IsFunctionExpression(functionNode) || ast.IsArrowFunction(functionNode)) &&
+					!containsExplicitAny(returnNode) {
+					for _, signature := range callSignatures {
+						signatureReturnType := checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, signature)
+						// If the contextual return type is a concrete type (not any/unknown),
+						// don't flag the return as unsafe
+						if signatureReturnType != nil &&
+							!utils.IsTypeFlagSet(signatureReturnType, checker.TypeFlagsAny|checker.TypeFlagsUnknown) {
+							return
+						}
+					}
 				}
 
 				var typeString string

--- a/internal/rules/no_unsafe_return/no_unsafe_return_test.go
+++ b/internal/rules/no_unsafe_return/no_unsafe_return_test.go
@@ -157,6 +157,27 @@ function foo(): Set<number> {
         }
       }
     `},
+		// Test case: conditional type with ReturnType should correctly resolve property types
+		// When using Unwrap<ReturnType<typeof fn>>, the resolved type's properties should
+		// not be incorrectly inferred as `any`.
+		{Code: `
+      type Wrapper<T> = { value: T };
+      type Unwrap<W> = W extends Wrapper<infer T> ? T : never;
+
+      // Using declare to focus on the type resolution, not the implementation
+      declare function create(): Wrapper<{ id: string }>;
+
+      type Result = Unwrap<ReturnType<typeof create>>;
+      declare const items: Result[];
+      const ids = items.map((i) => i.id);  // i.id should be string, not any
+    `},
+		// Test case for array.map with properly typed callback parameter
+		{Code: `
+      interface Item { id: string; name: string }
+      declare const items: Item[];
+      const ids = items.map((item) => item.id);
+      const names = items.map((item) => item.name);
+    `},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `


### PR DESCRIPTION
## Summary

Fixes false positives in `no-unsafe-return` where arrow function callbacks (e.g., `.map()` callbacks) were incorrectly flagged as returning `any` when TypeScript correctly infers the type through contextual typing.

## Problem

When using complex types like conditional types with `ReturnType<typeof fn>`, typescript-go's type inference could report a property access as `any` even though TypeScript correctly resolves it:

```typescript
type Wrapper<T> = { value: T };
type Unwrap<W> = W extends Wrapper<infer T> ? T : never;

declare function create(): Wrapper<{ id: string }>;

type Result = Unwrap<ReturnType<typeof create>>;
declare const items: Result[];

// ❌ Before: incorrectly flagged `i.id` as returning `any`
// ✅ After: correctly recognizes contextual typing
const ids = items.map((i) => i.id);
```

## Solution

Added logic to distinguish between:

1. Genuine unsafe returns (explicit any usage) - should be flagged:
  - x as any
  - [] as any[]
  - new Set<any>()
2. False positives (type inference differences) - should NOT be flagged:
  - Arrow functions with contextual typing
  - No explicit any in the source code
  - Contextual return type is concrete (not any/unknown)

## Changes

- no_unsafe_return.go:
  - Added containsExplicitAny() helper function to detect explicit any type annotations in AST nodes (type assertions, type arguments, etc.)
  - Added check before reporting unsafeReturn that skips the error when contextual typing provides a concrete type and the source doesn't contain explicit any
- no_unsafe_return_test.go:
  - Updated test case to use declare function for cleaner reproduction
  - Added test case for .map() callbacks with typed interfaces

## Test Plan

- All existing no-unsafe-return tests pass
- New test cases for contextually-typed arrow functions pass
- Explicit any cases ([] as any[], new Set<any>()) still correctly flagged
