### PR TITLE
fix: `prefer-nullish-coalescing`: do not call AsBinaryExpression unless we know it is one

### DIFF
--- a/internal/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.go
+++ b/internal/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.go
@@ -533,7 +533,12 @@ var PreferNullishCoalescingRule = rule.Rule{
 					// Check if the node is already wrapped in parentheses
 					if !ast.IsParenthesizedExpression(node.Parent) {
 						leftExpr := binExpr.Left
-						if ast.IsLogicalExpression(leftExpr) && !isLogicalOrOperator(leftExpr.AsBinaryExpression().Left) {
+						// Only apply special logical expression handling when leftExpr is
+						// directly a binary expression. If it's wrapped in parentheses,
+						// the parentheses already provide visual grouping, so we insert
+						// before binExpr.Left instead.
+						// See: https://github.com/oxc-project/tsgolint/issues/604
+						if ast.IsBinaryExpression(leftExpr) && ast.IsLogicalExpression(leftExpr) && !isLogicalOrOperator(leftExpr.AsBinaryExpression().Left) {
 							fixes = append(fixes, rule.RuleFixInsertBefore(ctx.SourceFile, leftExpr.AsBinaryExpression().Right, "("))
 						} else {
 							fixes = append(fixes, rule.RuleFixInsertBefore(ctx.SourceFile, binExpr.Left, "("))

--- a/internal/rules/prefer_nullish_coalescing/prefer_nullish_coalescing_test.go
+++ b/internal/rules/prefer_nullish_coalescing/prefer_nullish_coalescing_test.go
@@ -2766,5 +2766,73 @@ c ?? (c ? 1 : 2);
 				},
 			},
 		},
+		// https://github.com/oxc-project/tsgolint/issues/604
+		// Test for parenthesized logical expressions
+		{
+			Code: `
+declare let a: string | null;
+declare let b: string;
+declare let c: string;
+const x = (a && b) || c || 'd';
+      `,
+			Output: []string{`
+declare let a: string | null;
+declare let b: string;
+declare let c: string;
+const x = ((a && b) ?? c) || 'd';
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferNullishOverOr",
+				},
+			},
+		},
+		// https://github.com/oxc-project/tsgolint/issues/604
+		// Test for deeply nested parenthesized logical expressions
+		{
+			Code: `
+declare let a: string | null;
+declare let b: string;
+declare let c: string;
+const x = ((a && b)) || c || 'd';
+      `,
+			Output: []string{`
+declare let a: string | null;
+declare let b: string;
+declare let c: string;
+const x = (((a && b)) ?? c) || 'd';
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferNullishOverOr",
+				},
+			},
+		},
+		// https://github.com/oxc-project/tsgolint/issues/604
+		// Test for non-parenthesized logical expression
+		{
+			Code: `
+declare let a: string | null;
+declare let b: string;
+declare let c: string;
+const x = a && b || c || 'd';
+      `,
+			Output: []string{`
+declare let a: string | null;
+declare let b: string;
+declare let c: string;
+const x = a && (b ?? c) || 'd';
+      `, `
+declare let a: string | null;
+declare let b: string;
+declare let c: string;
+const x = a && (b ?? c) ?? 'd';
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferNullishOverOr",
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
- Fixes https://github.com/oxc-project/tsgolint/issues/604

We were calling `AsBinaryExpression()` on `leftExpr` assuming it would always be a logical expression, but in the case of a parenthesized expression, it is not. I used Claude Opus 4.5 to help generate some test cases but confirmed that it will panic without this change.