### PR TITLE
fix(promise-function-async): use different error message for hybrid return types

### DIFF
--- a/internal/rules/promise_function_async/promise_function_async_test.go
+++ b/internal/rules/promise_function_async/promise_function_async_test.go
@@ -814,7 +814,64 @@ function promiseInUnionWithoutExplicitReturnType(p: boolean) {
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
-					MessageId: "missingAsync",
+					MessageId: "missingAsyncHybridReturn",
+				},
+			},
+		},
+		{
+			Code: `
+function test1(): 'one' | Promise<'one'>;
+function test1(a: number): Promise<number>;
+function test1(a?: number) {
+  if (a) {
+    return Promise.resolve(a);
+  }
+
+  return Math.random() > 0.5 ? 'one' : Promise.resolve('one');
+}
+      `,
+			Output: []string{`
+function test1(): 'one' | Promise<'one'>;
+function test1(a: number): Promise<number>;
+ async function test1(a?: number) {
+  if (a) {
+    return Promise.resolve(a);
+  }
+
+  return Math.random() > 0.5 ? 'one' : Promise.resolve('one');
+}
+      `,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingAsyncHybridReturn",
+				},
+			},
+		},
+		{
+			Code: `
+class PromiseType {
+  s?: string;
+}
+
+function promiseInUnionWithoutExplicitReturnType(p: boolean) {
+  return p ? new PromiseType() : 5;
+}
+      `,
+			Output: []string{`
+class PromiseType {
+  s?: string;
+}
+
+ async function promiseInUnionWithoutExplicitReturnType(p: boolean) {
+  return p ? new PromiseType() : 5;
+}
+      `,
+			},
+			Options: rule_tester.OptionsFromJSON[PromiseFunctionAsyncOptions](`{"allowedPromiseNames": ["PromiseType"]}`),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingAsyncHybridReturn",
 				},
 			},
 		},


### PR DESCRIPTION
Add a more helpful error message for functions with hybrid return types (union of promise and non-promise types without an explicit return type annotation). Instead of just saying "Functions that return promises must be async", it now suggests adding an explicit return type annotation if the union is intentional.

Ports typescript-eslint/typescript-eslint#10950
Fixes typescript-eslint/typescript-eslint#10687