### PR TITLE
style: format code by `just fmt`

### DIFF
--- a/internal/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/rules/no_deprecated/no_deprecated_test.go
@@ -8,9 +8,8 @@ import (
 )
 
 func TestNoDeprecatedRule(t *testing.T) {
-		t.Parallel()
+	t.Parallel()
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.includeTypes.json", t, &NoDeprecatedRule, []rule_tester.ValidTestCase{
-
 
 		{Code: `/** @deprecated */ var a;`},
 		{Code: `/** @deprecated */ var a = 1;`},


### PR DESCRIPTION
The indentation seems to have shifted during conflict resolution at #631