### PR TITLE
chore: add pnpm fmt to justfile fmt task

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ lint:
 
 fmt:
   gofmt -w internal cmd tools
+  pnpm run fmt
 
 shim:
   go run tools/gen_shims/main.go


### PR DESCRIPTION
## Summary
- Add `pnpm run fmt` to the `just fmt` task so both Go and JS/TS files are formatted in a single command

## Test plan
- [x] Verify `just fmt` runs both `gofmt` and `pnpm run fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)