### PR TITLE
feat: allow labeled ranges for diagnostics in headless output

### DIFF
--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -98,11 +98,21 @@ const (
 	headlessDiagnosticKindTsconfig
 )
 
+// A labeled span of source code. Useful for highlighting additional info related to a diagnostic in the context
+// of the source code.
+type headlessLabeledRange struct {
+	// The text label associated with this range.
+	Label string `json:"label"`
+	// The range in the source file that this label applies to.
+	Range headlessRange `json:"range"`
+}
+
 type headlessDiagnostic struct {
-	Kind     headlessDiagnosticKind `json:"kind"`
-	Range    *headlessRange         `json:"range,omitempty"`
-	Message  headlessRuleMessage    `json:"message"`
-	FilePath *string                `json:"file_path"`
+	Kind          headlessDiagnosticKind `json:"kind"`
+	Range         *headlessRange         `json:"range,omitempty"`
+	Message       headlessRuleMessage    `json:"message"`
+	FilePath      *string                `json:"file_path"`
+	LabeledRanges []headlessLabeledRange `json:"labeled_ranges,omitempty"`
 
 	// Only for kind="rule"
 	Rule        *string              `json:"rule,omitempty"`
@@ -285,13 +295,24 @@ func runHeadless(args []string) int {
 				rd := d.ruleDiagnostic
 				filePath := rd.SourceFile.FileName()
 				hd = headlessDiagnostic{
-					Kind:        headlessDiagnosticKindRule,
-					Range:       headlessRangeFromRange(rd.Range),
-					Rule:        &rd.RuleName,
-					Message:     headlessRuleMessageFromRuleMessage(rd.Message),
-					Fixes:       nil,
-					Suggestions: nil,
-					FilePath:    &filePath,
+					Kind:          headlessDiagnosticKindRule,
+					Range:         headlessRangeFromRange(rd.Range),
+					Rule:          &rd.RuleName,
+					Message:       headlessRuleMessageFromRuleMessage(rd.Message),
+					Fixes:         nil,
+					Suggestions:   nil,
+					FilePath:      &filePath,
+					LabeledRanges: nil,
+				}
+
+				if len(rd.LabeledRanges) > 0 {
+					hd.LabeledRanges = make([]headlessLabeledRange, len(rd.LabeledRanges))
+					for i, labeledRange := range rd.LabeledRanges {
+						hd.LabeledRanges[i] = headlessLabeledRange{
+							Label: labeledRange.Label,
+							Range: *headlessRangeFromRange(labeledRange.Range),
+						}
+					}
 				}
 
 				if opts.fix {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -233,6 +233,16 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 							SourceFile:  file,
 							Program:     w.program,
 							TypeChecker: w.checker,
+							ReportDiagnostic: func(diagnostic rule.RuleDiagnostic) {
+								onDiagnostic(rule.RuleDiagnostic{
+									RuleName:      r.Name,
+									Message:       diagnostic.Message,
+									FixesPtr:      diagnostic.FixesPtr,
+									Suggestions:   diagnostic.Suggestions,
+									SourceFile:    file,
+									LabeledRanges: diagnostic.LabeledRanges,
+								})
+							},
 							ReportRange: func(textRange core.TextRange, msg rule.RuleMessage) {
 								onDiagnostic(rule.RuleDiagnostic{
 									RuleName:   r.Name,

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -47,6 +47,11 @@ type RuleFix struct {
 	Range core.TextRange
 }
 
+type RuleLabeledRange struct {
+	Label string         `json:"label"`
+	Range core.TextRange `json:"range"`
+}
+
 func RuleFixInsertBefore(file *ast.SourceFile, node *ast.Node, text string) RuleFix {
 	trimmed := utils.TrimNodeTextRange(file, node)
 	return RuleFix{
@@ -92,8 +97,9 @@ type RuleDiagnostic struct {
 	// nil if no fixes were provided
 	FixesPtr *[]RuleFix
 	// nil if no suggestions were provided
-	Suggestions *[]RuleSuggestion
-	SourceFile  *ast.SourceFile
+	Suggestions   *[]RuleSuggestion
+	SourceFile    *ast.SourceFile
+	LabeledRanges []RuleLabeledRange
 }
 
 func (d RuleDiagnostic) Fixes() []RuleFix {
@@ -113,6 +119,7 @@ type RuleContext struct {
 	SourceFile                 *ast.SourceFile
 	Program                    *compiler.Program
 	TypeChecker                *checker.Checker
+	ReportDiagnostic           func(diagnostic RuleDiagnostic)
 	ReportRange                func(textRange core.TextRange, msg RuleMessage)
 	ReportRangeWithSuggestions func(textRange core.TextRange, msg RuleMessage, suggestionsFn func() []RuleSuggestion)
 	ReportNode                 func(node *ast.Node, msg RuleMessage)

--- a/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -16,6 +16,8 @@
 package no_unnecessary_condition
 
 import (
+	"fmt"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
@@ -86,10 +88,22 @@ func buildLiteralBinaryExpressionMessage() rule.RuleMessage {
 	}
 }
 
-func buildNoOverlapMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "noOverlapBooleanExpression",
-		Description: "This condition will always return the same value since the types have no overlap.",
+func buildNoOverlapDiagnostic(leftType string, leftRange core.TextRange, rightType string, rightRange core.TextRange) rule.RuleDiagnostic {
+	return rule.RuleDiagnostic{
+		Message: rule.RuleMessage{
+			Id:          "noOverlapBooleanExpression",
+			Description: "This condition will always return the same value since the types have no overlap.",
+		},
+		LabeledRanges: []rule.RuleLabeledRange{
+			{
+				Label: fmt.Sprintf("Type: %v", leftType),
+				Range: leftRange,
+			},
+			{
+				Label: fmt.Sprintf("Type: %v", rightType),
+				Range: rightRange,
+			},
+		},
 	}
 }
 
@@ -1551,7 +1565,12 @@ var NoUnnecessaryConditionRule = rule.Rule{
 							}
 
 							// Types don't overlap, report it
-							ctx.ReportNode(node, buildNoOverlapMessage())
+							ctx.ReportDiagnostic(buildNoOverlapDiagnostic(
+								ctx.TypeChecker.TypeToString(leftType),
+								binExpr.Left.Loc,
+								ctx.TypeChecker.TypeToString(rightType),
+								binExpr.Right.Loc,
+							))
 						}
 					}
 				}


### PR DESCRIPTION
- closes https://github.com/oxc-project/tsgolint/issues/650
- depends on https://github.com/oxc-project/oxc/pull/19201

This adds support for labeled ranges being returned by the tsgolint headless mode. This should be a backwards compatible change, as we can simply ignore this additional data on the `oxlint` side. Let's check it, but I think that old versions of `oxlint` won't serialize this field.

## Changes

This adds a new `ReportDiagnostic` that allows completely customizing how a `RuleDiagnostic` is reported. This is like a superset of all the other diagnostic reporting functions. So, this naturally allows setting of the new `LabeledRanges` field as well. Diagnostic functions in rules can then be refactored to return `RuleDiagnostic` instead of `RuleMessage`. This will also be useful in the future in case we add more fields to the diagnostic struct.

## Example

I used the `no-unnecessary-condition` rule diagnostic as an example because it is a good example where we lack contextual information currently, but it makes a lot more sense when we can add contextual labels with the type info.

Example output from running on `test.ts`:

```ts
// test.ts
const left: boolean = true;
const right: string = "foo";

if (left === right) {
  console.log("This will never be logged");
}
```

```json
{
  "kind": 0,
  "message": {
    "id": "noOverlapBooleanExpression",
    "description": "This condition will always return the same value since the types have no overlap."
  },
  "file_path": "/path/to/tsgolint/test.ts",
  "labeled_ranges": [
    { "label": "true", "range": { "pos": 62, "end": 66 } },
    { "label": "string", "range": { "pos": 70, "end": 76 } }
  ],
  "rule": "no-unnecessary-condition"
}
```