### PR TITLE
feat: split help messages into the `Help` field

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -296,7 +296,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-confusing-void-expression/index.ts",
     "kind": 0,
     "message": {
-      "description": "Placing a void expression inside another expression is forbidden. Move it to its own statement instead.",
+      "description": "Placing a void expression inside another expression is forbidden.",
+      "help": "Move it to its own statement instead.",
       "id": "invalidVoidExpr",
     },
     "range": {
@@ -309,7 +310,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-confusing-void-expression/index.ts",
     "kind": 0,
     "message": {
-      "description": "Placing a void expression inside another expression is forbidden. Move it to its own statement instead.",
+      "description": "Placing a void expression inside another expression is forbidden.",
+      "help": "Move it to its own statement instead.",
       "id": "invalidVoidExpr",
     },
     "range": {
@@ -518,7 +520,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     ],
     "kind": 0,
     "message": {
-      "description": "Returning a void expression from an arrow function shorthand is forbidden. Please add braces to the arrow function.",
+      "description": "Returning a void expression from an arrow function shorthand is forbidden.",
+      "help": "Add braces to the arrow function.",
       "id": "invalidVoidExprArrow",
     },
     "range": {
@@ -802,7 +805,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-for-in-array/index.ts",
     "kind": 0,
     "message": {
-      "description": "For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties. Use a more robust iteration method such as for-of or array.forEach instead.",
+      "description": "For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties.",
+      "help": "Use a more robust iteration method such as for-of or array.forEach instead.",
       "id": "forInViolation",
     },
     "range": {
@@ -815,7 +819,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-for-in-array/index.ts",
     "kind": 0,
     "message": {
-      "description": "For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties. Use a more robust iteration method such as for-of or array.forEach instead.",
+      "description": "For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties.",
+      "help": "Use a more robust iteration method such as for-of or array.forEach instead.",
       "id": "forInViolation",
     },
     "range": {
@@ -906,7 +911,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-meaningless-void-operator/index.ts",
     "kind": 0,
     "message": {
-      "description": "Placing a void expression inside another expression is forbidden. Move it to its own statement instead.",
+      "description": "Placing a void expression inside another expression is forbidden.",
+      "help": "Move it to its own statement instead.",
       "id": "invalidVoidExpr",
     },
     "range": {
@@ -3324,8 +3330,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/unbound-method/index.ts",
     "kind": 0,
     "message": {
-      "description": "Avoid referencing unbound methods which may cause unintentional scoping of \`this\`.
-If your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.",
+      "description": "Avoid referencing unbound methods which may cause unintentional scoping of \`this\`.",
+      "help": "If your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.",
       "id": "unboundWithoutThisAnnotation",
     },
     "range": {
@@ -3338,8 +3344,8 @@ If your function does not access \`this\`, you can annotate it with \`this: void
     "file_path": "fixtures/basic/rules/unbound-method/index.ts",
     "kind": 0,
     "message": {
-      "description": "Avoid referencing unbound methods which may cause unintentional scoping of \`this\`.
-If your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.",
+      "description": "Avoid referencing unbound methods which may cause unintentional scoping of \`this\`.",
+      "help": "If your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.",
       "id": "unboundWithoutThisAnnotation",
     },
     "range": {
@@ -3352,8 +3358,8 @@ If your function does not access \`this\`, you can annotate it with \`this: void
     "file_path": "fixtures/basic/rules/unbound-method/index.ts",
     "kind": 0,
     "message": {
-      "description": "Avoid referencing unbound methods which may cause unintentional scoping of \`this\`.
-If your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.",
+      "description": "Avoid referencing unbound methods which may cause unintentional scoping of \`this\`.",
+      "help": "If your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.",
       "id": "unboundWithoutThisAnnotation",
     },
     "range": {
@@ -3366,8 +3372,8 @@ If your function does not access \`this\`, you can annotate it with \`this: void
     "file_path": "fixtures/basic/rules/unbound-method/index.ts",
     "kind": 0,
     "message": {
-      "description": "Avoid referencing unbound methods which may cause unintentional scoping of \`this\`.
-If your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.",
+      "description": "Avoid referencing unbound methods which may cause unintentional scoping of \`this\`.",
+      "help": "If your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.",
       "id": "unboundWithoutThisAnnotation",
     },
     "range": {
@@ -3452,7 +3458,8 @@ If your function does not access \`this\`, you can annotate it with \`this: void
     ],
     "kind": 0,
     "message": {
-      "description": "Returning a void expression from an arrow function shorthand is forbidden. Please add braces to the arrow function.",
+      "description": "Returning a void expression from an arrow function shorthand is forbidden.",
+      "help": "Add braces to the arrow function.",
       "id": "invalidVoidExprArrow",
     },
     "range": {
@@ -3739,7 +3746,8 @@ If your function does not access \`this\`, you can annotate it with \`this: void
     ],
     "kind": 0,
     "message": {
-      "description": "Returning a void expression from an arrow function shorthand is forbidden. Please add braces to the arrow function.",
+      "description": "Returning a void expression from an arrow function shorthand is forbidden.",
+      "help": "Add braces to the arrow function.",
       "id": "invalidVoidExprArrow",
     },
     "range": {
@@ -4026,7 +4034,8 @@ If your function does not access \`this\`, you can annotate it with \`this: void
     ],
     "kind": 0,
     "message": {
-      "description": "Returning a void expression from an arrow function shorthand is forbidden. Please add braces to the arrow function.",
+      "description": "Returning a void expression from an arrow function shorthand is forbidden.",
+      "help": "Add braces to the arrow function.",
       "id": "invalidVoidExprArrow",
     },
     "range": {
@@ -4313,7 +4322,8 @@ If your function does not access \`this\`, you can annotate it with \`this: void
     ],
     "kind": 0,
     "message": {
-      "description": "Returning a void expression from an arrow function shorthand is forbidden. Please add braces to the arrow function.",
+      "description": "Returning a void expression from an arrow function shorthand is forbidden.",
+      "help": "Add braces to the arrow function.",
       "id": "invalidVoidExprArrow",
     },
     "range": {

--- a/internal/rules/no_confusing_void_expression/no_confusing_void_expression.go
+++ b/internal/rules/no_confusing_void_expression/no_confusing_void_expression.go
@@ -11,13 +11,15 @@ import (
 func buildInvalidVoidExprMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "invalidVoidExpr",
-		Description: "Placing a void expression inside another expression is forbidden. Move it to its own statement instead.",
+		Description: "Placing a void expression inside another expression is forbidden.",
+		Help:        "Move it to its own statement instead.",
 	}
 }
 func buildInvalidVoidExprArrowMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "invalidVoidExprArrow",
-		Description: "Returning a void expression from an arrow function shorthand is forbidden. Please add braces to the arrow function.",
+		Description: "Returning a void expression from an arrow function shorthand is forbidden.",
+		Help:        "Add braces to the arrow function.",
 	}
 }
 func buildInvalidVoidExprArrowWrapVoidMessage() rule.RuleMessage {

--- a/internal/rules/no_for_in_array/no_for_in_array.go
+++ b/internal/rules/no_for_in_array/no_for_in_array.go
@@ -10,7 +10,8 @@ import (
 func buildForInViolationMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "forInViolation",
-		Description: "For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties. Use a more robust iteration method such as for-of or array.forEach instead.",
+		Description: "For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties.",
+		Help:        "Use a more robust iteration method such as for-of or array.forEach instead.",
 	}
 }
 

--- a/internal/rules/no_unsafe_assignment/no_unsafe_assignment.go
+++ b/internal/rules/no_unsafe_assignment/no_unsafe_assignment.go
@@ -24,9 +24,9 @@ func buildAnyAssignmentMessage(sender *checker.Type) rule.RuleMessage {
 }
 func buildAnyAssignmentThisMessage(sender *checker.Type) rule.RuleMessage {
 	return rule.RuleMessage{
-		Id: "anyAssignmentThis",
-		Description: fmt.Sprintf("Unsafe assignment of an %v value. `this` is typed as `any`.\n", formatSenderType(sender)) +
-			"You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.",
+		Id:          "anyAssignmentThis",
+		Description: fmt.Sprintf("Unsafe assignment of an %v value. `this` is typed as `any`.\n", formatSenderType(sender)),
+		Help:        "You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.",
 	}
 }
 func buildUnsafeArrayPatternMessage(sender *checker.Type) rule.RuleMessage {

--- a/internal/rules/no_unsafe_call/no_unsafe_call.go
+++ b/internal/rules/no_unsafe_call/no_unsafe_call.go
@@ -17,9 +17,9 @@ func buildUnsafeCallMessage(t string) rule.RuleMessage {
 }
 func buildUnsafeCallThisMessage(t string) rule.RuleMessage {
 	return rule.RuleMessage{
-		Id: "unsafeCallThis",
-		Description: fmt.Sprintf("Unsafe call of a(n) %v typed value. `this` is typed as %v.\n", t, t) +
-			"You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.",
+		Id:          "unsafeCallThis",
+		Description: fmt.Sprintf("Unsafe call of a(n) %v typed value. `this` is typed as %v.\n", t, t),
+		Help:        "You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.",
 	}
 }
 func buildUnsafeNewMessage(t string) rule.RuleMessage {

--- a/internal/rules/no_unsafe_member_access/no_unsafe_member_access.go
+++ b/internal/rules/no_unsafe_member_access/no_unsafe_member_access.go
@@ -33,9 +33,9 @@ func buildUnsafeMemberExpressionMessage(property, t string) rule.RuleMessage {
 }
 func buildUnsafeThisMemberExpressionMessage(property string) rule.RuleMessage {
 	return rule.RuleMessage{
-		Id: "unsafeThisMemberExpression",
-		Description: fmt.Sprintf("Unsafe member access %v on an `any` value. `this` is typed as `any`.", property) +
-			"You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.",
+		Id:          "unsafeThisMemberExpression",
+		Description: fmt.Sprintf("Unsafe member access %v on an `any` value. `this` is typed as `any`.", property),
+		Help:        "You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.",
 	}
 }
 

--- a/internal/rules/no_unsafe_return/no_unsafe_return.go
+++ b/internal/rules/no_unsafe_return/no_unsafe_return.go
@@ -23,9 +23,9 @@ func buildUnsafeReturnAssignmentMessage(sender, receiver string) rule.RuleMessag
 }
 func buildUnsafeReturnThisMessage(t string) rule.RuleMessage {
 	return rule.RuleMessage{
-		Id: "unsafeReturnThis",
-		Description: fmt.Sprintf("Unsafe return of a value of type `%v`. `this` is typed as `any`.", t) +
-			"You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.",
+		Id:          "unsafeReturnThis",
+		Description: fmt.Sprintf("Unsafe return of a value of type `%v`. `this` is typed as `any`.", t),
+		Help:        "You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.",
 	}
 }
 

--- a/internal/rules/promise_function_async/promise_function_async.go
+++ b/internal/rules/promise_function_async/promise_function_async.go
@@ -17,7 +17,8 @@ func buildMissingAsyncMessage() rule.RuleMessage {
 func buildMissingAsyncHybridReturnMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "missingAsyncHybridReturn",
-		Description: "Functions that return promises must be async. Consider adding an explicit return type annotation if the function is intended to return a union of promise and non-promise types.",
+		Description: "Functions that return promises must be async.",
+		Help:        "Consider adding an explicit return type annotation if the function is intended to return a union of promise and non-promise types.",
 	}
 }
 

--- a/internal/rules/unbound_method/unbound_method.go
+++ b/internal/rules/unbound_method/unbound_method.go
@@ -20,7 +20,8 @@ func buildUnboundMessage() rule.RuleMessage {
 func buildUnboundWithoutThisAnnotationMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unboundWithoutThisAnnotation",
-		Description: baseMessage + "\nIf your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.",
+		Description: baseMessage,
+		Help:        "If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.",
 	}
 }
 


### PR DESCRIPTION
- part of https://github.com/oxc-project/tsgolint/issues/649

Splits out the help messages already present in some rules into the `Help` field explicitly. This should improve readability of these messages on the `oxlint` side.