### PR TITLE
refactor: remove redundant BindSourceFiles call in linter

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -166,7 +166,6 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 	}
 
 	close(queue)
-	program.BindSourceFiles()
 
 	ctx := core.WithRequestID(context.Background(), "__single_run__")
 


### PR DESCRIPTION
## Summary
- Remove duplicate `program.BindSourceFiles()` call in `RunLinterOnProgram` — it is already called in `create_program.go` during [program](https://github.com/oxc-project/tsgolint/blob/c0ba8793ac1d41eb5d3e88af652478edd439436e/internal/utils/create_program.go#L115) [initialization](https://github.com/oxc-project/tsgolint/blob/c0ba8793ac1d41eb5d3e88af652478edd439436e/internal/utils/create_program.go#L151).

🤖 Generated with [Claude Code](https://claude.com/claude-code)