### PR TITLE
feat: add labeled ranges to diagnostic for `no-unnecessary-type-conversion`

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -1346,6 +1346,15 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unnecessary-type-conversion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This expression already has type '"asdf"'.",
+        "range": {
+          "end": 94,
+          "pos": 88,
+        },
+      },
+    ],
     "message": {
       "description": "This type conversion does not change the type or value of the expression.",
       "id": "unnecessaryTypeConversion",
@@ -1391,6 +1400,15 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unnecessary-type-conversion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This expression already has type '"asdf"'.",
+        "range": {
+          "end": 113,
+          "pos": 107,
+        },
+      },
+    ],
     "message": {
       "description": "This type conversion does not change the type or value of the expression.",
       "id": "unnecessaryTypeConversion",
@@ -1436,6 +1454,15 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unnecessary-type-conversion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This expression already has type '"asdf"'.",
+        "range": {
+          "end": 147,
+          "pos": 141,
+        },
+      },
+    ],
     "message": {
       "description": "This type conversion does not change the type or value of the expression.",
       "id": "unnecessaryTypeConversion",
@@ -1481,6 +1508,15 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unnecessary-type-conversion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This expression already has type '123'.",
+        "range": {
+          "end": 169,
+          "pos": 166,
+        },
+      },
+    ],
     "message": {
       "description": "This type conversion does not change the type or value of the expression.",
       "id": "unnecessaryTypeConversion",
@@ -1526,6 +1562,15 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unnecessary-type-conversion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This expression already has type 'true'.",
+        "range": {
+          "end": 188,
+          "pos": 184,
+        },
+      },
+    ],
     "message": {
       "description": "This type conversion does not change the type or value of the expression.",
       "id": "unnecessaryTypeConversion",

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -235,9 +235,25 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 							ReportDiagnostic: func(diagnostic rule.RuleDiagnostic) {
 								onDiagnostic(rule.RuleDiagnostic{
 									RuleName:      r.Name,
+									Range:         diagnostic.Range,
 									Message:       diagnostic.Message,
 									FixesPtr:      diagnostic.FixesPtr,
 									Suggestions:   diagnostic.Suggestions,
+									SourceFile:    file,
+									LabeledRanges: diagnostic.LabeledRanges,
+								})
+							},
+							ReportDiagnosticWithSuggestions: func(diagnostic rule.RuleDiagnostic, suggestionsFn func() []rule.RuleSuggestion) {
+								var suggestions []rule.RuleSuggestion = nil
+								if fixState.FixSuggestions {
+									suggestions = suggestionsFn()
+								}
+								onDiagnostic(rule.RuleDiagnostic{
+									RuleName:      r.Name,
+									Range:         diagnostic.Range,
+									Message:       diagnostic.Message,
+									FixesPtr:      diagnostic.FixesPtr,
+									Suggestions:   &suggestions,
 									SourceFile:    file,
 									LabeledRanges: diagnostic.LabeledRanges,
 								})

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -116,15 +116,16 @@ func (d RuleDiagnostic) GetSuggestions() []RuleSuggestion {
 }
 
 type RuleContext struct {
-	SourceFile                 *ast.SourceFile
-	Program                    *compiler.Program
-	TypeChecker                *checker.Checker
-	ReportDiagnostic           func(diagnostic RuleDiagnostic)
-	ReportRange                func(textRange core.TextRange, msg RuleMessage)
-	ReportRangeWithSuggestions func(textRange core.TextRange, msg RuleMessage, suggestionsFn func() []RuleSuggestion)
-	ReportNode                 func(node *ast.Node, msg RuleMessage)
-	ReportNodeWithFixes        func(node *ast.Node, msg RuleMessage, fixesFn func() []RuleFix)
-	ReportNodeWithSuggestions  func(node *ast.Node, msg RuleMessage, suggestionsFn func() []RuleSuggestion)
+	SourceFile                      *ast.SourceFile
+	Program                         *compiler.Program
+	TypeChecker                     *checker.Checker
+	ReportDiagnostic                func(diagnostic RuleDiagnostic)
+	ReportDiagnosticWithSuggestions func(diagnostic RuleDiagnostic, suggestionsFn func() []RuleSuggestion)
+	ReportRange                     func(textRange core.TextRange, msg RuleMessage)
+	ReportRangeWithSuggestions      func(textRange core.TextRange, msg RuleMessage, suggestionsFn func() []RuleSuggestion)
+	ReportNode                      func(node *ast.Node, msg RuleMessage)
+	ReportNodeWithFixes             func(node *ast.Node, msg RuleMessage, fixesFn func() []RuleFix)
+	ReportNodeWithSuggestions       func(node *ast.Node, msg RuleMessage, suggestionsFn func() []RuleSuggestion)
 }
 
 func ReportNodeWithFixesOrSuggestions(ctx RuleContext, node *ast.Node, fix bool, msg RuleMessage, suggestionMsg RuleMessage, fixes ...RuleFix) {

--- a/internal/rule_tester/__snapshots__/no-unnecessary-type-conversion.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-type-conversion.snap
@@ -4,6 +4,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:6)
 Message: This type conversion does not change the type or value of the expression.
    1 | String('asdf');
      | ~~~~~~
+  Label: This expression already has type '"asdf"'. (1:8 - 1:13)
+   1 | String('asdf');
+     |        ^^^^^^ This expression already has type '"asdf"'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -13,6 +16,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:8 - 1:17)
 Message: This type conversion does not change the type or value of the expression.
    1 | 'asdf'.toString();
      |        ~~~~~~~~~~
+  Label: This expression already has type '"asdf"'. (1:1 - 1:6)
+   1 | 'asdf'.toString();
+     | ^^^^^^ This expression already has type '"asdf"'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -22,6 +28,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:2)
 Message: This type conversion does not change the type or value of the expression.
    1 | !!true;
      | ~~
+  Label: This expression already has type 'true'. (1:3 - 1:6)
+   1 | !!true;
+     |   ^^^^ This expression already has type 'true'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -31,6 +40,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:6)
 Message: This type conversion does not change the type or value of the expression.
    1 | BigInt(3n);
      | ~~~~~~
+  Label: This expression already has type '3n'. (1:8 - 1:9)
+   1 | BigInt(3n);
+     |        ^^ This expression already has type '3n'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -41,6 +53,11 @@ Message: This type conversion does not change the type or value of the expressio
    2 |         function f<T extends string>(x: T) {
    3 |           return String(x);
      |                  ~~~~~~
+   4 |         }
+  Label: This expression already has type 'string'. (3:25 - 3:25)
+   2 |         function f<T extends string>(x: T) {
+   3 |           return String(x);
+     |                         ^ This expression already has type 'string'.
    4 |         }
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
@@ -53,6 +70,11 @@ Message: This type conversion does not change the type or value of the expressio
    3 |           return Number(x);
      |                  ~~~~~~
    4 |         }
+  Label: This expression already has type 'number'. (3:25 - 3:25)
+   2 |         function f<T extends number>(x: T) {
+   3 |           return Number(x);
+     |                         ^ This expression already has type 'number'.
+   4 |         }
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -63,6 +85,11 @@ Message: This type conversion does not change the type or value of the expressio
    2 |         function f<T extends boolean>(x: T) {
    3 |           return Boolean(x);
      |                  ~~~~~~~
+   4 |         }
+  Label: This expression already has type 'boolean'. (3:26 - 3:26)
+   2 |         function f<T extends boolean>(x: T) {
+   3 |           return Boolean(x);
+     |                          ^ This expression already has type 'boolean'.
    4 |         }
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
@@ -75,6 +102,11 @@ Message: This type conversion does not change the type or value of the expressio
    3 |           return BigInt(x);
      |                  ~~~~~~
    4 |         }
+  Label: This expression already has type 'bigint'. (3:25 - 3:25)
+   2 |         function f<T extends bigint>(x: T) {
+   3 |           return BigInt(x);
+     |                         ^ This expression already has type 'bigint'.
+   4 |         }
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -84,6 +116,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:47 - 1:50)
 Message: This type conversion does not change the type or value of the expression.
    1 | function f<T extends string>(x: T) { return x + ''; }
      |                                               ~~~~
+  Label: This expression already has type 'string'. (1:45 - 1:45)
+   1 | function f<T extends string>(x: T) { return x + ''; }
+     |                                             ^ This expression already has type 'string'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -93,6 +128,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:45 - 1:49)
 Message: This type conversion does not change the type or value of the expression.
    1 | function f<T extends string>(x: T) { return '' + x; }
      |                                             ~~~~~
+  Label: This expression already has type 'string'. (1:50 - 1:50)
+   1 | function f<T extends string>(x: T) { return '' + x; }
+     |                                                  ^ This expression already has type 'string'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -104,6 +142,11 @@ Message: This type conversion does not change the type or value of the expressio
    2 | x += '';
      | ~~~~~~~
    3 | return x;
+  Label: This expression already has type 'string'. (2:1 - 2:1)
+   1 | function f<T extends string>(x: T) {
+   2 | x += '';
+     | ^ This expression already has type 'string'.
+   3 | return x;
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -113,6 +156,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:45 - 1:45)
 Message: This type conversion does not change the type or value of the expression.
    1 | function f<T extends number>(x: T) { return +x; }
      |                                             ~
+  Label: This expression already has type 'number'. (1:46 - 1:46)
+   1 | function f<T extends number>(x: T) { return +x; }
+     |                                              ^ This expression already has type 'number'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -122,6 +168,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:5)
 Message: This type conversion does not change the type or value of the expression.
    1 | '' + 'asdf';
      | ~~~~~
+  Label: This expression already has type '"asdf"'. (1:6 - 1:11)
+   1 | '' + 'asdf';
+     |      ^^^^^^ This expression already has type '"asdf"'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -131,6 +180,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:46 - 1:47)
 Message: This type conversion does not change the type or value of the expression.
    1 | function f<T extends boolean>(x: T) { return !!x; }
      |                                              ~~
+  Label: This expression already has type 'boolean'. (1:48 - 1:48)
+   1 | function f<T extends boolean>(x: T) { return !!x; }
+     |                                                ^ This expression already has type 'boolean'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -140,6 +192,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:44 - 1:45)
 Message: This type conversion does not change the type or value of the expression.
    1 | function f<T extends 3 | 4>(x: T) { return ~~x; }
      |                                            ~~
+  Label: This expression already has type '3 | 4'. (1:46 - 1:46)
+   1 | function f<T extends 3 | 4>(x: T) { return ~~x; }
+     |                                              ^ This expression already has type '3 | 4'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -149,6 +204,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:6)
 Message: This type conversion does not change the type or value of the expression.
    1 | String('a' + 'b').length;
      | ~~~~~~
+  Label: This expression already has type 'string'. (1:8 - 1:16)
+   1 | String('a' + 'b').length;
+     |        ^^^^^^^^^ This expression already has type 'string'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -158,6 +216,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:13 - 1:22)
 Message: This type conversion does not change the type or value of the expression.
    1 | ('a' + 'b').toString().length;
      |             ~~~~~~~~~~
+  Label: This expression already has type 'string'. (1:1 - 1:11)
+   1 | ('a' + 'b').toString().length;
+     | ^^^^^^^^^^^ This expression already has type 'string'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -167,6 +228,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:5 - 1:5)
 Message: This type conversion does not change the type or value of the expression.
    1 | 2 * +(2 + 2);
      |     ~
+  Label: This expression already has type 'number'. (1:6 - 1:12)
+   1 | 2 * +(2 + 2);
+     |      ^^^^^^^ This expression already has type 'number'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -176,6 +240,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:5 - 1:10)
 Message: This type conversion does not change the type or value of the expression.
    1 | 2 * Number(2 + 2);
      |     ~~~~~~
+  Label: This expression already has type 'number'. (1:12 - 1:16)
+   1 | 2 * Number(2 + 2);
+     |            ^^^^^ This expression already has type 'number'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -185,6 +252,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:10 - 1:11)
 Message: This type conversion does not change the type or value of the expression.
    1 | false && !!(false || true);
      |          ~~
+  Label: This expression already has type 'true'. (1:12 - 1:26)
+   1 | false && !!(false || true);
+     |            ^^^^^^^^^^^^^^^ This expression already has type 'true'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -194,6 +264,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:10 - 1:16)
 Message: This type conversion does not change the type or value of the expression.
    1 | false && Boolean(false || true);
      |          ~~~~~~~
+  Label: This expression already has type 'true'. (1:18 - 1:30)
+   1 | false && Boolean(false || true);
+     |                  ^^^^^^^^^^^^^ This expression already has type 'true'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -203,6 +276,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:6 - 1:11)
 Message: This type conversion does not change the type or value of the expression.
    1 | 2n * BigInt(2n + 2n);
      |      ~~~~~~
+  Label: This expression already has type 'bigint'. (1:13 - 1:19)
+   1 | 2n * BigInt(2n + 2n);
+     |             ^^^^^^^ This expression already has type 'bigint'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -214,6 +290,11 @@ Message: This type conversion does not change the type or value of the expressio
    3 |         String(str).length;
      |         ~~~~~~
    4 |       
+  Label: This expression already has type 'string'. (3:16 - 3:18)
+   2 |         let str = 'asdf';
+   3 |         String(str).length;
+     |                ^^^ This expression already has type 'string'.
+   4 |       
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -223,6 +304,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:8 - 1:11)
 Message: This type conversion does not change the type or value of the expression.
    1 | 'asdf' + '';
      |        ~~~~
+  Label: This expression already has type '"asdf"'. (1:1 - 1:6)
+   1 | 'asdf' + '';
+     | ^^^^^^ This expression already has type '"asdf"'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -234,6 +318,11 @@ Message: This type conversion does not change the type or value of the expressio
    3 |         str.toString().length;
      |             ~~~~~~~~~~
    4 |       
+  Label: This expression already has type 'string'. (3:9 - 3:11)
+   2 |         let str = 'asdf';
+   3 |         str.toString().length;
+     |         ^^^ This expression already has type 'string'.
+   4 |       
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -243,6 +332,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:2)
 Message: This type conversion does not change the type or value of the expression.
    1 | ~~1;
      | ~~
+  Label: This expression already has type '1'. (1:3 - 1:3)
+   1 | ~~1;
+     |   ^ This expression already has type '1'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -252,6 +344,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:2)
 Message: This type conversion does not change the type or value of the expression.
    1 | ~~-1;
      | ~~
+  Label: This expression already has type '-1'. (1:3 - 1:4)
+   1 | ~~-1;
+     |   ^^ This expression already has type '-1'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -262,6 +357,11 @@ Message: This type conversion does not change the type or value of the expressio
    2 |         declare const threeOrFour: 3 | 4;
    3 |         ~~threeOrFour;
      |         ~~
+   4 |       
+  Label: This expression already has type '3 | 4'. (3:11 - 3:21)
+   2 |         declare const threeOrFour: 3 | 4;
+   3 |         ~~threeOrFour;
+     |           ^^^^^^^^^^^ This expression already has type '3 | 4'.
    4 |       
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
@@ -274,6 +374,11 @@ Message: This type conversion does not change the type or value of the expressio
    3 | str += '';
      | ~~~~~~~~~
    4 |       
+  Label: This expression already has type 'string'. (3:1 - 3:3)
+   2 | let str = 'asdf';
+   3 | str += '';
+     | ^^^ This expression already has type 'string'.
+   4 |       
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -285,6 +390,11 @@ Message: This type conversion does not change the type or value of the expressio
    3 | 'asdf' + (str += '');
      |           ~~~~~~~~~
    4 |       
+  Label: This expression already has type 'string'. (3:11 - 3:13)
+   2 | let str = 'asdf';
+   3 | 'asdf' + (str += '');
+     |           ^^^ This expression already has type 'string'.
+   4 |       
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -294,6 +404,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:6)
 Message: This type conversion does not change the type or value of the expression.
    1 | Number(123);
      | ~~~~~~
+  Label: This expression already has type '123'. (1:8 - 1:10)
+   1 | Number(123);
+     |        ^^^ This expression already has type '123'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -303,6 +416,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:1)
 Message: This type conversion does not change the type or value of the expression.
    1 | +123;
      | ~
+  Label: This expression already has type '123'. (1:2 - 1:4)
+   1 | +123;
+     |  ^^^ This expression already has type '123'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -312,6 +428,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:2)
 Message: This type conversion does not change the type or value of the expression.
    1 | ~~123;
      | ~~
+  Label: This expression already has type '123'. (1:3 - 1:5)
+   1 | ~~123;
+     |   ^^^ This expression already has type '123'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---
@@ -321,6 +440,9 @@ Diagnostic 1: unnecessaryTypeConversion (1:1 - 1:7)
 Message: This type conversion does not change the type or value of the expression.
    1 | Boolean(true);
      | ~~~~~~~
+  Label: This expression already has type 'true'. (1:9 - 1:12)
+   1 | Boolean(true);
+     |         ^^^^ This expression already has type 'true'.
   Suggestion 1: [suggestRemove] Remove the type conversion.
   Suggestion 2: [suggestSatisfies] Instead, assert that the value satisfies the primitive type.
 ---


### PR DESCRIPTION
This improves the diagnostics for this rule. Also added `ReportDiagnosticWithSuggestions`, which will hopefully come to replace all of the `Report*WithSuggestions` functions eventually.

Also fixed a bug where the diagnostic primary range wasn't passed through with these new reporting functions.