### PR TITLE
perf(no-floating-promises): reduce checker calls in promise checks

### DIFF
--- a/internal/rules/no_floating_promises/no_floating_promises.go
+++ b/internal/rules/no_floating_promises/no_floating_promises.go
@@ -202,6 +202,10 @@ var NoFloatingPromisesRule = rule.Rule{
 		}
 
 		isKnownSafePromiseReturn := func(node *ast.Node) bool {
+			if len(opts.AllowForKnownSafeCalls) == 0 {
+				return false
+			}
+
 			if !ast.IsCallExpression(node) {
 				return false
 			}


### PR DESCRIPTION
- Removed checker calls inside `isPromiseArray` and `isPromiseLike`, and now reuses a single queried type.
- Added an early return when `allowForKnownSafeCalls` is empty.