### PR TITLE
refactor: run `go fix` for `newexpr` analyzer

### DIFF
--- a/internal/rules/no_unnecessary_condition/no_unnecessary_condition_test.go
+++ b/internal/rules/no_unnecessary_condition/no_unnecessary_condition_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/typescript-eslint/tsgolint/internal/rule_tester"
 	"github.com/typescript-eslint/tsgolint/internal/rules/fixtures"
-	"github.com/typescript-eslint/tsgolint/internal/utils"
 )
 
 func TestNoUnnecessaryConditionRule(t *testing.T) {
@@ -558,19 +557,19 @@ const x = b1 && b2;
 			Code: `
 while (true) {}
       `,
-			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: utils.Ref(true)},
+			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: new(true)},
 		},
 		{
 			Code: `
 for (; true; ) {}
       `,
-			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: utils.Ref(true)},
+			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: new(true)},
 		},
 		{
 			Code: `
 do {} while (true);
       `,
-			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: utils.Ref(true)},
+			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: new(true)},
 		},
 		{
 			Code: `
@@ -1849,7 +1848,7 @@ declare const test: true;
 
 while (test) {}
       `,
-			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: utils.Ref(false)},
+			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: new(false)},
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy"}},
 		},
 		{
@@ -1858,7 +1857,7 @@ declare const test: true;
 
 for (; test; ) {}
       `,
-			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: utils.Ref(false)},
+			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: new(false)},
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy"}},
 		},
 		{
@@ -1867,7 +1866,7 @@ declare const test: true;
 
 do {} while (test);
       `,
-			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: utils.Ref(false)},
+			Options: NoUnnecessaryConditionOptions{AllowConstantLoopConditions: new(false)},
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy"}},
 		},
 		{

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -60,11 +60,6 @@ func TypeRecurser(t *checker.Type, predicate func(t *checker.Type) /* should sto
 	}
 }
 
-// SUPER DIRTY HACK FOR OPTIONAL FIELDS :(
-func Ref[T any](a T) *T {
-	return &a
-}
-
 func GetNumberIndexType(typeChecker *checker.Checker, t *checker.Type) *checker.Type {
 	return checker.Checker_getIndexTypeOfType(typeChecker, t, checker.Checker_numberType(typeChecker))
 }


### PR DESCRIPTION
Output from `go fix -newexpr` and then deleting `utils.Ref` which is no longer needed (supported by the language now!)