### PR TITLE
refactor: run `go fix` for `stringscut` analyzer

### DIFF
--- a/internal/rule_tester/snapshot.go
+++ b/internal/rule_tester/snapshot.go
@@ -154,20 +154,17 @@ func parseSnapshotFile(data string) map[string]string {
 			continue
 		}
 
-		newline := strings.IndexByte(block, '\n')
-		if newline == -1 {
+		before, after, ok := strings.Cut(block, "\n")
+		if !ok {
 			continue
 		}
 
-		key := block[:newline]
+		key := before
 		if !strings.HasPrefix(key, "[") || !strings.HasSuffix(key, "]") {
 			continue
 		}
 
-		content := block[newline+1:]
-		content = strings.TrimRight(content, "\n")
-
-		entries[key] = content
+		entries[key] = strings.TrimRight(after, "\n")
 	}
 
 	return entries

--- a/internal/utils/overlay_vfs.go
+++ b/internal/utils/overlay_vfs.go
@@ -64,8 +64,8 @@ func (vfs *OverlayVFS) GetAccessibleEntries(path string) (result vfs.Entries) {
 			continue
 		}
 
-		if slashIndex := strings.IndexByte(withoutPrefix, '/'); slashIndex >= 0 {
-			result.Directories = append(result.Directories, withoutPrefix[:slashIndex])
+		if before, _, ok := strings.Cut(withoutPrefix, "/"); ok {
+			result.Directories = append(result.Directories, before)
 		} else {
 			result.Files = append(result.Files, withoutPrefix)
 		}


### PR DESCRIPTION
Output from `go fix -stringscut` plus slightly simplifying the `content` definition.