### PR TITLE
refactor: run `go fix` for `stringsseq` analyzer

### DIFF
--- a/internal/rule_tester/snapshot.go
+++ b/internal/rule_tester/snapshot.go
@@ -146,9 +146,9 @@ func (sf *snapshotFile) write(t *testing.T) {
 func parseSnapshotFile(data string) map[string]string {
 	entries := make(map[string]string)
 
-	blocks := strings.Split(data, "---\n")
+	blocks := strings.SplitSeq(data, "---\n")
 
-	for _, block := range blocks {
+	for block := range blocks {
 		block = strings.TrimLeft(block, "\n")
 		if block == "" {
 			continue


### PR DESCRIPTION
Output from `go fix -stringsseq`.