### PR TITLE
feat: add suggestions for `switch-exhaustiveness-check`

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -3485,6 +3485,24 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
       "pos": 180,
     },
     "rule": "switch-exhaustiveness-check",
+    "suggestions": [
+      {
+        "fixes": [
+          {
+            "range": {
+              "end": 300,
+              "pos": 300,
+            },
+            "text": "
+    case "rejected": { throw new Error('Not implemented yet: "rejected" case') }",
+          },
+        ],
+        "message": {
+          "description": "Switch is not exhaustive. Cases not matched: "rejected"",
+          "id": "switchIsNotExhaustive",
+        },
+      },
+    ],
   },
   {
     "file_path": "fixtures/basic/rules/unbound-method/index.ts",

--- a/internal/rule_tester/__snapshots__/switch-exhaustiveness-check.snap
+++ b/internal/rule_tester/__snapshots__/switch-exhaustiveness-check.snap
@@ -6,6 +6,7 @@ Message: Switch is not exhaustive. Cases not matched: "literal"
    3 | switch (value) {
      |         ~~~~~
    4 | }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-1 - 1]
@@ -15,6 +16,7 @@ Message: Switch is not exhaustive. Cases not matched: "literal"
    3 | switch (value) {
      |         ~~~~~
    4 | }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-10 - 1]
@@ -24,6 +26,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    4 | switch (value) {
      |         ~~~~~
    5 |   case a:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-11 - 1]
@@ -33,6 +36,7 @@ Message: Switch is not exhaustive. Cases not matched: typeof a | typeof b
    5 | switch (value) {
      |         ~~~~~
    6 |   case 1:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-12 - 1]
@@ -42,6 +46,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    4 | switch (value) {
      |         ~~~~~
    5 |   case a:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-13 - 1]
@@ -51,6 +56,7 @@ Message: Switch is not exhaustive. Cases not matched: false | true
    3 | switch (value) {
      |         ~~~~~
    4 | }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-14 - 1]
@@ -60,6 +66,7 @@ Message: Switch is not exhaustive. Cases not matched: 1 | true
    3 | switch (value) {
      |         ~~~~~
    4 |   case false:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-15 - 1]
@@ -69,6 +76,7 @@ Message: Switch is not exhaustive. Cases not matched: false | true
    3 | switch (value) {
      |         ~~~~~
    4 |   case 1:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 
 Diagnostic 2: switchIsNotExhaustive (3:9 - 3:13)
 Message: Switch is not exhaustive. Cases not matched: default
@@ -76,6 +84,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    3 | switch (value) {
      |         ~~~~~
    4 |   case 1:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-16 - 1]
@@ -85,6 +94,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    3 | switch (value) {
      |         ~~~~~
    4 |   case 1:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-17 - 1]
@@ -94,6 +104,7 @@ Message: Switch is not exhaustive. Cases not matched: Aaa.Bar
    7 | switch (value) {
      |         ~~~~~
    8 |   case 1:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 
 Diagnostic 2: switchIsNotExhaustive (7:9 - 7:13)
 Message: Switch is not exhaustive. Cases not matched: default
@@ -101,6 +112,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    7 | switch (value) {
      |         ~~~~~
    8 |   case 1:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-18 - 1]
@@ -110,6 +122,7 @@ Message: Switch is not exhaustive. Cases not matched: "Friday" | "Saturday" | "S
   14 | switch (day) {
      |         ~~~
   15 |   case 'Monday': {
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-19 - 1]
@@ -119,6 +132,7 @@ Message: Switch is not exhaustive. Cases not matched: Enum.B
    8 |   switch (value) {
      |           ~~~~~
    9 |     case Enum.A:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-2 - 1]
@@ -128,6 +142,7 @@ Message: Switch is not exhaustive. Cases not matched: 1
    3 | switch (value) {
      |         ~~~~~
    4 |   case 'literal':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-20 - 1]
@@ -137,6 +152,7 @@ Message: Switch is not exhaustive. Cases not matched: "b" | "c"
    8 |   switch (value) {
      |           ~~~~~
    9 |     case 'a':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-21 - 1]
@@ -146,6 +162,7 @@ Message: Switch is not exhaustive. Cases not matched: 1 | true
    9 |   switch (value) {
      |           ~~~~~
   10 |     case 'a':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-22 - 1]
@@ -155,6 +172,7 @@ Message: Switch is not exhaustive. Cases not matched: "B"
    5 |   switch (value.type) {
      |           ~~~~~~~~~~
    6 |     case 'A':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-23 - 1]
@@ -164,6 +182,7 @@ Message: Switch is not exhaustive. Cases not matched: "Friday" | "Monday" | "Sat
   13 | switch (day) {
      |         ~~~
   14 | }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-24 - 1]
@@ -173,6 +192,7 @@ Message: Switch is not exhaustive. Cases not matched: typeof b | typeof c
    9 |   switch (value) {
      |           ~~~~~
   10 |     case a:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-25 - 1]
@@ -182,6 +202,7 @@ Message: Switch is not exhaustive. Cases not matched: 2
    5 |   switch (value) {
      |           ~~~~~
    6 |     case 1:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-26 - 1]
@@ -191,6 +212,7 @@ Message: Switch is not exhaustive. Cases not matched: 1 | 2
    5 |   switch (value) {
      |           ~~~~~
    6 |   }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-27 - 1]
@@ -200,6 +222,7 @@ Message: Switch is not exhaustive. Cases not matched: typeof Enum["test-test"] |
    8 |   switch (arg) {
      |           ~~~
    9 |   }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-28 - 1]
@@ -209,6 +232,7 @@ Message: Switch is not exhaustive. Cases not matched: typeof Enum[""] | Enum.tes
    8 |   switch (arg) {
      |           ~~~
    9 |   }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-29 - 1]
@@ -218,6 +242,7 @@ Message: Switch is not exhaustive. Cases not matched: typeof Enum["9test"] | Enu
    8 |   switch (arg) {
      |           ~~~
    9 |   }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-3 - 1]
@@ -227,6 +252,7 @@ Message: Switch is not exhaustive. Cases not matched: "2"
    3 | switch (value) {
      |         ~~~~~
    4 |   case '1':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-30 - 1]
@@ -236,6 +262,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    3 | switch (value) {
      |         ~~~~~
    4 |   case 0:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-31 - 1]
@@ -245,6 +272,7 @@ Message: Switch is not exhaustive. Cases not matched: Enum.a | typeof Enum["key-
   11 |         switch (a) {
      |                 ~
   12 |         }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-32 - 1]
@@ -254,6 +282,7 @@ Message: Switch is not exhaustive. Cases not matched: Enum.a | typeof Enum["'a' 
    9 |         switch (a) {}
      |                 ~
   10 |       
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-33 - 1]
@@ -354,6 +383,7 @@ Message: Switch is not exhaustive. Cases not matched: "2"
    3 | switch (value) {
      |         ~~~~~
    4 |   case '1':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 
 Diagnostic 2: switchIsNotExhaustive (3:9 - 3:13)
 Message: Switch is not exhaustive. Cases not matched: default
@@ -361,6 +391,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    3 | switch (value) {
      |         ~~~~~
    4 |   case '1':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-40 - 1]
@@ -370,6 +401,7 @@ Message: Switch is not exhaustive. Cases not matched: "b"
    4 | switch (literal) {
      |         ~~~~~~~
    5 |   case 'a':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-41 - 1]
@@ -379,6 +411,7 @@ Message: Switch is not exhaustive. Cases not matched: "b"
    4 | switch (literal) {
      |         ~~~~~~~
    5 |   case 'a':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-42 - 1]
@@ -388,6 +421,7 @@ Message: Switch is not exhaustive. Cases not matched: "b"
    4 | switch (literal) {
      |         ~~~~~~~
    5 |   default:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-43 - 1]
@@ -397,6 +431,7 @@ Message: Switch is not exhaustive. Cases not matched: "b" | "c"
    4 | switch (literal) {
      |         ~~~~~~~
    5 |   case 'a':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-44 - 1]
@@ -406,6 +441,7 @@ Message: Switch is not exhaustive. Cases not matched: MyEnum.Bar | MyEnum.Baz
   10 | switch (myEnum) {
      |         ~~~~~~
   11 |   case MyEnum.Foo:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-45 - 1]
@@ -415,6 +451,7 @@ Message: Switch is not exhaustive. Cases not matched: false | true
    3 | switch (value) {
      |         ~~~~~
    4 |   default: {
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-46 - 1]
@@ -424,6 +461,7 @@ Message: Switch is not exhaustive. Cases not matched: undefined
    3 |   switch (x[0]) {
      |           ~~~~
    4 |     case 'hi':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-5 - 1]
@@ -433,6 +471,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    3 | switch (value) {
      |         ~~~~~
    4 |   case '1':
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-50 - 1]
@@ -442,6 +481,7 @@ Message: Switch is not exhaustive. Cases not matched: B.D
    9 |         switch (foo) {
      |                 ~~~
   10 |           case A.B.C: {
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-51 - 1]
@@ -451,6 +491,7 @@ Message: Switch is not exhaustive. Cases not matched: B.D
    4 |         switch (foo) {
      |                 ~~~
    5 |           case A.B.C: {
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-6 - 1]
@@ -460,6 +501,7 @@ Message: Switch is not exhaustive. Cases not matched: undefined | null | "1" | 1
    3 | switch (value) {
      |         ~~~~~
    4 | }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 
 Diagnostic 2: switchIsNotExhaustive (3:9 - 3:13)
 Message: Switch is not exhaustive. Cases not matched: default
@@ -467,6 +509,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    3 | switch (value) {
      |         ~~~~~
    4 | }
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-7 - 1]
@@ -476,6 +519,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    3 | switch (value) {
      |         ~~~~~
    4 |   case 1:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-8 - 1]
@@ -485,6 +529,7 @@ Message: Switch is not exhaustive. Cases not matched: default
    4 | switch (value) {
      |         ~~~~~
    5 |   case a:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---
 
 [TestSwitchExhaustivenessCheckRule/invalid-9 - 1]
@@ -494,4 +539,5 @@ Message: Switch is not exhaustive. Cases not matched: default
    3 | switch (value) {
      |         ~~~~~
    4 |   case 10n:
+  Suggestion 1: [addMissingCases] Add branches for missing cases.
 ---

--- a/internal/rules/switch_exhaustiveness_check/switch_exhaustiveness_check.go
+++ b/internal/rules/switch_exhaustiveness_check/switch_exhaustiveness_check.go
@@ -1,21 +1,24 @@
 package switch_exhaustiveness_check
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/typescript-eslint/tsgolint/internal/rule"
 	"github.com/typescript-eslint/tsgolint/internal/utils"
 )
 
-// func buildAddMissingCasesMessage() rule.RuleMessage {
-// return rule.RuleMessage{
-// Id:          "addMissingCases",
-// Description: "Add branches for missing cases.",
-// }
-// }
+func buildAddMissingCasesMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "addMissingCases",
+		Description: "Add branches for missing cases.",
+	}
+}
 
 func buildDangerousDefaultCaseMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -35,93 +38,214 @@ type SwitchMetadata struct {
 	// nil if there is no default case
 	DefaultCase               *ast.CaseOrDefaultClause
 	MissingLiteralBranchTypes []*checker.Type
-	// TODO: add support for fixed (symbolname is used only for fixes)
-	// SymbolName string
+	SymbolName                string
+}
+
+func isLiteralLikeType(t *checker.Type) bool {
+	return utils.IsTypeFlagSet(
+		t,
+		checker.TypeFlagsLiteral|checker.TypeFlagsUndefined|checker.TypeFlagsNull|checker.TypeFlagsUniqueESSymbol,
+	)
+}
+
+/**
+ * For example:
+ *
+ * - `"foo" | "bar"` is a type with all literal types.
+ * - `"foo" | number` is a type that contains non-literal types.
+ * - `"foo" & { bar: 1 }` is a type that contains non-literal types.
+ *
+ * Default cases are never superfluous in switches with non-literal types.
+ */
+func doesTypeContainNonLiteralType(t *checker.Type) bool {
+	return utils.Some(
+		utils.UnionTypeParts(t),
+		func(t *checker.Type) bool {
+			return utils.Every(
+				utils.IntersectionTypeParts(t),
+				func(t *checker.Type) bool {
+					return !isLiteralLikeType(t)
+				},
+			)
+		},
+	)
+}
+
+func getSwitchMetadata(typeChecker *checker.Checker, node *ast.SwitchStatement) *SwitchMetadata {
+	cases := node.CaseBlock.AsCaseBlock().Clauses.Nodes
+	defaultCaseIndex := slices.IndexFunc(cases, func(clause *ast.Node) bool {
+		return clause.Kind == ast.KindDefaultClause
+	})
+	var defaultCase *ast.CaseOrDefaultClause
+	if defaultCaseIndex > -1 {
+		defaultCase = cases[defaultCaseIndex].AsCaseOrDefaultClause()
+	}
+
+	discriminantType := utils.GetConstrainedTypeAtLocation(typeChecker, node.Expression)
+	symbolName := ""
+	if discriminantType.Symbol() != nil {
+		symbolName = discriminantType.Symbol().Name
+	}
+
+	caseTypeSet := make(map[*checker.Type]struct{}, len(cases))
+	hasUndefinedCase := false
+	for _, c := range cases {
+		if c.Kind == ast.KindDefaultClause {
+			continue
+		}
+
+		caseType := utils.GetConstrainedTypeAtLocation(typeChecker, c.AsCaseOrDefaultClause().Expression)
+		caseTypeSet[caseType] = struct{}{}
+		if utils.IsTypeFlagSet(caseType, checker.TypeFlagsUndefined) {
+			hasUndefinedCase = true
+		}
+	}
+
+	containsNonLiteralType := doesTypeContainNonLiteralType(discriminantType)
+
+	missingLiteralBranchTypes := make([]*checker.Type, 0, 10)
+	utils.TypeRecurser(discriminantType, func(t *checker.Type) bool {
+		if _, ok := caseTypeSet[t]; ok || !isLiteralLikeType(t) {
+			return false
+		}
+
+		// "missing", "optional" and "undefined" types are different runtime objects,
+		// but all of them have TypeFlags.Undefined type flag
+		if hasUndefinedCase && utils.IsTypeFlagSet(t, checker.TypeFlagsUndefined) {
+			return false
+		}
+
+		missingLiteralBranchTypes = append(missingLiteralBranchTypes, t)
+
+		return false
+	})
+
+	return &SwitchMetadata{
+		ContainsNonLiteralType:    containsNonLiteralType,
+		DefaultCase:               defaultCase,
+		MissingLiteralBranchTypes: missingLiteralBranchTypes,
+		SymbolName:                symbolName,
+	}
+}
+
+func requiresQuoting(text string) bool {
+	return !scanner.IsIdentifierText(text, core.LanguageVariantStandard)
+}
+
+func getNodeIndent(sourceFile *ast.SourceFile, node *ast.Node) string {
+	trimmed := utils.TrimNodeTextRange(sourceFile, node)
+	_, column := scanner.GetECMALineAndCharacterOfPosition(sourceFile, trimmed.Pos())
+	if column <= 0 {
+		return ""
+	}
+	return strings.Repeat(" ", column)
+}
+
+func buildCaseTest(typeChecker *checker.Checker, missingBranchType *checker.Type, symbolName string) string {
+	missingBranchName := ""
+	if missingBranchType.Symbol() != nil {
+		missingBranchName = missingBranchType.Symbol().Name
+	}
+
+	caseTest := ""
+	if utils.IsTypeFlagSet(missingBranchType, checker.TypeFlagsESSymbolLike) {
+		caseTest = missingBranchName
+	} else {
+		caseTest = typeChecker.TypeToString(missingBranchType)
+	}
+
+	if symbolName != "" && requiresQuoting(missingBranchName) {
+		escapedBranchName := strings.NewReplacer(
+			"'", "\\'",
+			"\n", "\\n",
+			"\r", "\\r",
+		).Replace(missingBranchName)
+
+		return fmt.Sprintf("%s['%s']", symbolName, escapedBranchName)
+	}
+
+	return caseTest
+}
+
+func buildMissingCaseLine(typeChecker *checker.Checker, missingBranchType *checker.Type, symbolName string) string {
+	if missingBranchType == nil {
+		return "default: { throw new Error('default case') }"
+	}
+
+	caseTest := buildCaseTest(typeChecker, missingBranchType, symbolName)
+	escapedCase := strings.NewReplacer("\\", "\\\\", "'", "\\'").Replace(caseTest)
+	return fmt.Sprintf("case %s: { throw new Error('Not implemented yet: %s case') }", caseTest, escapedCase)
+}
+
+func buildMissingCases(typeChecker *checker.Checker, missingBranchTypes []*checker.Type, symbolName string) []string {
+	missingCases := make([]string, 0, len(missingBranchTypes))
+	for _, missingBranchType := range missingBranchTypes {
+		missingCases = append(missingCases, buildMissingCaseLine(typeChecker, missingBranchType, symbolName))
+	}
+	return missingCases
+}
+
+func applyMissingCases(sourceFile *ast.SourceFile, node *ast.SwitchStatement, defaultCase *ast.CaseOrDefaultClause, missingCases []string) []rule.RuleFix {
+	cases := node.CaseBlock.AsCaseBlock().Clauses.Nodes
+
+	var lastCase *ast.Node
+	if len(cases) > 0 {
+		lastCase = cases[len(cases)-1]
+	}
+
+	caseIndent := ""
+	if lastCase != nil {
+		caseIndent = getNodeIndent(sourceFile, lastCase)
+	} else {
+		caseIndent = getNodeIndent(sourceFile, &node.Node)
+	}
+
+	fixString := ""
+	if len(missingCases) > 0 {
+		indented := make([]string, 0, len(missingCases))
+		for _, code := range missingCases {
+			indented = append(indented, caseIndent+code)
+		}
+		fixString = strings.Join(indented, "\n")
+	}
+
+	if lastCase != nil {
+		if defaultCase != nil {
+			beforeFixBuilder := strings.Builder{}
+			for _, code := range missingCases {
+				beforeFixBuilder.WriteString(code)
+				beforeFixBuilder.WriteByte('\n')
+				beforeFixBuilder.WriteString(caseIndent)
+			}
+
+			return []rule.RuleFix{
+				rule.RuleFixInsertBefore(sourceFile, &defaultCase.Node, beforeFixBuilder.String()),
+			}
+		}
+
+		return []rule.RuleFix{
+			rule.RuleFixInsertAfter(lastCase, "\n"+fixString),
+		}
+	}
+
+	return []rule.RuleFix{
+		rule.RuleFixReplace(
+			sourceFile,
+			node.CaseBlock,
+			strings.Join([]string{"{", fixString, caseIndent + "}"}, "\n"),
+		),
+	}
+}
+
+func fixSwitch(sourceFile *ast.SourceFile, typeChecker *checker.Checker, node *ast.SwitchStatement, missingBranchTypes []*checker.Type, defaultCase *ast.CaseOrDefaultClause, symbolName string) []rule.RuleFix {
+	missingCases := buildMissingCases(typeChecker, missingBranchTypes, symbolName)
+	return applyMissingCases(sourceFile, node, defaultCase, missingCases)
 }
 
 var SwitchExhaustivenessCheckRule = rule.Rule{
 	Name: "switch-exhaustiveness-check",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		opts := utils.UnmarshalOptions[SwitchExhaustivenessCheckOptions](options, "switch-exhaustiveness-check")
-
-		isLiteralLikeType := func(t *checker.Type) bool {
-			return utils.IsTypeFlagSet(
-				t,
-				checker.TypeFlagsLiteral|checker.TypeFlagsUndefined|checker.TypeFlagsNull|checker.TypeFlagsUniqueESSymbol,
-			)
-		}
-
-		/**
-		 * For example:
-		 *
-		 * - `"foo" | "bar"` is a type with all literal types.
-		 * - `"foo" | number` is a type that contains non-literal types.
-		 * - `"foo" & { bar: 1 }` is a type that contains non-literal types.
-		 *
-		 * Default cases are never superfluous in switches with non-literal types.
-		 */
-		doesTypeContainNonLiteralType := func(t *checker.Type) bool {
-			return utils.Some(
-				utils.UnionTypeParts(t),
-				func(t *checker.Type) bool {
-					return utils.Every(
-						utils.IntersectionTypeParts(t),
-						func(t *checker.Type) bool {
-							return !isLiteralLikeType(t)
-						},
-					)
-				},
-			)
-		}
-
-		getSwitchMetadata := func(node *ast.SwitchStatement) *SwitchMetadata {
-			cases := node.CaseBlock.AsCaseBlock().Clauses.Nodes
-			defaultCaseIndex := slices.IndexFunc(cases, func(clause *ast.Node) bool {
-				return clause.Kind == ast.KindDefaultClause
-			})
-			var defaultCase *ast.CaseOrDefaultClause
-			if defaultCaseIndex > -1 {
-				defaultCase = cases[defaultCaseIndex].AsCaseOrDefaultClause()
-			}
-
-			discriminantType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node.Expression)
-
-			caseTypes := make([]*checker.Type, 0, len(cases))
-			for _, c := range cases {
-				if c.Kind == ast.KindDefaultClause {
-					continue
-				}
-
-				caseTypes = append(caseTypes, utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, c.AsCaseOrDefaultClause().Expression))
-			}
-
-			containsNonLiteralType := doesTypeContainNonLiteralType(discriminantType)
-
-			missingLiteralBranchTypes := make([]*checker.Type, 0, 10)
-			utils.TypeRecurser(discriminantType, func(t *checker.Type) bool {
-				if slices.Contains(caseTypes, t) || !isLiteralLikeType(t) {
-					return false
-				}
-
-				// "missing", "optional" and "undefined" types are different runtime objects,
-				// but all of them have TypeFlags.Undefined type flag
-				if slices.ContainsFunc(caseTypes, func(t *checker.Type) bool {
-					return utils.IsTypeFlagSet(t, checker.TypeFlagsUndefined)
-				}) && utils.IsTypeFlagSet(t, checker.TypeFlagsUndefined) {
-					return false
-				}
-
-				missingLiteralBranchTypes = append(missingLiteralBranchTypes, t)
-
-				return false
-			})
-
-			return &SwitchMetadata{
-				ContainsNonLiteralType:    containsNonLiteralType,
-				DefaultCase:               defaultCase,
-				MissingLiteralBranchTypes: missingLiteralBranchTypes,
-			}
-		}
 
 		checkSwitchExhaustive := func(node *ast.SwitchStatement, switchMetadata *SwitchMetadata) {
 			// If considerDefaultExhaustiveForUnions is enabled, the presence of a default case
@@ -141,7 +265,12 @@ var SwitchExhaustivenessCheckRule = rule.Rule{
 					missingBranches = append(missingBranches, ctx.TypeChecker.TypeToString(missingType))
 				}
 
-				ctx.ReportNode(node.Expression, buildSwitchIsNotExhaustiveMessage(strings.Join(missingBranches, " | ")))
+				ctx.ReportNodeWithSuggestions(node.Expression, buildSwitchIsNotExhaustiveMessage(strings.Join(missingBranches, " | ")), func() []rule.RuleSuggestion {
+					return []rule.RuleSuggestion{{
+						Message:  buildAddMissingCasesMessage(),
+						FixesArr: fixSwitch(ctx.SourceFile, ctx.TypeChecker, node, switchMetadata.MissingLiteralBranchTypes, switchMetadata.DefaultCase, switchMetadata.SymbolName),
+					}}
+				})
 			}
 		}
 
@@ -162,8 +291,12 @@ var SwitchExhaustivenessCheckRule = rule.Rule{
 			}
 
 			if switchMetadata.ContainsNonLiteralType && switchMetadata.DefaultCase == nil {
-				ctx.ReportNode(node.Expression, buildSwitchIsNotExhaustiveMessage("default"))
-				// TODO(port): missing suggestion
+				ctx.ReportNodeWithSuggestions(node.Expression, buildSwitchIsNotExhaustiveMessage("default"), func() []rule.RuleSuggestion {
+					return []rule.RuleSuggestion{{
+						Message:  buildAddMissingCasesMessage(),
+						FixesArr: fixSwitch(ctx.SourceFile, ctx.TypeChecker, node, []*checker.Type{nil}, switchMetadata.DefaultCase, switchMetadata.SymbolName),
+					}}
+				})
 			}
 		}
 
@@ -172,7 +305,7 @@ var SwitchExhaustivenessCheckRule = rule.Rule{
 
 				stmt := node.AsSwitchStatement()
 
-				metadata := getSwitchMetadata(stmt)
+				metadata := getSwitchMetadata(ctx.TypeChecker, stmt)
 				checkSwitchExhaustive(stmt, metadata)
 				checkSwitchUnnecessaryDefaultCase(metadata)
 				checkSwitchNoUnionDefaultCase(stmt, metadata)

--- a/internal/rules/switch_exhaustiveness_check/switch_exhaustiveness_check_test.go
+++ b/internal/rules/switch_exhaustiveness_check/switch_exhaustiveness_check_test.go
@@ -773,18 +773,17 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: 'literal';
-					// switch (value) {
-					// case "literal": { throw new Error('Not implemented yet: "literal" case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: 'literal';
+switch (value) {
+case "literal": { throw new Error('Not implemented yet: "literal" case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -800,18 +799,17 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: 'literal' & { _brand: true };
-					// switch (value) {
-					// case "literal": { throw new Error('Not implemented yet: "literal" case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: 'literal' & { _brand: true };
+switch (value) {
+case "literal": { throw new Error('Not implemented yet: "literal" case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -829,20 +827,19 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: ('literal' & { _brand: true }) | 1;
-					// switch (value) {
-					//   case 'literal':
-					//     break;
-					//   case 1: { throw new Error('Not implemented yet: 1 case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: ('literal' & { _brand: true }) | 1;
+switch (value) {
+  case 'literal':
+    break;
+  case 1: { throw new Error('Not implemented yet: 1 case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -860,20 +857,19 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: '1' | '2' | number;
-					// switch (value) {
-					//   case '1':
-					//     break;
-					//   case "2": { throw new Error('Not implemented yet: "2" case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  case "2": { throw new Error('Not implemented yet: "2" case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -891,39 +887,37 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: '1' | '2' | number;
-					// switch (value) {
-					//   case '1':
-					//     break;
-					//   case "2": { throw new Error('Not implemented yet: "2" case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  case "2": { throw new Error('Not implemented yet: "2" case') }
+}
+      `,
+						},
+					},
 				},
 				{
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: '1' | '2' | number;
-					// switch (value) {
-					//   case '1':
-					//     break;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -941,20 +935,19 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: (string & { foo: 'bar' }) | '1';
-					// switch (value) {
-					//   case '1':
-					//     break;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: (string & { foo: 'bar' }) | '1';
+switch (value) {
+  case '1':
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -970,38 +963,36 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: (string & { foo: 'bar' }) | '1' | 1 | null | undefined;
-					// switch (value) {
-					// case undefined: { throw new Error('Not implemented yet: undefined case') }
-					// case null: { throw new Error('Not implemented yet: null case') }
-					// case "1": { throw new Error('Not implemented yet: "1" case') }
-					// case 1: { throw new Error('Not implemented yet: 1 case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: (string & { foo: 'bar' }) | '1' | 1 | null | undefined;
+switch (value) {
+case undefined: { throw new Error('Not implemented yet: undefined case') }
+case null: { throw new Error('Not implemented yet: null case') }
+case "1": { throw new Error('Not implemented yet: "1" case') }
+case 1: { throw new Error('Not implemented yet: 1 case') }
+}
+      `,
+						},
+					},
 				},
 				{
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: (string & { foo: 'bar' }) | '1' | 1 | null | undefined;
-					// switch (value) {
-					// default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: (string & { foo: 'bar' }) | '1' | 1 | null | undefined;
+switch (value) {
+default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1019,20 +1010,19 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: string | number;
-					// switch (value) {
-					//   case 1:
-					//     break;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: string | number;
+switch (value) {
+  case 1:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1051,21 +1041,20 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      4,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: number;
-					// declare const a: number;
-					// switch (value) {
-					//   case a:
-					//     break;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: number;
+declare const a: number;
+switch (value) {
+  case a:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1083,20 +1072,19 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: bigint;
-					// switch (value) {
-					//   case 10n:
-					//     break;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: bigint;
+switch (value) {
+  case 10n:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1115,21 +1103,20 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      4,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: symbol;
-					// const a = Symbol('a');
-					// switch (value) {
-					//   case a:
-					//     break;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: symbol;
+const a = Symbol('a');
+switch (value) {
+  case a:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1149,23 +1136,22 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      5,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// const a = Symbol('aa');
-					// const b = Symbol('bb');
-					// declare const value: typeof a | typeof b | 1;
-					// switch (value) {
-					//   case 1:
-					//     break;
-					//   case a: { throw new Error('Not implemented yet: a case') }
-					//   case b: { throw new Error('Not implemented yet: b case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+const a = Symbol('aa');
+const b = Symbol('bb');
+declare const value: typeof a | typeof b | 1;
+switch (value) {
+  case 1:
+    break;
+  case a: { throw new Error('Not implemented yet: a case') }
+  case b: { throw new Error('Not implemented yet: b case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1184,21 +1170,20 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      4,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// const a = Symbol('a');
-					// declare const value: typeof a | string;
-					// switch (value) {
-					//   case a:
-					//     break;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+const a = Symbol('a');
+declare const value: typeof a | string;
+switch (value) {
+  case a:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1214,19 +1199,18 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: boolean;
-					// switch (value) {
-					// case false: { throw new Error('Not implemented yet: false case') }
-					// case true: { throw new Error('Not implemented yet: true case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: boolean;
+switch (value) {
+case false: { throw new Error('Not implemented yet: false case') }
+case true: { throw new Error('Not implemented yet: true case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1244,21 +1228,20 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: boolean | 1;
-					// switch (value) {
-					//   case false:
-					//     break;
-					//   case true: { throw new Error('Not implemented yet: true case') }
-					//   case 1: { throw new Error('Not implemented yet: 1 case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: boolean | 1;
+switch (value) {
+  case false:
+    break;
+  case 1: { throw new Error('Not implemented yet: 1 case') }
+  case true: { throw new Error('Not implemented yet: true case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1276,40 +1259,38 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: boolean | number;
-					// switch (value) {
-					//   case 1:
-					//     break;
-					//   case false: { throw new Error('Not implemented yet: false case') }
-					//   case true: { throw new Error('Not implemented yet: true case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: boolean | number;
+switch (value) {
+  case 1:
+    break;
+  case false: { throw new Error('Not implemented yet: false case') }
+  case true: { throw new Error('Not implemented yet: true case') }
+}
+      `,
+						},
+					},
 				},
 				{
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: boolean | number;
-					// switch (value) {
-					//   case 1:
-					//     break;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: boolean | number;
+switch (value) {
+  case 1:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1327,20 +1308,19 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const value: object;
-					// switch (value) {
-					//   case 1:
-					//     break;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const value: object;
+switch (value) {
+  case 1:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1364,51 +1344,49 @@ switch (value) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      7,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// enum Aaa {
-					//   Foo,
-					//   Bar,
-					// }
-					// declare const value: Aaa | 1 | string;
-					// switch (value) {
-					//   case 1:
-					//     break;
-					//   case Aaa.Foo:
-					//     break;
-					//   case Aaa.Bar: { throw new Error('Not implemented yet: Aaa.Bar case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+enum Aaa {
+  Foo,
+  Bar,
+}
+declare const value: Aaa | 1 | string;
+switch (value) {
+  case 1:
+    break;
+  case Aaa.Foo:
+    break;
+  case Aaa.Bar: { throw new Error('Not implemented yet: Aaa.Bar case') }
+}
+      `,
+						},
+					},
 				},
 				{
 					MessageId: "switchIsNotExhaustive",
 					Line:      7,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// enum Aaa {
-					//   Foo,
-					//   Bar,
-					// }
-					// declare const value: Aaa | 1 | string;
-					// switch (value) {
-					//   case 1:
-					//     break;
-					//   case Aaa.Foo:
-					//     break;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+enum Aaa {
+  Foo,
+  Bar,
+}
+declare const value: Aaa | 1 | string;
+switch (value) {
+  case 1:
+    break;
+  case Aaa.Foo:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1438,38 +1416,37 @@ switch (day) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      14,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// type Day =
-					//   | 'Monday'
-					//   | 'Tuesday'
-					//   | 'Wednesday'
-					//   | 'Thursday'
-					//   | 'Friday'
-					//   | 'Saturday'
-					//   | 'Sunday';
-					//
-					// const day = 'Monday' as Day;
-					// let result = 0;
-					//
-					// switch (day) {
-					//   case 'Monday': {
-					//     result = 1;
-					//     break;
-					//   }
-					//   case "Tuesday": { throw new Error('Not implemented yet: "Tuesday" case') }
-					//   case "Wednesday": { throw new Error('Not implemented yet: "Wednesday" case') }
-					//   case "Thursday": { throw new Error('Not implemented yet: "Thursday" case') }
-					//   case "Friday": { throw new Error('Not implemented yet: "Friday" case') }
-					//   case "Saturday": { throw new Error('Not implemented yet: "Saturday" case') }
-					//   case "Sunday": { throw new Error('Not implemented yet: "Sunday" case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+type Day =
+  | 'Monday'
+  | 'Tuesday'
+  | 'Wednesday'
+  | 'Thursday'
+  | 'Friday'
+  | 'Saturday'
+  | 'Sunday';
+
+const day = 'Monday' as Day;
+let result = 0;
+
+switch (day) {
+  case 'Monday': {
+    result = 1;
+    break;
+  }
+  case "Friday": { throw new Error('Not implemented yet: "Friday" case') }
+  case "Saturday": { throw new Error('Not implemented yet: "Saturday" case') }
+  case "Sunday": { throw new Error('Not implemented yet: "Sunday" case') }
+  case "Thursday": { throw new Error('Not implemented yet: "Thursday" case') }
+  case "Tuesday": { throw new Error('Not implemented yet: "Tuesday" case') }
+  case "Wednesday": { throw new Error('Not implemented yet: "Wednesday" case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1492,26 +1469,25 @@ function test(value: Enum): number {
 					MessageId: "switchIsNotExhaustive",
 					Line:      8,
 					Column:    11,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// enum Enum {
-					//   A,
-					//   B,
-					// }
-					//
-					// function test(value: Enum): number {
-					//   switch (value) {
-					//     case Enum.A:
-					//       return 1;
-					//     case Enum.B: { throw new Error('Not implemented yet: Enum.B case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+enum Enum {
+  A,
+  B,
+}
+
+function test(value: Enum): number {
+  switch (value) {
+    case Enum.A:
+      return 1;
+    case Enum.B: { throw new Error('Not implemented yet: Enum.B case') }
+  }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1534,27 +1510,26 @@ function test(value: Union): number {
 					MessageId: "switchIsNotExhaustive",
 					Line:      8,
 					Column:    11,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// type A = 'a';
-					// type B = 'b';
-					// type C = 'c';
-					// type Union = A | B | C;
-					//
-					// function test(value: Union): number {
-					//   switch (value) {
-					//     case 'a':
-					//       return 1;
-					//     case "b": { throw new Error('Not implemented yet: "b" case') }
-					//     case "c": { throw new Error('Not implemented yet: "c" case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+type A = 'a';
+type B = 'b';
+type C = 'c';
+type Union = A | B | C;
+
+function test(value: Union): number {
+  switch (value) {
+    case 'a':
+      return 1;
+    case "b": { throw new Error('Not implemented yet: "b" case') }
+    case "c": { throw new Error('Not implemented yet: "c" case') }
+  }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1578,28 +1553,27 @@ function test(value: Union): number {
 					MessageId: "switchIsNotExhaustive",
 					Line:      9,
 					Column:    11,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// const A = 'a';
-					// const B = 1;
-					// const C = true;
-					//
-					// type Union = typeof A | typeof B | typeof C;
-					//
-					// function test(value: Union): number {
-					//   switch (value) {
-					//     case 'a':
-					//       return 1;
-					//     case true: { throw new Error('Not implemented yet: true case') }
-					//     case 1: { throw new Error('Not implemented yet: 1 case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+const A = 'a';
+const B = 1;
+const C = true;
+
+type Union = typeof A | typeof B | typeof C;
+
+function test(value: Union): number {
+  switch (value) {
+    case 'a':
+      return 1;
+    case 1: { throw new Error('Not implemented yet: 1 case') }
+    case true: { throw new Error('Not implemented yet: true case') }
+  }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1619,23 +1593,22 @@ function test(value: DiscriminatedUnion): number {
 					MessageId: "switchIsNotExhaustive",
 					Line:      5,
 					Column:    11,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// type DiscriminatedUnion = { type: 'A'; a: 1 } | { type: 'B'; b: 2 };
-					//
-					// function test(value: DiscriminatedUnion): number {
-					//   switch (value.type) {
-					//     case 'A':
-					//       return 1;
-					//     case "B": { throw new Error('Not implemented yet: "B" case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+type DiscriminatedUnion = { type: 'A'; a: 1 } | { type: 'B'; b: 2 };
+
+function test(value: DiscriminatedUnion): number {
+  switch (value.type) {
+    case 'A':
+      return 1;
+    case "B": { throw new Error('Not implemented yet: "B" case') }
+  }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1660,34 +1633,33 @@ switch (day) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      13,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// type Day =
-					//   | 'Monday'
-					//   | 'Tuesday'
-					//   | 'Wednesday'
-					//   | 'Thursday'
-					//   | 'Friday'
-					//   | 'Saturday'
-					//   | 'Sunday';
-					//
-					// const day = 'Monday' as Day;
-					//
-					// switch (day) {
-					// case "Monday": { throw new Error('Not implemented yet: "Monday" case') }
-					// case "Tuesday": { throw new Error('Not implemented yet: "Tuesday" case') }
-					// case "Wednesday": { throw new Error('Not implemented yet: "Wednesday" case') }
-					// case "Thursday": { throw new Error('Not implemented yet: "Thursday" case') }
-					// case "Friday": { throw new Error('Not implemented yet: "Friday" case') }
-					// case "Saturday": { throw new Error('Not implemented yet: "Saturday" case') }
-					// case "Sunday": { throw new Error('Not implemented yet: "Sunday" case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+type Day =
+  | 'Monday'
+  | 'Tuesday'
+  | 'Wednesday'
+  | 'Thursday'
+  | 'Friday'
+  | 'Saturday'
+  | 'Sunday';
+
+const day = 'Monday' as Day;
+
+switch (day) {
+case "Friday": { throw new Error('Not implemented yet: "Friday" case') }
+case "Monday": { throw new Error('Not implemented yet: "Monday" case') }
+case "Saturday": { throw new Error('Not implemented yet: "Saturday" case') }
+case "Sunday": { throw new Error('Not implemented yet: "Sunday" case') }
+case "Thursday": { throw new Error('Not implemented yet: "Thursday" case') }
+case "Tuesday": { throw new Error('Not implemented yet: "Tuesday" case') }
+case "Wednesday": { throw new Error('Not implemented yet: "Wednesday" case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1711,28 +1683,27 @@ function test(value: T): number {
 					MessageId: "switchIsNotExhaustive",
 					Line:      9,
 					Column:    11,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// const a = Symbol('a');
-					// const b = Symbol('b');
-					// const c = Symbol('c');
-					//
-					// type T = typeof a | typeof b | typeof c;
-					//
-					// function test(value: T): number {
-					//   switch (value) {
-					//     case a:
-					//       return 1;
-					//     case b: { throw new Error('Not implemented yet: b case') }
-					//     case c: { throw new Error('Not implemented yet: c case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+const a = Symbol('a');
+const b = Symbol('b');
+const c = Symbol('c');
+
+type T = typeof a | typeof b | typeof c;
+
+function test(value: T): number {
+  switch (value) {
+    case a:
+      return 1;
+    case b: { throw new Error('Not implemented yet: b case') }
+    case c: { throw new Error('Not implemented yet: c case') }
+  }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1750,23 +1721,22 @@ function test(value: T): number {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "switchIsNotExhaustive",
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// type T = 1 | 2;
-					//
-					// function test(value: T): number {
-					//   switch (value) {
-					//     case 1:
-					//       return 1;
-					//     case 2: { throw new Error('Not implemented yet: 2 case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+type T = 1 | 2;
+
+function test(value: T): number {
+  switch (value) {
+    case 1:
+      return 1;
+    case 2: { throw new Error('Not implemented yet: 2 case') }
+  }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1782,22 +1752,21 @@ function test(value: T): number {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "switchIsNotExhaustive",
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// type T = 1 | 2;
-					//
-					// function test(value: T): number {
-					//   switch (value) {
-					//   case 1: { throw new Error('Not implemented yet: 1 case') }
-					//   case 2: { throw new Error('Not implemented yet: 2 case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+type T = 1 | 2;
+
+function test(value: T): number {
+  switch (value) {
+  case 1: { throw new Error('Not implemented yet: 1 case') }
+  case 2: { throw new Error('Not implemented yet: 2 case') }
+  }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1816,25 +1785,22 @@ function test(arg: Enum): string {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "switchIsNotExhaustive",
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// export enum Enum {
-					//   'test-test' = 'test-test',
-					//   'test' = 'test',
-					// }
-					//
-					// function test(arg: Enum): string {
-					//   switch (arg) {
-					//   case Enum['test-test']: { throw new Error('Not implemented yet: Enum[\'test-test\'] case') }
-					//   case Enum.test: { throw new Error('Not implemented yet: Enum.test case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "addMissingCases",
+						Output: `
+export enum Enum {
+  'test-test' = 'test-test',
+  'test' = 'test',
+}
+
+function test(arg: Enum): string {
+  switch (arg) {
+  case Enum['test-test']: { throw new Error('Not implemented yet: Enum[\'test-test\'] case') }
+  case Enum.test: { throw new Error('Not implemented yet: Enum.test case') }
+  }
+}
+      `,
+					}},
 				},
 			},
 		},
@@ -1853,25 +1819,24 @@ function test(arg: Enum): string {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "switchIsNotExhaustive",
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// export enum Enum {
-					//   '' = 'test-test',
-					//   'test' = 'test',
-					// }
-					//
-					// function test(arg: Enum): string {
-					//   switch (arg) {
-					//   case Enum['']: { throw new Error('Not implemented yet: Enum[\'\'] case') }
-					//   case Enum.test: { throw new Error('Not implemented yet: Enum.test case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+export enum Enum {
+  '' = 'test-test',
+  'test' = 'test',
+}
+
+function test(arg: Enum): string {
+  switch (arg) {
+  case Enum['']: { throw new Error('Not implemented yet: Enum[\'\'] case') }
+  case Enum.test: { throw new Error('Not implemented yet: Enum.test case') }
+  }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1890,25 +1855,24 @@ function test(arg: Enum): string {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "switchIsNotExhaustive",
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// export enum Enum {
-					//   '9test' = 'test-test',
-					//   'test' = 'test',
-					// }
-					//
-					// function test(arg: Enum): string {
-					//   switch (arg) {
-					//   case Enum['9test']: { throw new Error('Not implemented yet: Enum[\'9test\'] case') }
-					//   case Enum.test: { throw new Error('Not implemented yet: Enum.test case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+export enum Enum {
+  '9test' = 'test-test',
+  'test' = 'test',
+}
+
+function test(arg: Enum): string {
+  switch (arg) {
+  case Enum['9test']: { throw new Error('Not implemented yet: Enum[\'9test\'] case') }
+  case Enum.test: { throw new Error('Not implemented yet: Enum.test case') }
+  }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1926,22 +1890,21 @@ switch (value) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "switchIsNotExhaustive",
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// const value: number = Math.floor(Math.random() * 3);
-					// switch (value) {
-					//   case 0:
-					//     return 0;
-					//   case 1:
-					//     return 1;
-					//   default: { throw new Error('default case') }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+const value: number = Math.floor(Math.random() * 3);
+switch (value) {
+  case 0:
+    return 0;
+  case 1:
+    return 1;
+  default: { throw new Error('default case') }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -1962,27 +1925,26 @@ switch (value) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "switchIsNotExhaustive",
-					// TODO(port): add support for suggestions
-					//       Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//         {
-					//           MessageId: "addMissingCases",
-					//           Output: `
-					//   enum Enum {
-					//     'a' = 1,
-					//     [` + "`" + `key-with
-					//
-					//     new-line` + "`" + `] = 2,
-					//   }
-					//
-					//   declare const a: Enum;
-					//
-					//   switch (a) {
-					//   case Enum.a: { throw new Error('Not implemented yet: Enum.a case') }
-					//   case Enum['key-with\n\n          new-line']: { throw new Error('Not implemented yet: Enum[\'key-with\\n\\n          new-line\'] case') }
-					//   }
-					// `,
-					//         },
-					//       },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+        enum Enum {
+          'a' = 1,
+          [` + "`" + `key-with
+
+          new-line` + "`" + `] = 2,
+        }
+
+        declare const a: Enum;
+
+        switch (a) {
+        case Enum.a: { throw new Error('Not implemented yet: Enum.a case') }
+        case Enum['key-with\n\n          new-line']: { throw new Error('Not implemented yet: Enum[\'key-with\\n\\n          new-line\'] case') }
+        }
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -2000,25 +1962,24 @@ switch (value) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "switchIsNotExhaustive",
-					// TODO(port): add support for suggestions
-					//       Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//         {
-					//           MessageId: "addMissingCases",
-					//           Output: `
-					//   enum Enum {
-					//     'a' = 1,
-					//     "'a' ` + "`" + `b` + "`" + ` \"c\"" = 2,
-					//   }
-					//
-					//   declare const a: Enum;
-					//
-					//   switch (a) {
-					//   case Enum.a: { throw new Error('Not implemented yet: Enum.a case') }
-					//   case Enum['\'a\' ` + "`" + `b` + "`" + ` "c"']: { throw new Error('Not implemented yet: Enum[\'\\\'a\\\' ` + "`" + `b` + "`" + ` "c"\'] case') }
-					//   }
-					// `,
-					//         },
-					//       },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+        enum Enum {
+          'a' = 1,
+          "'a' ` + "`" + `b` + "`" + ` \"c\"" = 2,
+        }
+
+        declare const a: Enum;
+
+        switch (a) {
+        case Enum.a: { throw new Error('Not implemented yet: Enum.a case') }
+        case Enum['\'a\' ` + "`" + `b` + "`" + ` "c"']: { throw new Error('Not implemented yet: Enum[\'\\\'a\\\' ` + "`" + `b` + "`" + ` "c"\'] case') }
+        }
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -2205,23 +2166,22 @@ switch (literal) {
 				MessageId: "switchIsNotExhaustive",
 				Line:      4,
 				Column:    9,
-				// TODO(port): add support for suggestions
-				//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-				//               {
-				//                 MessageId: "addMissingCases",
-				//                 Output: `
-				// declare const literal: 'a' | 'b';
-				//
-				// switch (literal) {
-				//   case 'a':
-				//     break;
-				//   case "b": { throw new Error('Not implemented yet: "b" case') }
-				//   default:
-				//     break;
-				// }
-				//       `,
-				//               },
-				//             },
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{
+						MessageId: "addMissingCases",
+						Output: `
+declare const literal: 'a' | 'b';
+
+switch (literal) {
+  case 'a':
+    break;
+  case "b": { throw new Error('Not implemented yet: "b" case') }
+  default:
+    break;
+}
+      `,
+					},
+				},
 			},
 			},
 		},
@@ -2233,21 +2193,23 @@ switch (literal) {
   case 'a':
     break;
 }
-`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "switchIsNotExhaustive", Line: 4, Column: 9}}, // TODO(port): add support for suggestions
-			// Suggestions: []rule_tester.InvalidTestCaseSuggestion{ {
-			//                 MessageId: "addMissingCases",
-			//                 Output: `
-			// declare const literal: 'a' | 'b';
-			//
-			// switch (literal) {
-			//   case 'a':
-			//     break;
-			//   case "b": { throw new Error('Not implemented yet: "b" case') }
-			// }
-			//       `,
-			//               },
-			//             },
+`, Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "switchIsNotExhaustive",
+				Line:      4,
+				Column:    9,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+					MessageId: "addMissingCases",
+					Output: `
+declare const literal: 'a' | 'b';
 
+switch (literal) {
+  case 'a':
+    break;
+  case "b": { throw new Error('Not implemented yet: "b" case') }
+}
+`,
+				}},
+			}},
 		},
 		{
 			Code: `
@@ -2263,22 +2225,21 @@ switch (literal) {
 				MessageId: "switchIsNotExhaustive",
 				Line:      4,
 				Column:    9,
-				// TODO(port): add support for suggestions
-				//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-				//               {
-				//                 MessageId: "addMissingCases",
-				//                 Output: `
-				// declare const literal: 'a' | 'b';
-				//
-				// switch (literal) {
-				//   case "b": { throw new Error('Not implemented yet: "b" case') }
-				//   default:
-				//   case 'a':
-				//     break;
-				// }
-				//       `,
-				//               },
-				//             },
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{
+						MessageId: "addMissingCases",
+						Output: `
+declare const literal: 'a' | 'b';
+
+switch (literal) {
+  case "b": { throw new Error('Not implemented yet: "b" case') }
+  default:
+  case 'a':
+    break;
+}
+      `,
+					},
+				},
 			},
 			},
 		},
@@ -2297,24 +2258,23 @@ switch (literal) {
 				MessageId: "switchIsNotExhaustive",
 				Line:      4,
 				Column:    9,
-				// TODO(port): add support for suggestions
-				//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-				//               {
-				//                 MessageId: "addMissingCases",
-				//                 Output: `
-				// declare const literal: 'a' | 'b' | 'c';
-				//
-				// switch (literal) {
-				//   case 'a':
-				//     break;
-				//   case "b": { throw new Error('Not implemented yet: "b" case') }
-				//   case "c": { throw new Error('Not implemented yet: "c" case') }
-				//   default:
-				//     break;
-				// }
-				//       `,
-				//               },
-				//             },
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{
+						MessageId: "addMissingCases",
+						Output: `
+declare const literal: 'a' | 'b' | 'c';
+
+switch (literal) {
+  case 'a':
+    break;
+  case "b": { throw new Error('Not implemented yet: "b" case') }
+  case "c": { throw new Error('Not implemented yet: "c" case') }
+  default:
+    break;
+}
+      `,
+					},
+				},
 			},
 			},
 		},
@@ -2340,31 +2300,30 @@ switch (myEnum) {
 				MessageId: "switchIsNotExhaustive",
 				Line:      10,
 				Column:    9,
-				// TODO(port): add support for suggestions
-				//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-				//               {
-				//                 MessageId: "addMissingCases",
-				//                 Output: `
-				// enum MyEnum {
-				//   Foo = 'Foo',
-				//   Bar = 'Bar',
-				//   Baz = 'Baz',
-				// }
-				//
-				// declare const myEnum: MyEnum;
-				//
-				// switch (myEnum) {
-				//   case MyEnum.Foo:
-				//     break;
-				//   case MyEnum.Bar: { throw new Error('Not implemented yet: MyEnum.Bar case') }
-				//   case MyEnum.Baz: { throw new Error('Not implemented yet: MyEnum.Baz case') }
-				//   default: {
-				//     break;
-				//   }
-				// }
-				//       `,
-				//               },
-				//             },
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{
+						MessageId: "addMissingCases",
+						Output: `
+enum MyEnum {
+  Foo = 'Foo',
+  Bar = 'Bar',
+  Baz = 'Baz',
+}
+
+declare const myEnum: MyEnum;
+
+switch (myEnum) {
+  case MyEnum.Foo:
+    break;
+  case MyEnum.Bar: { throw new Error('Not implemented yet: MyEnum.Bar case') }
+  case MyEnum.Baz: { throw new Error('Not implemented yet: MyEnum.Baz case') }
+  default: {
+    break;
+  }
+}
+      `,
+					},
+				},
 			},
 			},
 		},
@@ -2381,22 +2340,21 @@ switch (value) {
 				MessageId: "switchIsNotExhaustive",
 				Line:      3,
 				Column:    9,
-				// TODO(port): add support for suggestions
-				//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-				//               {
-				//                 MessageId: "addMissingCases",
-				//                 Output: `
-				// declare const value: boolean;
-				// switch (value) {
-				//   case false: { throw new Error('Not implemented yet: false case') }
-				//   case true: { throw new Error('Not implemented yet: true case') }
-				//   default: {
-				//     break;
-				//   }
-				// }
-				//       `,
-				//               },
-				//             },
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{
+						MessageId: "addMissingCases",
+						Output: `
+declare const value: boolean;
+switch (value) {
+  case false: { throw new Error('Not implemented yet: false case') }
+  case true: { throw new Error('Not implemented yet: true case') }
+  default: {
+    break;
+  }
+}
+      `,
+					},
+				},
 			},
 			},
 		},
@@ -2415,21 +2373,20 @@ function foo(x: string[]) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      3,
 					Column:    11,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// function foo(x: string[]) {
-					//   switch (x[0]) {
-					//     case 'hi':
-					//       break;
-					//     case undefined: { throw new Error('Not implemented yet: undefined case') }
-					//   }
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+function foo(x: string[]) {
+  switch (x[0]) {
+    case 'hi':
+      break;
+    case undefined: { throw new Error('Not implemented yet: undefined case') }
+  }
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -2467,23 +2424,22 @@ switch (literal) {
 				MessageId: "switchIsNotExhaustive",
 				Line:      4,
 				Column:    9,
-				// TODO(port): add support for suggestions
-				//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-				//               {
-				//                 MessageId: "addMissingCases",
-				//                 Output: `
-				// declare const literal: 'a' | 'b' | 'c';
-				//
-				// switch (literal) {
-				//   case 'a':
-				//     break;
-				//   case "b": { throw new Error('Not implemented yet: "b" case') }
-				//   case "c": { throw new Error('Not implemented yet: "c" case') }
-				//   // no default
-				// }
-				//       `,
-				//               },
-				//             },
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{
+						MessageId: "addMissingCases",
+						Output: `
+declare const literal: 'a' | 'b' | 'c';
+
+switch (literal) {
+  case 'a':
+    break;
+  case "b": { throw new Error('Not implemented yet: "b" case') }
+  case "c": { throw new Error('Not implemented yet: "c" case') }
+  // no default
+}
+      `,
+					},
+				},
 			},
 			},
 		},
@@ -2505,23 +2461,22 @@ switch (literal) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      4,
 					Column:    9,
-					// TODO(port): add support for suggestions
-					//             Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//               {
-					//                 MessageId: "addMissingCases",
-					//                 Output: `
-					// declare const literal: 'a' | 'b' | 'c';
-					//
-					// switch (literal) {
-					//   case 'a':
-					//     break;
-					//   case "b": { throw new Error('Not implemented yet: "b" case') }
-					//   case "c": { throw new Error('Not implemented yet: "c" case') }
-					//   // skip default
-					// }
-					//       `,
-					//               },
-					//             },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+declare const literal: 'a' | 'b' | 'c';
+
+switch (literal) {
+  case 'a':
+    break;
+  case "b": { throw new Error('Not implemented yet: "b" case') }
+  case "c": { throw new Error('Not implemented yet: "c" case') }
+  // skip default
+}
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -2545,27 +2500,26 @@ switch (literal) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      9,
 					Column:    17,
-					// TODO(port): add support for suggestions
-					//       Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//         {
-					//           MessageId: "addMissingCases",
-					//           Output: `
-					//   export namespace A {
-					//     export enum B {
-					//       C,
-					//       D,
-					//     }
-					//   }
-					//   declare const foo: A.B;
-					//   switch (foo) {
-					//     case A.B.C: {
-					//       break;
-					//     }
-					//     case A.B.D: { throw new Error('Not implemented yet: A.B.D case') }
-					//   }
-					// `,
-					//         },
-					//       },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+        export namespace A {
+          export enum B {
+            C,
+            D,
+          }
+        }
+        declare const foo: A.B;
+        switch (foo) {
+          case A.B.C: {
+            break;
+          }
+          case B.D: { throw new Error('Not implemented yet: B.D case') }
+        }
+      `,
+						},
+					},
 				},
 			},
 		},
@@ -2584,22 +2538,21 @@ switch (literal) {
 					MessageId: "switchIsNotExhaustive",
 					Line:      4,
 					Column:    17,
-					// TODO(port): add support for suggestions
-					//       Suggestions: []rule_tester.InvalidTestCaseSuggestion{
-					//         {
-					//           MessageId: "addMissingCases",
-					//           Output: `
-					//   import { A } from './switch-exhaustiveness-check';
-					//   declare const foo: A.B;
-					//   switch (foo) {
-					//     case A.B.C: {
-					//       break;
-					//     }
-					//     case A.B.D: { throw new Error('Not implemented yet: A.B.D case') }
-					//   }
-					// `,
-					//         },
-					//       },
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "addMissingCases",
+							Output: `
+        import { A } from './switch-exhaustiveness-check';
+        declare const foo: A.B;
+        switch (foo) {
+          case A.B.C: {
+            break;
+          }
+          case B.D: { throw new Error('Not implemented yet: B.D case') }
+        }
+      `,
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
- Part of https://github.com/oxc-project/tsgolint/issues/668

NOTE: AI was used to help implement much of this. I recommend reviewing this PR with whitespace changes hidden, as most of the changes revolve around simply extracting the helper closures to the top-level, since they don't need to change between rule runs.

The ported code was strongly based on the upstream typescript-eslint implementation, and I believe we have parity with all of the test cases here.