### PR TITLE
perf: do not reallocate rule context struct per-rule-per-file

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -152,6 +152,92 @@ func RunLinter(
 
 }
 
+// ruleContextBuilder is a per-worker struct that provides the RuleContext
+// reporting methods. Instead of allocating 8 new closures per file, per rule, a
+// single builder is created per worker goroutine and its mutable fields
+// are updated before each rule invocation to match the current rule and file.
+type ruleContextBuilder struct {
+	file         *ast.SourceFile
+	ruleName     string
+	program      *compiler.Program
+	checker      *checker.Checker
+	fixState     Fixes
+	onDiagnostic func(rule.RuleDiagnostic)
+}
+
+// Calls `onDiagnostic` with the given diagnostic's information, but sets the
+// rule name and source file to match the file and rule currently being run.
+func (b *ruleContextBuilder) emitDiagnostic(d rule.RuleDiagnostic) {
+	d.RuleName = b.ruleName
+	d.SourceFile = b.file
+	b.onDiagnostic(d)
+}
+
+func (b *ruleContextBuilder) reportDiagnosticWithFixes(d rule.RuleDiagnostic, fixesFn func() []rule.RuleFix) {
+	var fixes []rule.RuleFix
+	if b.fixState.Fix {
+		fixes = fixesFn()
+	}
+	d.FixesPtr = &fixes
+	b.emitDiagnostic(d)
+}
+
+func (b *ruleContextBuilder) reportDiagnosticWithSuggestions(d rule.RuleDiagnostic, suggestionsFn func() []rule.RuleSuggestion) {
+	var suggestions []rule.RuleSuggestion
+	if b.fixState.FixSuggestions {
+		suggestions = suggestionsFn()
+	}
+	d.Suggestions = &suggestions
+	b.emitDiagnostic(d)
+}
+
+func (b *ruleContextBuilder) reportRange(textRange core.TextRange, msg rule.RuleMessage) {
+	b.emitDiagnostic(rule.RuleDiagnostic{
+		Range:   textRange,
+		Message: msg,
+	})
+}
+
+func (b *ruleContextBuilder) reportRangeWithSuggestions(textRange core.TextRange, msg rule.RuleMessage, suggestionsFn func() []rule.RuleSuggestion) {
+	var suggestions []rule.RuleSuggestion
+	if b.fixState.FixSuggestions {
+		suggestions = suggestionsFn()
+	}
+	b.emitDiagnostic(rule.RuleDiagnostic{
+		Range:       textRange,
+		Message:     msg,
+		Suggestions: &suggestions,
+	})
+}
+
+func (b *ruleContextBuilder) reportNode(node *ast.Node, msg rule.RuleMessage) {
+	b.emitDiagnostic(rule.RuleDiagnostic{
+		Range:   utils.TrimNodeTextRange(b.file, node),
+		Message: msg,
+	})
+}
+
+func (b *ruleContextBuilder) reportNodeWithFixes(node *ast.Node, msg rule.RuleMessage, fixesFn func() []rule.RuleFix) {
+	var fixes []rule.RuleFix
+	if b.fixState.Fix {
+		fixes = fixesFn()
+	}
+	b.emitDiagnostic(rule.RuleDiagnostic{
+		Range:    utils.TrimNodeTextRange(b.file, node),
+		Message:  msg,
+		FixesPtr: &fixes,
+	})
+}
+
+func (b *ruleContextBuilder) reportNodeWithSuggestions(node *ast.Node, msg rule.RuleMessage, suggestionsFn func() []rule.RuleSuggestion) {
+	suggestions := suggestionsFn()
+	b.emitDiagnostic(rule.RuleDiagnostic{
+		Range:       utils.TrimNodeTextRange(b.file, node),
+		Message:     msg,
+		Suggestions: &suggestions,
+	})
+}
+
 func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, files []*ast.SourceFile, workers int, getRulesForFile func(sourceFile *ast.SourceFile) []ConfiguredRule, onDiagnostic func(diagnostic rule.RuleDiagnostic), onInternalDiagnostic func(d diagnostic.Internal), fixState Fixes, typeErrors TypeErrors) error {
 	type checkerWorkload struct {
 		checker *checker.Checker
@@ -219,127 +305,62 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 	wg := core.NewWorkGroup(workers == 1)
 	for range workers {
 		wg.Queue(func() {
-			registeredListeners := make(map[ast.Kind][](func(node *ast.Node)), 20)
+			// Listeners are tagged with the rule that is associated with, so that when a diagnostic
+			// is emitted we know what rule it is coming from.
+			type taggedListener struct {
+				ruleName string
+				fn       func(node *ast.Node)
+			}
+			registeredListeners := make(map[ast.Kind][]taggedListener, 20)
+
+			ctxBuilder := &ruleContextBuilder{
+				fixState:     fixState,
+				onDiagnostic: onDiagnostic,
+			}
+
+			// These closures remain valid for the length of linting, as we mutate the fields
+			// of `ctxBuilder`, but `ctxBuilder` itself will not change.
+			ctx := rule.RuleContext{
+				ReportDiagnostic:                ctxBuilder.emitDiagnostic,
+				ReportDiagnosticWithFixes:       ctxBuilder.reportDiagnosticWithFixes,
+				ReportDiagnosticWithSuggestions: ctxBuilder.reportDiagnosticWithSuggestions,
+				ReportRange:                     ctxBuilder.reportRange,
+				ReportRangeWithSuggestions:      ctxBuilder.reportRangeWithSuggestions,
+				ReportNode:                      ctxBuilder.reportNode,
+				ReportNodeWithFixes:             ctxBuilder.reportNodeWithFixes,
+				ReportNodeWithSuggestions:       ctxBuilder.reportNodeWithSuggestions,
+			}
 
 			for w := range workloadQueue {
+				ctxBuilder.program = w.program
+				ctxBuilder.checker = w.checker
+				ctx.Program = w.program
+				ctx.TypeChecker = w.checker
+
 				for file := range w.queue {
 					if logLevel == utils.LogLevelDebug {
 						log.Print(file.FileName())
 					}
+					ctxBuilder.file = file
+					ctx.SourceFile = file
+
 					rules := getRulesForFile(file)
 					for _, r := range rules {
-						ctx := rule.RuleContext{
-							SourceFile:  file,
-							Program:     w.program,
-							TypeChecker: w.checker,
-							ReportDiagnostic: func(diagnostic rule.RuleDiagnostic) {
-								onDiagnostic(rule.RuleDiagnostic{
-									RuleName:      r.Name,
-									Range:         diagnostic.Range,
-									Message:       diagnostic.Message,
-									FixesPtr:      diagnostic.FixesPtr,
-									Suggestions:   diagnostic.Suggestions,
-									SourceFile:    file,
-									LabeledRanges: diagnostic.LabeledRanges,
-								})
-							},
-							ReportDiagnosticWithFixes: func(diagnostic rule.RuleDiagnostic, fixesFn func() []rule.RuleFix) {
-								var fixes []rule.RuleFix = nil
-								if fixState.Fix {
-									fixes = fixesFn()
-								}
-								onDiagnostic(rule.RuleDiagnostic{
-									RuleName:      r.Name,
-									Range:         diagnostic.Range,
-									Message:       diagnostic.Message,
-									FixesPtr:      &fixes,
-									SourceFile:    file,
-									LabeledRanges: diagnostic.LabeledRanges,
-								})
-							},
-							ReportDiagnosticWithSuggestions: func(diagnostic rule.RuleDiagnostic, suggestionsFn func() []rule.RuleSuggestion) {
-								var suggestions []rule.RuleSuggestion = nil
-								if fixState.FixSuggestions {
-									suggestions = suggestionsFn()
-								}
-								onDiagnostic(rule.RuleDiagnostic{
-									RuleName:      r.Name,
-									Range:         diagnostic.Range,
-									Message:       diagnostic.Message,
-									FixesPtr:      diagnostic.FixesPtr,
-									Suggestions:   &suggestions,
-									SourceFile:    file,
-									LabeledRanges: diagnostic.LabeledRanges,
-								})
-							},
-							ReportRange: func(textRange core.TextRange, msg rule.RuleMessage) {
-								onDiagnostic(rule.RuleDiagnostic{
-									RuleName:   r.Name,
-									Range:      textRange,
-									Message:    msg,
-									SourceFile: file,
-								})
-							},
-							ReportRangeWithSuggestions: func(textRange core.TextRange, msg rule.RuleMessage, suggestionsFn func() []rule.RuleSuggestion) {
-								var suggestions []rule.RuleSuggestion = nil
-								if fixState.FixSuggestions {
-									suggestions = suggestionsFn()
-								}
-								onDiagnostic(rule.RuleDiagnostic{
-									RuleName:    r.Name,
-									Range:       textRange,
-									Message:     msg,
-									Suggestions: &suggestions,
-									SourceFile:  file,
-								})
-							},
-							ReportNode: func(node *ast.Node, msg rule.RuleMessage) {
-								onDiagnostic(rule.RuleDiagnostic{
-									RuleName:   r.Name,
-									Range:      utils.TrimNodeTextRange(file, node),
-									Message:    msg,
-									SourceFile: file,
-								})
-							},
-							ReportNodeWithFixes: func(node *ast.Node, msg rule.RuleMessage, fixesFn func() []rule.RuleFix) {
-								var fixes []rule.RuleFix = nil
-								if fixState.Fix {
-									fixes = fixesFn()
-								}
-								onDiagnostic(rule.RuleDiagnostic{
-									RuleName:   r.Name,
-									Range:      utils.TrimNodeTextRange(file, node),
-									Message:    msg,
-									FixesPtr:   &fixes,
-									SourceFile: file,
-								})
-							},
-
-							ReportNodeWithSuggestions: func(node *ast.Node, msg rule.RuleMessage, suggestionsFn func() []rule.RuleSuggestion) {
-								suggestions := suggestionsFn()
-								onDiagnostic(rule.RuleDiagnostic{
-									RuleName:    r.Name,
-									Range:       utils.TrimNodeTextRange(file, node),
-									Message:     msg,
-									Suggestions: &suggestions,
-									SourceFile:  file,
-								})
-							},
-						}
-
+						ctxBuilder.ruleName = r.Name
 						for kind, listener := range r.Run(ctx) {
 							listeners, ok := registeredListeners[kind]
 							if !ok {
-								listeners = make([](func(node *ast.Node)), 0, len(rules))
+								listeners = make([]taggedListener, 0, len(rules))
 							}
-							registeredListeners[kind] = append(listeners, listener)
+							registeredListeners[kind] = append(listeners, taggedListener{ruleName: r.Name, fn: listener})
 						}
 					}
 
 					runListeners := func(kind ast.Kind, node *ast.Node) {
 						if listeners, ok := registeredListeners[kind]; ok {
 							for _, listener := range listeners {
-								listener(node)
+								ctxBuilder.ruleName = listener.ruleName
+								listener.fn(node)
 							}
 						}
 					}
@@ -410,7 +431,10 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 						return false
 					}
 					file.Node.ForEachChild(childVisitor)
-					clear(registeredListeners)
+					// Instead of clearing the map, we clear the slices in-place to avoid re-allocating memory for the listeners on each file.
+					for k := range registeredListeners {
+						registeredListeners[k] = registeredListeners[k][:0]
+					}
 				}
 			}
 		})

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1,0 +1,283 @@
+package linter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/typescript-eslint/tsgolint/internal/diagnostic"
+	"github.com/typescript-eslint/tsgolint/internal/rule"
+	"github.com/typescript-eslint/tsgolint/internal/rules/fixtures"
+	"github.com/typescript-eslint/tsgolint/internal/utils"
+
+	"gotest.tools/v3/assert"
+)
+
+var cachedBaseFS = cachedvfs.From(bundled.WrapFS(osvfs.FS()))
+
+func TestRunLinterOnProgram_MultipleListenersDiagnostics(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	fileName := "file.ts"
+	filePath := tspath.ResolvePath(rootDir, fileName)
+	code := `
+function greet(name: string): string {
+	const greeting = "hello";
+	return greeting + " " + name;
+}
+`
+
+	fs := utils.NewOverlayVFS(
+		cachedBaseFS,
+		map[string]string{filePath: code},
+	)
+	host := utils.CreateCompilerHost(rootDir, fs)
+
+	program, _, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.minimal.json", host)
+	assert.NilError(t, err, "couldn't create program")
+
+	sourceFiles := []*ast.SourceFile{program.GetSourceFile(filePath)}
+
+	const ruleName = "multi-listener-rule"
+	funcMessage := rule.RuleMessage{
+		Id:          "noFunction",
+		Description: "Found a function declaration",
+	}
+	varMessage := rule.RuleMessage{
+		Id:          "noVariable",
+		Description: "Found a variable statement",
+	}
+
+	var mu sync.Mutex
+	var diagnostics []rule.RuleDiagnostic
+
+	err = RunLinterOnProgram(
+		utils.LogLevelNormal,
+		program,
+		sourceFiles,
+		1,
+		func(sourceFile *ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{
+				{
+					Name: ruleName,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return rule.RuleListeners{
+							ast.KindFunctionDeclaration: func(node *ast.Node) {
+								ctx.ReportNode(node, funcMessage)
+							},
+							ast.KindVariableStatement: func(node *ast.Node) {
+								ctx.ReportNode(node, varMessage)
+							},
+						}
+					},
+				},
+			}
+		},
+		func(d rule.RuleDiagnostic) {
+			mu.Lock()
+			defer mu.Unlock()
+			diagnostics = append(diagnostics, d)
+		},
+		func(d diagnostic.Internal) {},
+		Fixes{Fix: false, FixSuggestions: false},
+		TypeErrors{ReportSyntactic: false, ReportSemantic: false},
+	)
+	assert.NilError(t, err, "unexpected error from RunLinterOnProgram")
+
+	assert.Equal(t, len(diagnostics), 2, "expected exactly two diagnostics")
+
+	// Both diagnostics should have the same rule name and source file
+	for i, d := range diagnostics {
+		assert.Equal(t, d.RuleName, ruleName, "diagnostic %d should have the correct rule name", i)
+		assert.Assert(t, d.SourceFile != nil, "diagnostic %d should have a non-nil source file", i)
+		assert.Equal(t, d.SourceFile.FileName(), filePath, "diagnostic %d source file should match the input file", i)
+	}
+
+	// Verify each listener produced the expected diagnostic (order matches AST traversal)
+	assert.Equal(t, diagnostics[0].Message.Id, funcMessage.Id, "first diagnostic should be from the function listener")
+	assert.Equal(t, diagnostics[1].Message.Id, varMessage.Id, "second diagnostic should be from the variable listener")
+}
+
+func TestRunLinterOnProgram_MultipleRules(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	fileName := "file.ts"
+	filePath := tspath.ResolvePath(rootDir, fileName)
+	code := `
+const x: number = 1;
+function add(a: number, b: number): number {
+	return a + b;
+}
+`
+
+	fs := utils.NewOverlayVFS(
+		cachedBaseFS,
+		map[string]string{filePath: code},
+	)
+	host := utils.CreateCompilerHost(rootDir, fs)
+
+	program, _, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.minimal.json", host)
+	assert.NilError(t, err, "couldn't create program")
+
+	sourceFiles := []*ast.SourceFile{program.GetSourceFile(filePath)}
+
+	const ruleA = "no-variables"
+	const ruleB = "no-functions"
+	msgA := rule.RuleMessage{
+		Id:          "noVar",
+		Description: "Variable statements are not allowed",
+	}
+	msgB := rule.RuleMessage{
+		Id:          "noFunc",
+		Description: "Function declarations are not allowed",
+	}
+
+	var mu sync.Mutex
+	var diagnostics []rule.RuleDiagnostic
+
+	err = RunLinterOnProgram(
+		utils.LogLevelNormal,
+		program,
+		sourceFiles,
+		1,
+		func(sourceFile *ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{
+				{
+					Name: ruleA,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return rule.RuleListeners{
+							ast.KindVariableStatement: func(node *ast.Node) {
+								ctx.ReportNode(node, msgA)
+							},
+						}
+					},
+				},
+				{
+					Name: ruleB,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return rule.RuleListeners{
+							ast.KindFunctionDeclaration: func(node *ast.Node) {
+								ctx.ReportNode(node, msgB)
+							},
+						}
+					},
+				},
+			}
+		},
+		func(d rule.RuleDiagnostic) {
+			mu.Lock()
+			defer mu.Unlock()
+			diagnostics = append(diagnostics, d)
+		},
+		func(d diagnostic.Internal) {},
+		Fixes{Fix: false, FixSuggestions: false},
+		TypeErrors{ReportSyntactic: false, ReportSemantic: false},
+	)
+	assert.NilError(t, err, "unexpected error from RunLinterOnProgram")
+
+	assert.Equal(t, len(diagnostics), 2, "expected exactly two diagnostics")
+
+	// All diagnostics should reference the correct source file
+	for i, d := range diagnostics {
+		assert.Assert(t, d.SourceFile != nil, "diagnostic %d should have a non-nil source file", i)
+		assert.Equal(t, d.SourceFile.FileName(), filePath, "diagnostic %d source file should match the input file", i)
+	}
+
+	// Each diagnostic should be attributed to the correct rule.
+	// The variable statement appears first in the source, so ruleA fires first,
+	// then the function declaration triggers ruleB.
+	assert.Equal(t, diagnostics[0].RuleName, ruleA, "first diagnostic should come from ruleA")
+	assert.Equal(t, diagnostics[0].Message.Id, msgA.Id, "first diagnostic should have ruleA's message id")
+
+	assert.Equal(t, diagnostics[1].RuleName, ruleB, "second diagnostic should come from ruleB")
+	assert.Equal(t, diagnostics[1].Message.Id, msgB.Id, "second diagnostic should have ruleB's message id")
+}
+
+func TestRunLinterOnProgram_DiagnosticsEmittedInRun(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	fileName := "file.ts"
+	filePath := tspath.ResolvePath(rootDir, fileName)
+	code := `const x = 1;`
+
+	fs := utils.NewOverlayVFS(
+		cachedBaseFS,
+		map[string]string{filePath: code},
+	)
+	host := utils.CreateCompilerHost(rootDir, fs)
+
+	program, _, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.minimal.json", host)
+	assert.NilError(t, err, "couldn't create program")
+
+	sourceFiles := []*ast.SourceFile{program.GetSourceFile(filePath)}
+
+	const ruleA = "file-checker-a"
+	const ruleB = "file-checker-b"
+	msgA := rule.RuleMessage{
+		Id:          "fileCheckA",
+		Description: "Rule A checked this file",
+	}
+	msgB := rule.RuleMessage{
+		Id:          "fileCheckB",
+		Description: "Rule B checked this file",
+	}
+
+	var mu sync.Mutex
+	var diagnostics []rule.RuleDiagnostic
+
+	err = RunLinterOnProgram(
+		utils.LogLevelNormal,
+		program,
+		sourceFiles,
+		1,
+		func(sourceFile *ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{
+				{
+					Name: ruleA,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						// Emit a diagnostic directly in Run, without any listeners
+						ctx.ReportDiagnostic(rule.RuleDiagnostic{
+							Message: msgA,
+						})
+						return rule.RuleListeners{}
+					},
+				},
+				{
+					Name: ruleB,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						// Emit a diagnostic directly in Run, without any listeners
+						ctx.ReportDiagnostic(rule.RuleDiagnostic{
+							Message: msgB,
+						})
+						return rule.RuleListeners{}
+					},
+				},
+			}
+		},
+		func(d rule.RuleDiagnostic) {
+			mu.Lock()
+			defer mu.Unlock()
+			diagnostics = append(diagnostics, d)
+		},
+		func(d diagnostic.Internal) {},
+		Fixes{Fix: false, FixSuggestions: false},
+		TypeErrors{ReportSyntactic: false, ReportSemantic: false},
+	)
+	assert.NilError(t, err, "unexpected error from RunLinterOnProgram")
+
+	assert.Equal(t, len(diagnostics), 2, "expected exactly two diagnostics")
+
+	// Both diagnostics should have the correct source file set by the linter
+	for i, d := range diagnostics {
+		assert.Assert(t, d.SourceFile != nil, "diagnostic %d should have a non-nil source file", i)
+		assert.Equal(t, d.SourceFile.FileName(), filePath, "diagnostic %d source file should match the input file", i)
+	}
+
+	// Verify each diagnostic is attributed to the correct rule
+	assert.Equal(t, diagnostics[0].RuleName, ruleA, "first diagnostic should come from ruleA")
+	assert.Equal(t, diagnostics[0].Message.Id, msgA.Id, "first diagnostic should have ruleA's message")
+
+	assert.Equal(t, diagnostics[1].RuleName, ruleB, "second diagnostic should come from ruleB")
+	assert.Equal(t, diagnostics[1].Message.Id, msgB.Id, "second diagnostic should have ruleB's message")
+}

--- a/internal/rules/no_useless_default_assignment/no_useless_default_assignment.go
+++ b/internal/rules/no_useless_default_assignment/no_useless_default_assignment.go
@@ -367,10 +367,8 @@ var NoUselessDefaultAssignmentRule = rule.Rule{
 
 			ctx.ReportDiagnostic(rule.RuleDiagnostic{
 				Range:         diagnosticRange,
-				RuleName:      noUselessDefaultAssignmentRuleName,
 				Message:       message,
 				FixesPtr:      &fixes,
-				SourceFile:    ctx.SourceFile,
 				LabeledRanges: labeledRanges,
 			})
 		}


### PR DESCRIPTION
~30% faster, ~48% less memory used, and ~37% fewer allocations on our simple benchmark. **IMPORTANT**: **this does _not_ mean that `oxlint` type-aware linting will run this much faster.** When I ran this with `oxlint`, it was not noticeably faster, it was maybe 1% better. But it was consistently faster, so I think it's worth merging. The intuition for the small real-world speedup is that the bottleneck is in the program creation and reading files from the filesystem, not the linting part itself.

The main idea is that we are currently re-allocating the rule context for every single file and every single rule. In most cases, though the behavior is exactly the same, we are just changing what file are rule we are linting with.

I refactored the diagnostic reporting code to be such that it never reallocates the diagnostic reporting functions: instead, we update the rule name and file and mutate the diagnostic reported with the current state after we've received it. This means we don't need to allocate this struct over and over again, which should reduce pressure on the GC quite a bit (this does show up in the benchmark too).

Before:

```
goos: darwin
goarch: arm64
pkg: github.com/typescript-eslint/tsgolint/cmd/tsgolint
cpu: Apple M1
BenchmarkAllRulesHeadless-8               	    4495	   2604683 ns/op	 7640387 B/op	   83526 allocs/op
BenchmarkAllRulesHeadless-8               	    4442	   2599917 ns/op	 7675330 B/op	   83833 allocs/op
BenchmarkAllRulesHeadless-8               	    4574	   2590637 ns/op	 7669025 B/op	   83771 allocs/op
BenchmarkAllRulesHeadless-8               	    4442	   2686293 ns/op	 7647700 B/op	   83587 allocs/op
BenchmarkAllRulesHeadless-8               	    4291	   2728212 ns/op	 7654198 B/op	   83647 allocs/op
BenchmarkAllRulesHeadlessSingleThread-8   	    2041	   5863713 ns/op	 7629003 B/op	   83638 allocs/op
BenchmarkAllRulesHeadlessSingleThread-8   	    2029	   5873142 ns/op	 7622800 B/op	   83581 allocs/op
BenchmarkAllRulesHeadlessSingleThread-8   	    2034	   5863612 ns/op	 7614713 B/op	   83508 allocs/op
BenchmarkAllRulesHeadlessSingleThread-8   	    2018	   5881180 ns/op	 7630698 B/op	   83649 allocs/op
BenchmarkAllRulesHeadlessSingleThread-8   	    2038	   5890125 ns/op	 7635571 B/op	   83689 allocs/op
```

After:

```
goos: darwin
goarch: arm64
pkg: github.com/typescript-eslint/tsgolint/cmd/tsgolint
cpu: Apple M1
BenchmarkAllRulesHeadless-8               	    6270	   1827035 ns/op	 4372362 B/op	   52719 allocs/op
BenchmarkAllRulesHeadless-8               	    6024	   1794715 ns/op	 4372635 B/op	   52719 allocs/op
BenchmarkAllRulesHeadless-8               	    6276	   1795347 ns/op	 4354735 B/op	   52559 allocs/op
BenchmarkAllRulesHeadless-8               	    6327	   1837421 ns/op	 4389465 B/op	   52866 allocs/op
BenchmarkAllRulesHeadless-8               	    6244	   1863864 ns/op	 4375612 B/op	   52741 allocs/op
BenchmarkAllRulesHeadlessSingleThread-8   	    2756	   4325317 ns/op	 3948056 B/op	   52395 allocs/op
BenchmarkAllRulesHeadlessSingleThread-8   	    2791	   4327110 ns/op	 3953848 B/op	   52463 allocs/op
BenchmarkAllRulesHeadlessSingleThread-8   	    2770	   4336311 ns/op	 3924766 B/op	   52215 allocs/op
BenchmarkAllRulesHeadlessSingleThread-8   	    2758	   4342168 ns/op	 3948428 B/op	   52401 allocs/op
BenchmarkAllRulesHeadlessSingleThread-8   	    2726	   4339023 ns/op	 3954526 B/op	   52460 allocs/op
```