### PR TITLE
chore: add e2e single file benchmark

### DIFF
--- a/cmd/tsgolint/headless_bench_test.go
+++ b/cmd/tsgolint/headless_bench_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -143,4 +144,123 @@ func BenchmarkAllRulesHeadless(b *testing.B) {
 // BenchmarkAllRulesHeadlessSingleThread benchmarks with a single worker to measure per-core throughput.
 func BenchmarkAllRulesHeadlessSingleThread(b *testing.B) {
 	runAllRulesBenchmark(b, true)
+}
+
+// BenchmarkE2ESingleFile benchmarks the true end-to-end path for a single file:
+// FS creation, tsconfig resolution, program creation, linting with all rules,
+// and diagnostic emission. This measures the full cost that a real oxlint
+// invocation would pay for one file.
+func BenchmarkE2ESingleFile(b *testing.B) {
+	b.Helper()
+	b.ReportAllocs()
+
+	dir := fixtureDir
+	// Pick the first fixture file we can find.
+	baseFS := osvfs.FS()
+	wrappedFS := bundled.WrapFS(cachedvfs.From(baseFS))
+	resolver := utils.NewTsConfigResolver(wrappedFS, dir)
+
+	// Find a single .ts file in the fixtures directory.
+	var targetFile string
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".ts") && !strings.HasSuffix(path, ".d.ts") {
+			targetFile = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if targetFile == "" {
+		b.Fatal("no .ts fixture file found")
+	}
+
+	normalizedFile := tspath.NormalizeSlashes(targetFile)
+
+	// Resolve tsconfig once to know the config path (this is amortized in real usage).
+	result := resolver.FindTsConfigParallel([]string{normalizedFile})
+	tsconfigPath := result[normalizedFile]
+	if tsconfigPath == "" {
+		b.Fatal("no tsconfig found for fixture file:", normalizedFile)
+	}
+
+	getRulesForFile := func(_ *ast.SourceFile) []linter.ConfiguredRule {
+		rules := make([]linter.ConfiguredRule, len(allRules))
+		for i, r := range allRules {
+			rules[i] = linter.ConfiguredRule{
+				Name: r.Name,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return r.Run(ctx, nil)
+				},
+			}
+		}
+		return rules
+	}
+
+	// Warm up once to verify everything works.
+	{
+		fs := bundled.WrapFS(cachedvfs.From(baseFS))
+		host := utils.CreateCompilerHost(dir, fs)
+		program, diags, err := utils.CreateProgram(true, fs, dir, tsconfigPath, host)
+		if err != nil {
+			b.Fatal("warmup program creation failed:", err)
+		}
+		if len(diags) > 0 {
+			b.Fatal("tsconfig diagnostics:", diags[0].Description)
+		}
+
+		sf := program.GetSourceFile(normalizedFile)
+		if sf == nil {
+			b.Fatal("source file not found in program:", normalizedFile)
+		}
+
+		var diagnosticCount int64
+		err = linter.RunLinterOnProgram(
+			utils.LogLevelNormal,
+			program,
+			[]*ast.SourceFile{sf},
+			1,
+			getRulesForFile,
+			func(_ rule.RuleDiagnostic) { atomic.AddInt64(&diagnosticCount, 1) },
+			func(_ diagnostic.Internal) {},
+			linter.Fixes{},
+			linter.TypeErrors{},
+		)
+		if err != nil {
+			b.Fatal("warmup linter failed:", err)
+		}
+		b.Logf("file: %s, diagnostics: %d", normalizedFile, diagnosticCount)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		// Full end-to-end: fresh FS, host, program, lint.
+		fs := bundled.WrapFS(cachedvfs.From(baseFS))
+		host := utils.CreateCompilerHost(dir, fs)
+		program, _, err := utils.CreateProgram(true, fs, dir, tsconfigPath, host)
+		if err != nil {
+			b.Fatal("program creation failed:", err)
+		}
+
+		sf := program.GetSourceFile(normalizedFile)
+		if sf == nil {
+			b.Fatal("source file not found in program:", normalizedFile)
+		}
+
+		err = linter.RunLinterOnProgram(
+			utils.LogLevelNormal,
+			program,
+			[]*ast.SourceFile{sf},
+			1,
+			getRulesForFile,
+			func(_ rule.RuleDiagnostic) {},
+			func(_ diagnostic.Internal) {},
+			linter.Fixes{},
+			linter.TypeErrors{},
+		)
+		if err != nil {
+			b.Fatal("linter failed:", err)
+		}
+	}
 }


### PR DESCRIPTION
Adds a benchmark for local testing that includes program creation and filesystem operations as part of the benchmark. This is a little bit more realistic, since linting is not the bottleneck in most cases. This should make it easier to do profiling and benchmarking possible optimizations.