### PR TITLE
perf: add per-directory module resolution cache to typescript-go

### DIFF
--- a/patches/0008-perf-add-per-directory-module-resolution-cache.patch
+++ b/patches/0008-perf-add-per-directory-module-resolution-cache.patch
@@ -1,0 +1,203 @@
+From 7eb7016049c4fcbfada86ac4c5a1383847ee9844 Mon Sep 17 00:00:00 2001
+From: Cam McHenry <camchenry@users.noreply.github.com>
+Date: Mon, 2 Mar 2026 21:38:25 -0500
+Subject: [PATCH] perf: add per-directory module resolution cache
+
+Add a per-directory cache to ResolveModuleName and
+ResolveTypeReferenceDirective. Files in the same directory resolving the
+same module name with the same resolution mode and project reference
+redirect will always produce the same result, so we can cache and reuse
+the resolution result.
+---
+ internal/module/cache.go    | 72 ++++++++++++++++++++++++++++++++++++-
+ internal/module/resolver.go | 45 ++++++++++++++++++++---
+ 2 files changed, 112 insertions(+), 5 deletions(-)
+
+diff --git a/internal/module/cache.go b/internal/module/cache.go
+index bddce784ef..5dbe032bd5 100644
+--- a/internal/module/cache.go
++++ b/internal/module/cache.go
+@@ -3,15 +3,74 @@ package module
+ import (
+ 	"sync"
+ 
++	"github.com/microsoft/typescript-go/internal/collections"
+ 	"github.com/microsoft/typescript-go/internal/core"
+ 	"github.com/microsoft/typescript-go/internal/packagejson"
+ )
+ 
+ type ModeAwareCache[T any] map[ModeAwareCacheKey]T
+ 
++type moduleResolutionCacheKey struct {
++	containingDirectory string
++	moduleName          string
++	resolutionMode      core.ResolutionMode
++	redirectConfigName  string
++}
++
++type moduleResolutionCache struct {
++	cache collections.SyncMap[moduleResolutionCacheKey, *ResolvedModule]
++}
++
++func newModuleResolutionCache() *moduleResolutionCache {
++	return &moduleResolutionCache{
++		cache: collections.SyncMap[moduleResolutionCacheKey, *ResolvedModule]{},
++	}
++}
++
++func (c *moduleResolutionCache) Get(key moduleResolutionCacheKey) (*ResolvedModule, bool) {
++	return c.cache.Load(key)
++}
++
++func (c *moduleResolutionCache) Set(key moduleResolutionCacheKey, value *ResolvedModule) {
++	c.cache.Store(key, value)
++}
++
++type typeRefDirectiveResolutionCacheKey struct {
++	containingDirectory             string
++	typeReferenceName               string
++	resolutionMode                  core.ResolutionMode
++	redirectConfigName              string
++	fromInferredTypesContainingFile bool
++}
++
++type typeRefDirectiveResolutionCache struct {
++	cache collections.SyncMap[typeRefDirectiveResolutionCacheKey, *ResolvedTypeReferenceDirective]
++}
++
++func newTypeRefDirectiveResolutionCache() *typeRefDirectiveResolutionCache {
++	return &typeRefDirectiveResolutionCache{
++		cache: collections.SyncMap[typeRefDirectiveResolutionCacheKey, *ResolvedTypeReferenceDirective]{},
++	}
++}
++
++func (c *typeRefDirectiveResolutionCache) Get(key typeRefDirectiveResolutionCacheKey) (*ResolvedTypeReferenceDirective, bool) {
++	return c.cache.Load(key)
++}
++
++func (c *typeRefDirectiveResolutionCache) Set(key typeRefDirectiveResolutionCacheKey, value *ResolvedTypeReferenceDirective) {
++	c.cache.Store(key, value)
++}
++
+ type caches struct {
+ 	packageJsonInfoCache *packagejson.InfoCache
+ 
++	// Per-directory module resolution cache.
++	// Avoids re-resolving the same module name from the same directory.
++	moduleResolutionCache *moduleResolutionCache
++
++	// Per-directory type reference directive resolution cache.
++	typeRefDirectiveResolutionCache *typeRefDirectiveResolutionCache
++
+ 	// Cached representation for `core.CompilerOptions.paths`.
+ 	// Doesn't handle other path patterns like in `typesVersions`.
+ 	parsedPatternsForPathsOnce sync.Once
+@@ -24,6 +83,17 @@ func newCaches(
+ 	options *core.CompilerOptions,
+ ) caches {
+ 	return caches{
+-		packageJsonInfoCache: packagejson.NewInfoCache(currentDirectory, useCaseSensitiveFileNames),
++		packageJsonInfoCache:            packagejson.NewInfoCache(currentDirectory, useCaseSensitiveFileNames),
++		moduleResolutionCache:           newModuleResolutionCache(),
++		typeRefDirectiveResolutionCache: newTypeRefDirectiveResolutionCache(),
++	}
++}
++
++// getRedirectConfigName returns a stable string key for a ResolvedProjectReference.
++// Returns "" for nil redirects.
++func getRedirectConfigName(redirect ResolvedProjectReference) string {
++	if redirect == nil {
++		return ""
+ 	}
++	return redirect.ConfigName()
+ }
+diff --git a/internal/module/resolver.go b/internal/module/resolver.go
+index d22fa0a97b..d9034cca5b 100644
+--- a/internal/module/resolver.go
++++ b/internal/module/resolver.go
+@@ -196,10 +196,27 @@ func (r *Resolver) ResolveTypeReferenceDirective(
+ 	resolutionMode core.ResolutionMode,
+ 	redirectedReference ResolvedProjectReference,
+ ) (*ResolvedTypeReferenceDirective, []DiagAndArgs) {
++	containingDirectory := tspath.GetDirectoryPath(containingFile)
+ 	traceBuilder := r.newTraceBuilder()
+ 
++	fromInferredTypesContainingFile := strings.HasSuffix(containingFile, InferredTypesContainingFile)
++
++	cacheKey := typeRefDirectiveResolutionCacheKey{
++		containingDirectory:             containingDirectory,
++		typeReferenceName:               typeReferenceDirectiveName,
++		resolutionMode:                  resolutionMode,
++		redirectConfigName:              getRedirectConfigName(redirectedReference),
++		fromInferredTypesContainingFile: fromInferredTypesContainingFile,
++	}
++
++	// Only use type reference directive resolution cache when trace resolution is disabled
++	if traceBuilder == nil {
++		if cached, ok := r.typeRefDirectiveResolutionCache.Get(cacheKey); ok {
++			return cached, nil
++		}
++	}
++
+ 	compilerOptions := GetCompilerOptionsWithRedirect(r.compilerOptions, redirectedReference)
+-	containingDirectory := tspath.GetDirectoryPath(containingFile)
+ 
+ 	typeRoots, fromConfig := compilerOptions.GetEffectiveTypeRoots(r.host.GetCurrentDirectory())
+ 	if traceBuilder != nil {
+@@ -208,22 +225,39 @@ func (r *Resolver) ResolveTypeReferenceDirective(
+ 	}
+ 
+ 	state := newResolutionState(typeReferenceDirectiveName, containingDirectory, true /*isTypeReferenceDirective*/, resolutionMode, compilerOptions, redirectedReference, r, traceBuilder)
+-	result := state.resolveTypeReferenceDirective(typeRoots, fromConfig, strings.HasSuffix(containingFile, InferredTypesContainingFile))
++	result := state.resolveTypeReferenceDirective(typeRoots, fromConfig, fromInferredTypesContainingFile)
+ 
+ 	if traceBuilder != nil {
+ 		traceBuilder.traceTypeReferenceDirectiveResult(typeReferenceDirectiveName, result)
+ 	}
++
++	r.typeRefDirectiveResolutionCache.Set(cacheKey, result)
++
+ 	return result, traceBuilder.getTraces()
+ }
+ 
+ func (r *Resolver) ResolveModuleName(moduleName string, containingFile string, resolutionMode core.ResolutionMode, redirectedReference ResolvedProjectReference) (*ResolvedModule, []DiagAndArgs) {
++	containingDirectory := tspath.GetDirectoryPath(containingFile)
+ 	traceBuilder := r.newTraceBuilder()
++
++	cacheKey := moduleResolutionCacheKey{
++		containingDirectory: containingDirectory,
++		moduleName:          moduleName,
++		resolutionMode:      resolutionMode,
++		redirectConfigName:  getRedirectConfigName(redirectedReference),
++	}
++	// Only use module resolution cache when trace resolution is disabled
++	if traceBuilder == nil {
++		if cached, ok := r.moduleResolutionCache.Get(cacheKey); ok {
++			return cached, nil
++		}
++	}
++
+ 	compilerOptions := GetCompilerOptionsWithRedirect(r.compilerOptions, redirectedReference)
+ 	if traceBuilder != nil {
+ 		traceBuilder.write(diagnostics.Resolving_module_0_from_1, moduleName, containingFile)
+ 		traceBuilder.traceResolutionUsingProjectReference(redirectedReference)
+ 	}
+-	containingDirectory := tspath.GetDirectoryPath(containingFile)
+ 
+ 	moduleResolution := compilerOptions.GetModuleResolutionKind()
+ 	if compilerOptions.ModuleResolution != moduleResolution {
+@@ -257,7 +291,10 @@ func (r *Resolver) ResolveModuleName(moduleName string, containingFile string, r
+ 		}
+ 	}
+ 
+-	return r.tryResolveFromTypingsLocation(moduleName, containingDirectory, result, traceBuilder), traceBuilder.getTraces()
++	finalResult := r.tryResolveFromTypingsLocation(moduleName, containingDirectory, result, traceBuilder)
++	r.moduleResolutionCache.Set(cacheKey, finalResult)
++
++	return finalResult, traceBuilder.getTraces()
+ }
+ 
+ func (r *Resolver) ResolvePackageDirectory(moduleName string, containingFile string, resolutionMode core.ResolutionMode, redirectedReference ResolvedProjectReference) *ResolvedModule {
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION


Spent some time profiling our linting runs. One hot function that kept coming up was `resolveImportsAndModuleAugmentations`, as in many cases around 44% of stack frames were sampled as being in this function or a function that is called by it.

The idea of this optimization is to cache the results of `ResolveModuleName` and `ResolveTypeReferenceDirective` which are called frequently by this function. In theory, I think that for the same directory and the same module name, it should always return the same results?

So far, this seems to be correct: the diagnostics we return when linting `kibana`, `vscode`, `posthog` and other projects all appear to be identical.

This has a big effect on performance, since this is a hot path for us seemingly.

---

<details>

<summary>initial benchmark results</summary>

```
/Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --version
Version: 1.50.0
```

```
Benchmark 1: OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-main /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware vscode/src
  Time (mean ± σ):     10.801 s ±  0.182 s    [User: 30.387 s, System: 1.812 s]
  Range (min … max):   10.604 s … 11.236 s    20 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-dev /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware vscode/src --silent
  Time (mean ± σ):      9.702 s ±  0.113 s    [User: 29.975 s, System: 1.744 s]
  Range (min … max):    9.513 s …  9.888 s    20 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-dev /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware vscode/src --silent ran
    1.11 ± 0.02 times faster than OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-main /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware vscode/src
```

```
Benchmark 1: OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-main /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware kibana/src/core
  Time (mean ± σ):      3.572 s ±  0.090 s    [User: 18.257 s, System: 0.752 s]
  Range (min … max):    3.463 s …  3.692 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-dev /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware kibana/src/core --silent
  Time (mean ± σ):      2.731 s ±  0.054 s    [User: 11.797 s, System: 0.648 s]
  Range (min … max):    2.681 s …  2.857 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-dev /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware kibana/src/core --silent ran
    1.31 ± 0.04 times faster than OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-main /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware kibana/src/core
```

```
Benchmark 1: OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-main /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware kibana/src
  Time (mean ± σ):     44.540 s ±  1.350 s    [User: 267.742 s, System: 8.167 s]
  Range (min … max):   43.145 s … 47.717 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-dev /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware kibana/src --silent
  Time (mean ± σ):     28.104 s ±  0.195 s    [User: 155.435 s, System: 5.623 s]
  Range (min … max):   27.705 s … 28.325 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-dev /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware kibana/src --silent ran
    1.58 ± 0.05 times faster than OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-main /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware kibana/src
```

```
Benchmark 1: OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-main /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware posthog
  Time (mean ± σ):     555.7 ms ±   9.5 ms    [User: 2469.4 ms, System: 301.5 ms]
  Range (min … max):   544.7 ms … 567.5 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-dev /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware posthog --silent
  Time (mean ± σ):     523.6 ms ±  23.2 ms    [User: 2437.4 ms, System: 305.4 ms]
  Range (min … max):   500.1 ms … 578.2 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-dev /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware posthog --silent ran
    1.06 ± 0.05 times faster than OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-main /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware posthog
```

```
Benchmark 1: OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-main /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware social-app
  Time (mean ± σ):     635.4 ms ±  24.1 ms    [User: 3131.2 ms, System: 604.0 ms]
  Range (min … max):   606.6 ms … 684.1 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-dev /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware social-app --silent
  Time (mean ± σ):     587.3 ms ±  32.3 ms    [User: 2812.9 ms, System: 580.0 ms]
  Range (min … max):   554.2 ms … 650.7 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-dev /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware social-app --silent ran
    1.08 ± 0.07 times faster than OXLINT_TSGOLINT_PATH=/Users/camchenry/workspace/tsgolint/tsgolint-main /Users/camchenry/.npm/_npx/f4a33d9b4519ccab/node_modules/.bin/oxlint --type-aware social-app
```

flamegraph before:

<img width="1440" height="743" alt="Screenshot 2026-03-02 at 10 21 02 PM" src="https://github.com/user-attachments/assets/c84f571f-b493-4ad2-b39e-d0b9da1da622" />


flamegraph after:

<img width="1440" height="751" alt="Screenshot 2026-03-02 at 10 21 13 PM" src="https://github.com/user-attachments/assets/03b19f5d-7628-47d2-a485-37614b87d8d4" />

allocs before (kibana):

<img width="1116" height="328" alt="Screenshot 2026-03-02 at 10 27 11 PM" src="https://github.com/user-attachments/assets/d278e875-6b52-4e48-a12c-8d792683c92a" />
<img width="1440" height="478" alt="Screenshot 2026-03-02 at 10 28 37 PM" src="https://github.com/user-attachments/assets/5c0f5e21-789d-4beb-bf40-467f90b041f4" />

allocs after (kibana):

<img width="1440" height="501" alt="Screenshot 2026-03-02 at 10 28 50 PM" src="https://github.com/user-attachments/assets/1a13f344-0031-480f-8cb3-06c65408b8da" />
<img width="1112" height="257" alt="Screenshot 2026-03-02 at 10 27 38 PM" src="https://github.com/user-attachments/assets/907cc7d5-3b52-475d-9e7c-db224b1e4692" />

</details>
