### PR TITLE
Revise oxlint command examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,12 @@ Without this rule, rejected promises can be missed and reach production as flaky
 pnpm add -D oxlint-tsgolint@latest
 
 # Quick start
-pnpm dlx oxlint --type-aware --type-check
+pnpm dlx oxlint --type-aware
 
 # Or run on your project
+oxlint --type-aware
+
+# Optionally also run typechecking at the same time
 oxlint --type-aware --type-check
 ```
 


### PR DESCRIPTION
I don't think we should encourage using `--type-check` by default as it can be confusing for users on TypeScript versions <6 when they get different results, or errors. Which is going to be the vast majority of users. Plus AI will just assume it should always do this, which would be bad in these cases.