### PR TITLE
fix(no-base-to-string): handle overloaded toString declarations

### DIFF
--- a/internal/rule_tester/__snapshots__/no-base-to-string.snap
+++ b/internal/rule_tester/__snapshots__/no-base-to-string.snap
@@ -858,6 +858,16 @@ Help: Consider picking a property (e.g. `user.name`), using a formatter (or `JSO
 ---
 
 [TestNoBaseToStringRule/invalid-87 - 1]
+Diagnostic 1: baseToString (4:6 - 4:6)
+Message: 'x' will use Object's default stringification format ('[object Object]') when stringified.
+Help: Consider picking a property (e.g. `user.name`), using a formatter (or `JSON.stringify`), or implementing a custom `toString()`/`toLocaleString()` on the type.
+   3 | declare const x: Mapped;
+   4 | '' + x;
+     |      ~
+   5 |       
+---
+
+[TestNoBaseToStringRule/invalid-88 - 1]
 Diagnostic 1: baseArrayJoin (3:1 - 3:1)
 Message: Using `join()` for v will use Object's default stringification format ('[object Object]') when stringified.
 Help: Consider mapping the values to a meaningful string (e.g. pick a property or call a formatter) before calling `join()`, or implementing a custom `toString()`/`toLocaleString()` on the element type.

--- a/internal/rules/no_base_to_string/no_base_to_string.go
+++ b/internal/rules/no_base_to_string/no_base_to_string.go
@@ -231,37 +231,41 @@ var NoBaseToStringRule = rule.Rule{
 				return collectArrayCertainty(t, append(visited, t))
 			}
 
-			toString := checker.Checker_getPropertyOfType(ctx.TypeChecker, t, "toString")
-			if toString == nil {
-				toString = checker.Checker_getPropertyOfType(ctx.TypeChecker, t, "toLocaleString")
-			}
-			if toString == nil {
-				// unknown
-				if opts.CheckUnknown && utils.IsTypeFlagSet(t, checker.TypeFlagsUnknown) {
-					return usefulnessSometimes
+			foundFallbackOnObject := false
+			for _, propertyName := range []string{"toString", "toLocaleString", "valueOf"} {
+				property := checker.Checker_getPropertyOfType(ctx.TypeChecker, t, propertyName)
+				if property == nil {
+					continue
 				}
-				// e.g. any
-				return usefulnessAlways
-			}
 
-			declarations := toString.Declarations
+				declarations := property.Declarations
+				if len(declarations) == 0 {
+					continue
+				}
 
-			if declarations == nil || len(declarations) != 1 {
-				// If there are multiple declarations, at least one of them must not be
-				// the default object toString.
-				//
-				// This may only matter for older versions of TS
+				// If any declaration is not from the Object interface, this is
+				// user-defined (e.g. overloaded toString/toLocaleString/valueOf).
 				// see https://github.com/typescript-eslint/typescript-eslint/issues/8585
-				return usefulnessAlways
+				// see https://github.com/typescript-eslint/typescript-eslint/issues/11945
+				if utils.Some(declarations, func(declaration *ast.Declaration) bool {
+					return !(ast.IsInterfaceDeclaration(declaration.Parent) &&
+						declaration.Parent.AsInterfaceDeclaration().Name().Text() == "Object")
+				}) {
+					return usefulnessAlways
+				}
+
+				foundFallbackOnObject = true
 			}
 
-			declaration := declarations[0]
-			isBaseToString := ast.IsInterfaceDeclaration(declaration.Parent) && declaration.Parent.AsInterfaceDeclaration().Name().Text() == "Object"
-
-			if isBaseToString {
+			if foundFallbackOnObject {
 				return usefulnessNever
 			}
 
+			// unknown
+			if opts.CheckUnknown && utils.IsTypeFlagSet(t, checker.TypeFlagsUnknown) {
+				return usefulnessSometimes
+			}
+			// e.g. any
 			return usefulnessAlways
 		}
 

--- a/internal/rules/no_base_to_string/no_base_to_string_test.go
+++ b/internal/rules/no_base_to_string/no_base_to_string_test.go
@@ -107,6 +107,24 @@ class CustomToString {
 '' + new CustomToString();
     `},
 			{Code: `
+class Foo {
+  toString(): string;
+  toString(options: { verbose: boolean }): string;
+  toString(options?: { verbose: boolean }) {
+    return 'Hello, world!';
+  }
+}
+'' + new Foo();
+    `},
+			{Code: `
+class Foo {
+  valueOf() {
+    return 1;
+  }
+}
+'' + new Foo();
+    `},
+			{Code: `
 const literalWithToString = {
   toString: () => 'Hello, world!',
 };
@@ -183,6 +201,14 @@ String(myValue);
 			{Code: `
 import { String } from 'foo';
 String({});
+    `},
+			{Code: `
+declare module 'guid' {
+  export function toString(id: number): string;
+  export function toString(id: number, format: string): string;
+}
+import * as GUID from 'guid';
+GUID.toString(123);
     `},
 			{Code: `
 ['foo', 'bar'].join('');
@@ -1640,6 +1666,20 @@ type Value = [{ foo: string }, Value];
 declare const v: Value;
 
 String(v);
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "baseToString",
+				},
+			},
+		},
+		{
+			// Covers the branch where a synthesized mapped-type property has no
+			// declarations, so we need to keep checking Object fallbacks.
+			Code: `
+type Mapped = { [K in 'toString']: () => string };
+declare const x: Mapped;
+'' + x;
       `,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{


### PR DESCRIPTION
Upstream reference: typescript-eslint/typescript-eslint@2029c78dcbe11b7e750af588d3c47f1211f02798

Context: https://github.com/typescript-eslint/typescript-eslint/pull/12089