### PR TITLE
chore(justfile): add alias `r` for `ready`

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,6 +3,8 @@
 set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 set shell := ["bash", "-cu"]
 
+alias r := ready
+
 ready:
   just fmt
   just lint


### PR DESCRIPTION
## Summary
- Add short alias `r` for the `ready` recipe in justfile, aligning with oxc's convention
## Test plan
- Run `just r` and verify it executes `just ready` (fmt + lint)