### PR TITLE
chore(justfile): add pnpm install steps to init recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,6 +15,8 @@ init:
   git submodule update --init
   pushd typescript-go && git am --3way --no-gpg-sign ../patches/*.patch && popd
   mkdir -p internal/collections && find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \;
+  pnpm install
+  cd e2e && pnpm install && cd ..
 
 [windows]
 init:
@@ -22,6 +24,8 @@ init:
   pushd typescript-go; Get-ChildItem ../patches/*.patch | ForEach-Object { git am --3way --no-gpg-sign $_.FullName }; popd
   New-Item -ItemType Directory -Force -Path internal\collections
   Get-ChildItem -Path .\typescript-go\internal\collections\* -File | Where-Object { $_.Name -notlike '*_test.go' } | ForEach-Object { Copy-Item $_.FullName -Destination .\internal\collections\ }
+  pnpm install
+  Set-Location e2e; pnpm install; Set-Location ..
 
 [unix]
 build:


### PR DESCRIPTION
## Summary
- Add `pnpm install` for both root and `e2e/` directories in the `init` recipe
- Covers both Unix and Windows targets

This ensures `just init` fully prepares the project (submodule, patches, collections, **and** Node dependencies) in one go.