### PR TITLE
fix(no-unnecessary-condition): handle IndexedAccess types in ?? and ??= paths

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-condition.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-condition.snap
@@ -1893,3 +1893,21 @@ Message: Unnecessary conditional, value is always truthy.
      |                ~~~~~~~
    5 | }
 ---
+
+[TestNoUnnecessaryConditionRule/invalid-136 - 1]
+Diagnostic 1: alwaysNullish (3:3 - 3:5)
+Message: Unnecessary conditional, value is always nullish.
+   2 | function test<T extends { foo: null }, K extends 'foo'>(num: T[K]) {
+   3 |   num ?? 'default';
+     |   ~~~
+   4 | }
+---
+
+[TestNoUnnecessaryConditionRule/invalid-137 - 1]
+Diagnostic 1: alwaysNullish (3:3 - 3:5)
+Message: Unnecessary conditional, value is always nullish.
+   2 | function test<T extends { foo: null }, K extends 'foo'>(num: T[K]) {
+   3 |   num ??= null;
+     |   ~~~
+   4 | }
+---

--- a/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -461,22 +461,20 @@ var NoUnnecessaryConditionRule = rule.Rule{
 			return false
 		}
 
-		// checkIndexedAccessNullish resolves an indexed access type via its
-		// constraint and reports/skips accordingly.  Returns true when the
-		// caller should return (the indexed-access path was handled).
-		checkIndexedAccessNullish := func(t *checker.Type, reportNode *ast.Node) bool {
-			flags := checker.Type_flags(t)
-			if !isIndexedAccessFlags(flags) {
-				return false
+		// constrainIndexedAccessType resolves an indexed access type via its
+		// base constraint. Returns (resolvedType, shouldSkip).
+		//
+		// When the indexed access can't be resolved to a concrete constraint,
+		// callers should skip conservatively.
+		constrainIndexedAccessType := func(t *checker.Type) (*checker.Type, bool) {
+			if t == nil || !isIndexedAccessFlags(checker.Type_flags(t)) {
+				return t, false
 			}
 			constraintType := checker.Checker_getBaseConstraintOfType(ctx.TypeChecker, t)
 			if constraintType == nil || isIndexedAccessFlags(checker.Type_flags(constraintType)) {
-				return true // unresolvable — skip conservatively
+				return nil, true
 			}
-			if !isNullishType(constraintType) {
-				ctx.ReportNode(reportNode, buildNeverNullishMessage())
-			}
-			return true
+			return constraintType, false
 		}
 
 		checkCondition := func(node *ast.Node) {
@@ -1324,6 +1322,16 @@ var NoUnnecessaryConditionRule = rule.Rule{
 							return
 						}
 
+						if constrainedType, shouldSkip := constrainIndexedAccessType(leftType); shouldSkip {
+							return
+						} else {
+							leftType = constrainedType
+						}
+
+						if isIndeterminateType(leftType) {
+							return
+						}
+
 						// Check for never type first (never is a special case)
 						flags := checker.Type_flags(leftType)
 						if isNeverType(flags) {
@@ -1334,13 +1342,6 @@ var NoUnnecessaryConditionRule = rule.Rule{
 						// Check if the value is always nullish
 						if isAlwaysNullishType(leftType) {
 							ctx.ReportNode(binExpr.Left, buildAlwaysNullishMessage())
-							return
-						}
-
-						// Indexed access types (e.g., Partial<Record<R, T[]>>[R] where R is generic)
-						// may not be fully resolved. Try to resolve via constraint; if the
-						// constraint is still unresolved or includes nullish, skip the report.
-						if checkIndexedAccessNullish(leftType, binExpr.Left) {
 							return
 						}
 
@@ -1378,16 +1379,25 @@ var NoUnnecessaryConditionRule = rule.Rule{
 							return
 						}
 
-						// Check for always nullish first (before skipping for element access)
-						if isAlwaysNullishType(leftType) {
-							ctx.ReportNode(binExpr.Left, buildAlwaysNullishMessage())
+						if constrainedType, shouldSkip := constrainIndexedAccessType(leftType); shouldSkip {
+							return
+						} else {
+							leftType = constrainedType
+						}
+
+						if isIndeterminateType(leftType) {
 							return
 						}
 
-						// Indexed access types (e.g., Partial<Record<R, T[]>>[R] where R is generic)
-						// may not be fully resolved. Try to resolve via constraint; if the
-						// constraint is still unresolved or includes nullish, skip the report.
-						if checkIndexedAccessNullish(leftType, binExpr.Left) {
+						flags := checker.Type_flags(leftType)
+						if isNeverType(flags) {
+							ctx.ReportNode(binExpr.Left, buildNeverMessage())
+							return
+						}
+
+						// Check for always nullish first (before skipping for element access)
+						if isAlwaysNullishType(leftType) {
+							ctx.ReportNode(binExpr.Left, buildAlwaysNullishMessage())
 							return
 						}
 
@@ -1447,19 +1457,6 @@ var NoUnnecessaryConditionRule = rule.Rule{
 									}
 								}
 							}
-						}
-
-						// Check if the value is always nullish
-						flags := checker.Type_flags(leftType)
-						if isNeverType(flags) {
-							// Special case for never type
-							ctx.ReportNode(binExpr.Left, buildNeverMessage())
-							return
-						}
-
-						if isAlwaysNullishType(leftType) {
-							ctx.ReportNode(binExpr.Left, buildAlwaysNullishMessage())
-							return
 						}
 
 						// Check if the value is never nullish

--- a/internal/rules/no_unnecessary_condition/no_unnecessary_condition_test.go
+++ b/internal/rules/no_unnecessary_condition/no_unnecessary_condition_test.go
@@ -460,6 +460,11 @@ function foo<T extends object>(arg: T, key: keyof T): void {
   arg[key] ?? 'default';
 }
     `},
+		{Code: `
+function test<T extends [string], I extends number>(arr: T, i: I) {
+  return arr[i] ?? 'default';
+}
+    `},
 
 		// Indexing cases
 		{Code: `
@@ -1041,6 +1046,11 @@ foo &&= 1;
 		{Code: `
 function foo<T extends object>(arg: T, key: keyof T): void {
   arg[key] ??= 'default';
+}
+    `},
+		{Code: `
+function test<T extends string[], I extends number>(arr: T, i: I) {
+  arr[i] ??= 'default';
 }
     `},
 		{Code: `
@@ -2675,6 +2685,22 @@ if (arr[42] && arr[42]) {
       `,
 			TSConfig: "tsconfig.noUncheckedIndexedAccess.json",
 			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy"}},
+		},
+		{
+			Code: `
+function test<T extends { foo: null }, K extends 'foo'>(num: T[K]) {
+  num ?? 'default';
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysNullish"}},
+		},
+		{
+			Code: `
+function test<T extends { foo: null }, K extends 'foo'>(num: T[K]) {
+  num ??= null;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysNullish"}},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- Fix false positive in `no-unnecessary-condition` when the left side of `??` or `??=` is an unresolved indexed access type (e.g., `Partial<Record<R, T[]>>[R]` where `R` is a generic type parameter)
- Resolve the type via `getBaseConstraintOfType`; if the constraint is still unresolvable or includes nullish, skip the report conservatively
- Extract shared logic into a `checkIndexedAccessNullish` closure to avoid duplication between `??` and `??=` paths

Related Issue in oxc: https://github.com/oxc-project/oxc/issues/20149

## Test plan

- Added two valid test cases for `Partial<Record<R, T[]>>` (with and without `noUncheckedIndexedAccess`)
- Verified existing `invalid-49` test (`T[K]` with known non-nullish constraint) still correctly reports
- All existing tests pass: `go test ./internal/rules/no_unnecessary_condition/ -count=1`