### PR TITLE
fix(no-unnecessary-type-assertion): avoid contextual generic inference for call expressions

### DIFF
--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -245,6 +245,15 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 				}
 			}
 
+			// For call-like expressions, use the context-free expression type so
+			// contextual typing from the assertion itself doesn't leak into generic
+			// inference for the original expression.
+			if ast.IsCallExpression(expression) || ast.IsNewExpression(expression) || ast.IsTaggedTemplateExpression(expression) {
+				if t := checker.Checker_getContextFreeTypeOfExpression(ctx.TypeChecker, expression); t != nil {
+					return t
+				}
+			}
+
 			return ctx.TypeChecker.GetTypeAtLocation(expression)
 		}
 

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
@@ -462,6 +462,50 @@ function unwrap<T>(input: number | string | Wrapper<T>): number {
 		{Code: `
 const value = ((<T>(input: T): T | undefined => input)(1)) as number;
 		`},
+		{
+			// https://github.com/oxc-project/oxc/issues/20656
+			Code: `
+interface Element {
+  tagName: string;
+}
+
+interface HTMLCanvasElement extends Element {
+  getContext(contextId: string): unknown;
+}
+
+interface HTMLElementTagNameMap {
+  canvas: HTMLCanvasElement;
+}
+
+declare const document: {
+  querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
+  querySelector<E extends Element = Element>(selectors: string): E | null;
+};
+
+export const a = document.querySelector('.foo') as HTMLCanvasElement | null;
+		`},
+		{
+			Code: `
+interface Element { tagName: string; }
+
+interface HTMLCanvasElement extends Element { getContext(contextId: string): unknown; }
+
+interface Factory { new <E extends Element = Element>(): E | null; }
+
+declare const CanvasFactory: Factory;
+
+export const a = new CanvasFactory() as HTMLCanvasElement | null;
+		`},
+		{
+			Code: `
+interface Element { tagName: string; }
+
+interface HTMLCanvasElement extends Element { getContext(contextId: string): unknown; }
+
+declare const query: { <E extends Element = Element>(strings: TemplateStringsArray): E | null; };
+
+export const a = query` + "`" + `.foo` + "`" + ` as HTMLCanvasElement | null;
+		`},
 		{Code: `
 type NumberValueType = number | string;
 type NumberValuePairType = [NumberValueType, NumberValueType];


### PR DESCRIPTION
For call-like expressions, the assersion was infering the actual type.

This is fixed by asking the checker for the context-free expression type before comparing it withith the asserted type.



fixes https://github.com/oxc-project/oxc/issues/20656