### PR TITLE
fix(lint): suppress unparam on toStaticValue

### DIFF
--- a/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -159,7 +159,7 @@ func isAlwaysNullishType(t *checker.Type) bool {
 	return flags&(checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid) != 0
 }
 
-func toStaticValue(t *checker.Type) (any, bool) {
+func toStaticValue(t *checker.Type) (any, bool) { //nolint:unparam // the value return is reserved for follow-up checks; current callers only need the static-ness signal
 	if t == nil {
 		return nil, false
 	}


### PR DESCRIPTION
see #833 for reasoning - we may start using this in future.

In the mean time it makes sense to keep it to align with the upstream impl