### PR TITLE
fix(dot-notation): ignore non-ascii property names

### DIFF
--- a/internal/rule_tester/__snapshots__/dot-notation.snap
+++ b/internal/rule_tester/__snapshots__/dot-notation.snap
@@ -60,34 +60,27 @@ Message: ["b"] is better written in dot notation.
 ---
 
 [TestDotNotation/invalid-8 - 1]
-Diagnostic 1: useDot (1:3 - 1:5)
-Message: ["π"] is better written in dot notation.
-   1 | a['π'];
-     |   ~~~
----
-
-[TestDotNotation/invalid-9 - 1]
 Diagnostic 1: useDot (1:5 - 1:7)
 Message: ["c"] is better written in dot notation.
    1 | a.b['c'];
      |     ~~~
 ---
 
-[TestDotNotation/invalid-10 - 1]
+[TestDotNotation/invalid-9 - 1]
 Diagnostic 1: useDot (1:3 - 1:11)
 Message: ["_dangle"] is better written in dot notation.
    1 | a['_dangle'];
      |   ~~~~~~~~~
 ---
 
-[TestDotNotation/invalid-11 - 1]
+[TestDotNotation/invalid-10 - 1]
 Diagnostic 1: useDot (1:3 - 1:14)
 Message: ["SHOUT_CASE"] is better written in dot notation.
    1 | a['SHOUT_CASE'];
      |   ~~~~~~~~~~~~
 ---
 
-[TestDotNotation/invalid-12 - 1]
+[TestDotNotation/invalid-11 - 1]
 Diagnostic 1: useDot (3:4 - 3:15)
 Message: ["SHOUT_CASE"] is better written in dot notation.
    2 | a
@@ -96,7 +89,7 @@ Message: ["SHOUT_CASE"] is better written in dot notation.
    4 |       
 ---
 
-[TestDotNotation/invalid-13 - 1]
+[TestDotNotation/invalid-12 - 1]
 Diagnostic 1: useDot (3:6 - 3:12)
 Message: ["catch"] is better written in dot notation.
    2 |     .then(function(){})
@@ -111,7 +104,7 @@ Message: ["catch"] is better written in dot notation.
      |      ~~~~~~~
 ---
 
-[TestDotNotation/invalid-14 - 1]
+[TestDotNotation/invalid-13 - 1]
 Diagnostic 1: useBrackets (3:4 - 3:8)
 Message: .while is a syntax error.
    2 | foo
@@ -120,56 +113,56 @@ Message: .while is a syntax error.
    4 |       
 ---
 
-[TestDotNotation/invalid-15 - 1]
+[TestDotNotation/invalid-14 - 1]
 Diagnostic 1: useDot (1:19 - 1:23)
 Message: ["bar"] is better written in dot notation.
    1 | foo[/* comment */ 'bar'];
      |                   ~~~~~
 ---
 
-[TestDotNotation/invalid-16 - 1]
+[TestDotNotation/invalid-15 - 1]
 Diagnostic 1: useDot (1:5 - 1:9)
 Message: ["bar"] is better written in dot notation.
    1 | foo['bar' /* comment */];
      |     ~~~~~
 ---
 
-[TestDotNotation/invalid-17 - 1]
+[TestDotNotation/invalid-16 - 1]
 Diagnostic 1: useDot (1:5 - 1:9)
 Message: ["bar"] is better written in dot notation.
    1 | foo['bar'];
      |     ~~~~~
 ---
 
-[TestDotNotation/invalid-18 - 1]
+[TestDotNotation/invalid-17 - 1]
 Diagnostic 1: useBrackets (1:19 - 1:23)
 Message: .while is a syntax error.
    1 | foo./* comment */ while;
      |                   ~~~~~
 ---
 
-[TestDotNotation/invalid-19 - 1]
+[TestDotNotation/invalid-18 - 1]
 Diagnostic 1: useDot (1:5 - 1:8)
 Message: [null] is better written in dot notation.
    1 | foo[null];
      |     ~~~~
 ---
 
-[TestDotNotation/invalid-20 - 1]
+[TestDotNotation/invalid-19 - 1]
 Diagnostic 1: useDot (1:5 - 1:9)
 Message: ["bar"] is better written in dot notation.
    1 | foo['bar'] instanceof baz;
      |     ~~~~~
 ---
 
-[TestDotNotation/invalid-21 - 1]
+[TestDotNotation/invalid-20 - 1]
 Diagnostic 1: useBrackets (1:5 - 1:6)
 Message: .if is a syntax error.
    1 | let.if();
      |     ~~
 ---
 
-[TestDotNotation/invalid-22 - 1]
+[TestDotNotation/invalid-21 - 1]
 Diagnostic 1: useDot (7:3 - 7:18)
 Message: ["protected_prop"] is better written in dot notation.
    6 | const x = new X();
@@ -178,7 +171,7 @@ Message: ["protected_prop"] is better written in dot notation.
    8 |       
 ---
 
-[TestDotNotation/invalid-23 - 1]
+[TestDotNotation/invalid-22 - 1]
 Diagnostic 1: useDot (8:3 - 8:8)
 Message: ["prop"] is better written in dot notation.
    7 | const x = new X();
@@ -187,7 +180,7 @@ Message: ["prop"] is better written in dot notation.
    9 |       
 ---
 
-[TestDotNotation/invalid-24 - 1]
+[TestDotNotation/invalid-23 - 1]
 Diagnostic 1: useDot (6:5 - 6:13)
 Message: ["key_baz"] is better written in dot notation.
    5 | };
@@ -196,7 +189,7 @@ Message: ["key_baz"] is better written in dot notation.
    7 |       
 ---
 
-[TestDotNotation/invalid-25 - 1]
+[TestDotNotation/invalid-24 - 1]
 Diagnostic 1: useDot (10:5 - 10:14)
 Message: ["extraKey"] is better written in dot notation.
    9 | function f<T extends Foo>(x: T) {
@@ -205,7 +198,7 @@ Message: ["extraKey"] is better written in dot notation.
   11 | }
 ---
 
-[TestDotNotation/invalid-26 - 1]
+[TestDotNotation/invalid-25 - 1]
 Diagnostic 1: useDot (7:5 - 7:10)
 Message: [`prop`] is better written in dot notation.
    6 | declare const foo: Foo;
@@ -214,7 +207,7 @@ Message: [`prop`] is better written in dot notation.
    8 |       
 ---
 
-[TestDotNotation/invalid-27 - 1]
+[TestDotNotation/invalid-26 - 1]
 Diagnostic 1: useDot (1:7 - 1:11)
 Message: ["bar"] is better written in dot notation.
    1 | foo?.['bar'];

--- a/internal/rules/dot_notation/dot_notation.go
+++ b/internal/rules/dot_notation/dot_notation.go
@@ -43,6 +43,28 @@ func isKeyword(name string) bool {
 	return ok
 }
 
+// https://github.com/eslint/eslint/blob/39a6424373d915fa9de0d7b0caba9a4dc3da9b53/lib/rules/dot-notation.js#L18
+func isDotNotationIdentifier(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+
+	first := name[0]
+	if !(first >= 'a' && first <= 'z' || first >= 'A' && first <= 'Z' || first == '_' || first == '$') {
+		return false
+	}
+
+	for i := 1; i < len(name); i++ {
+		ch := name[i]
+		if ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9' || ch == '_' || ch == '$' {
+			continue
+		}
+		return false
+	}
+
+	return true
+}
+
 func getComputedPropertyValue(node *ast.Node) (value string, formatted string, ok bool) {
 	switch node.Kind {
 	case ast.KindStringLiteral:
@@ -143,7 +165,7 @@ var DotNotationRule = rule.Rule{
 				return
 			}
 
-			if !scanner.IsIdentifierText(value, core.LanguageVariantStandard) {
+			if !isDotNotationIdentifier(value) {
 				return
 			}
 

--- a/internal/rules/dot_notation/dot_notation_test.go
+++ b/internal/rules/dot_notation/dot_notation_test.go
@@ -51,6 +51,8 @@ func TestDotNotation(t *testing.T) {
 		{Code: "\ntype Foo = {\n  [key: string]: number;\n};\ndeclare const foo: Foo;\nfoo[`key_baz`];\n      ", TSConfig: "tsconfig.noPropertyAccessFromIndexSignature.json"},
 		{Code: "a['X-Amzn-Trace-Id'];"},
 		{Code: "a['X-Amzn-Trace-Id'];", Tsx: true},
+		{Code: "a['Prénom'];"},
+		{Code: "a['π'];"},
 		{Code: "a['has space'];"},
 	}, []rule_tester.InvalidTestCase{
 		{
@@ -106,13 +108,6 @@ func TestDotNotation(t *testing.T) {
 		{
 			Code:   "a['b'];",
 			Output: []string{"a.b;"},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "useDot"},
-			},
-		},
-		{
-			Code:   "a['π'];",
-			Output: []string{"a.π;"},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "useDot"},
 			},


### PR DESCRIPTION
fixes https://github.com/oxc-project/tsgolint/issues/828