### PR TITLE
perf(linter): use batch API for semantic diagnostics

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -4825,6 +4825,35 @@ exports[`TSGoLint E2E Snapshot Tests > should report an error if the tsconfig.js
 ]
 `;
 
+exports[`TSGoLint E2E Snapshot Tests > should report syntactic issues 1`] = `
+[
+  {
+    "file_path": "fixtures/semantic-syntactic-diagnostics/src/a.ts",
+    "kind": 1,
+    "message": {
+      "description": "Unterminated string literal.",
+      "id": "TS1002",
+    },
+    "range": {
+      "end": 24,
+      "pos": 24,
+    },
+  },
+  {
+    "file_path": "fixtures/semantic-syntactic-diagnostics/src/b.mts",
+    "kind": 1,
+    "message": {
+      "description": "Type 'string' is not assignable to type 'number'.",
+      "id": "TS2322",
+    },
+    "range": {
+      "end": 7,
+      "pos": 6,
+    },
+  },
+]
+`;
+
 exports[`TSGoLint E2E Snapshot Tests > should report type errors 1`] = `
 [
   {

--- a/e2e/fixtures/semantic-syntactic-diagnostics/src/a.ts
+++ b/e2e/fixtures/semantic-syntactic-diagnostics/src/a.ts
@@ -1,0 +1,1 @@
+"unterminated string lit

--- a/e2e/fixtures/semantic-syntactic-diagnostics/src/b.mts
+++ b/e2e/fixtures/semantic-syntactic-diagnostics/src/b.mts
@@ -1,0 +1,1 @@
+const x: number = "string";

--- a/e2e/fixtures/semantic-syntactic-diagnostics/tsconfig.json
+++ b/e2e/fixtures/semantic-syntactic-diagnostics/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
+}

--- a/e2e/snapshot.test.ts
+++ b/e2e/snapshot.test.ts
@@ -698,4 +698,26 @@ console.log(x);
 
     expect(diagnostics).toMatchSnapshot();
   });
+
+  it('should report syntactic issues', async () => {
+    const testFiles = await getTestFiles('semantic-syntactic-diagnostics');
+    expect(testFiles.length).toBeGreaterThan(0);
+
+    const config = generateConfig(testFiles, ALL_RULES, {
+      reportSemantic: true,
+      reportSyntactic: true,
+    });
+
+    const env = { ...process.env, GOMAXPROCS: '1' };
+
+    const output = execFileSync(TSGOLINT_BIN, ['headless'], {
+      input: config,
+      env,
+    });
+
+    let diagnostics = parseHeadlessOutput(output);
+    diagnostics = sortDiagnostics(diagnostics);
+
+    expect(diagnostics).toMatchSnapshot();
+  });
 });

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -256,38 +256,53 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 
 	ctx := core.WithRequestID(context.Background(), "__single_run__")
 
-	if typeErrors.ReportSyntactic || typeErrors.ReportSemantic {
+	if typeErrors.ReportSyntactic {
 		for _, file := range files {
 			fileName := file.FileName()
 
-			if typeErrors.ReportSyntactic {
-				syntacticDiagnostics := program.GetSyntacticDiagnostics(ctx, file)
-				for _, d := range syntacticDiagnostics {
-					if d.File() != nil && d.File().FileName() == fileName {
-						onInternalDiagnostic(diagnostic.Internal{
-							Range:       d.Loc(),
-							Id:          "TS" + strconv.Itoa(int(d.Code())),
-							Description: utils.GetDiagnosticMessage(d),
-							FilePath:    &fileName,
-						})
-					}
-				}
-			}
-
-			if typeErrors.ReportSemantic {
-				semanticDiagnostics := program.GetSemanticDiagnostics(ctx, file)
-				for _, d := range semanticDiagnostics {
-					if d.File() != nil && d.File().FileName() == fileName {
-						onInternalDiagnostic(diagnostic.Internal{
-							Range:       d.Loc(),
-							Id:          "TS" + strconv.Itoa(int(d.Code())),
-							Description: utils.GetDiagnosticMessage(d),
-							FilePath:    &fileName,
-						})
-					}
+			syntacticDiagnostics := program.GetSyntacticDiagnostics(ctx, file)
+			for _, d := range syntacticDiagnostics {
+				if d.File() != nil && d.File().FileName() == fileName {
+					onInternalDiagnostic(diagnostic.Internal{
+						Range:       d.Loc(),
+						Id:          "TS" + strconv.Itoa(int(d.Code())),
+						Description: utils.GetDiagnosticMessage(d),
+						FilePath:    &fileName,
+					})
 				}
 			}
 		}
+	}
+
+	if typeErrors.ReportSemantic {
+		semanticDiagnosticsByFile := program.GetSemanticDiagnosticsWithoutNoEmitFiltering(ctx, files)
+
+		programOption := program.Options()
+
+		for _, file := range files {
+			fileName := file.FileName()
+			finalDiagnostics := compiler.FilterNoEmitSemanticDiagnostics(semanticDiagnosticsByFile[file], programOption)
+			includeProcessorDiagnostics := program.GetIncludeProcessorDiagnostics(file)
+			if len(finalDiagnostics) == 0 && len(includeProcessorDiagnostics) == 0 {
+				continue
+			}
+			finalDiagnostics = append(append(make([]*ast.Diagnostic, 0, len(finalDiagnostics)+len(includeProcessorDiagnostics)), finalDiagnostics...), includeProcessorDiagnostics...)
+			if len(finalDiagnostics) > 1 {
+				finalDiagnostics = compiler.SortAndDeduplicateDiagnostics(finalDiagnostics)
+			}
+
+			for _, d := range finalDiagnostics {
+				if d.File() != nil && d.File().FileName() == fileName {
+					onInternalDiagnostic(diagnostic.Internal{
+						Range:       d.Loc(),
+						Id:          "TS" + strconv.Itoa(int(d.Code())),
+						Description: utils.GetDiagnosticMessage(d),
+						FilePath:    &fileName,
+					})
+				}
+			}
+		}
+
 	}
 
 	var flatQueueMu sync.Mutex


### PR DESCRIPTION
Before/after

![Screenshot 2026-03-27 at 19.36.37.png](https://app.graphite.com/user-attachments/assets/6d1d2050-4c27-4d9e-af94-0c50ed5c0c33.png)

Related to #843