### PR TITLE
chore: fix schema generator drift

### DIFF
--- a/.github/workflows/check-schemas.yml
+++ b/.github/workflows/check-schemas.yml
@@ -33,7 +33,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install go-jsonschema
-        run: go install github.com/atombender/go-jsonschema@latest
+        run: go install github.com/atombender/go-jsonschema@v0.23.0
 
       - name: Generate JSON schemas
         run: node tools/gen-json-schemas.mjs

--- a/tools/gen-json-schemas.mjs
+++ b/tools/gen-json-schemas.mjs
@@ -11,14 +11,18 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
+let goJSONSchemaHelp = '';
+
 // ensure go-jsonschema is installed
 try {
-  execSync('go-jsonschema -h', { stdio: 'ignore' });
+  goJSONSchemaHelp = execSync('go-jsonschema -h', { encoding: 'utf8' });
   console.log('go-jsonschema is installed.');
 } catch (e) {
   console.log('go-jsonschema is not installed. Please install it first.');
   process.exit(1);
 }
+
+const supportsDisableOmitZero = goJSONSchemaHelp.includes('--disable-omitzero');
 
 console.log('Generating Go structs from JSON schemas...');
 
@@ -96,10 +100,11 @@ for (const schemaDir of schemaDirs) {
 
   console.log(`Generating Go struct for schema: ${schemaPath} and outputting to: ${outputPath}`);
   try {
+    const omitZeroArg = supportsDisableOmitZero ? ' --disable-omitzero' : '';
     execSync(
       `go-jsonschema  "${schemaPath}" -o "${outputPath}" -p ${
         path.basename(schemaDir)
-      } --tags json --resolve-extension json`,
+      } --tags json --resolve-extension json${omitZeroArg}`,
       {
         stdio: 'inherit',
       },


### PR DESCRIPTION
## Summary

Fix the `Check Generated Schemas` workflow drift caused by upstream `go-jsonschema` changes.

## What changed

- detect whether the installed `go-jsonschema` supports `--disable-omitzero` and pass it when available
- pin the CI workflow to `github.com/atombender/go-jsonschema@v0.23.0` instead of `@latest`

## Root cause

The workflow was installing `go-jsonschema@latest`. A newer release started emitting `json:",omitempty,omitzero"` tags by default, so `node tools/gen-json-schemas.mjs` rewrote many generated `options.go` files on `main` and the schema check failed.

## Validation

- ran `node tools/gen-json-schemas.mjs` with `go-jsonschema v0.23.0`; no generated `internal/rules/*/options.go` drift remained
- ran `node tools/gen-json-schemas.mjs` with `go-jsonschema v0.22.0`; no generated `internal/rules/*/options.go` drift remained
