### PR TITLE
feat: improve `consistent-type-exports` diagnostics quality

### DIFF
--- a/internal/rule_tester/__snapshots__/consistent-type-exports.snap
+++ b/internal/rule_tester/__snapshots__/consistent-type-exports.snap
@@ -1,251 +1,248 @@
 
 [TestConsistentTypeExportsRule/invalid-0 - 1]
-Diagnostic 1: typeOverValue (1:1 - 1:50)
+Diagnostic 1: typeOverValue (1:1 - 1:6)
 Message: All exports in the declaration are only used as types. Use `export type`.
    1 | export { Type1 } from './consistent-type-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~
 ---
 
 [TestConsistentTypeExportsRule/invalid-1 - 1]
-Diagnostic 1: typeOverValue (1:1 - 1:58)
+Diagnostic 1: typeOverValue (1:1 - 1:6)
 Message: All exports in the declaration are only used as types. Use `export type`.
    1 | export { Type1 as "🍎" } from './consistent-type-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~
 ---
 
 [TestConsistentTypeExportsRule/invalid-2 - 1]
-Diagnostic 1: singleExportIsType (1:1 - 1:58)
+Diagnostic 1: singleExportIsType (1:10 - 1:14)
 Message: Type export Type1 is not a value and should be exported using `export type`.
+Help: Try adding the `type` keyword: `type Type1`
    1 | export { Type1, value1 } from './consistent-type-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |          ~~~~~
 ---
 
 [TestConsistentTypeExportsRule/invalid-3 - 1]
-Diagnostic 1: singleExportIsType (2:1 - 2:66)
+Diagnostic 1: singleExportIsType (2:10 - 2:14)
 Message: Type export Type1 is not a value and should be exported using `export type`.
+Help: Try adding the `type` keyword: `type Type1`
    1 | 
    2 | export { Type1, value1, value2 } from './consistent-type-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |          ~~~~~
    3 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-4 - 1]
-Diagnostic 1: multipleExportsAreTypes (2:1 - 2:73)
+Diagnostic 1: multipleExportsAreTypes
 Message: Type exports Type1 and Type2 are not values and should be exported using `export type`.
+  Label: Type1 is a type export, try `type Type1` (2:10 - 2:14)
    1 | 
    2 | export { Type1, value1, Type2, value2 } from './consistent-type-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |          ^^^^^ Type1 is a type export, try `type Type1`
+   3 |       
+  Label: Type2 is a type export, try `type Type2` (2:25 - 2:29)
+   1 | 
+   2 | export { Type1, value1, Type2, value2 } from './consistent-type-exports';
+     |                         ^^^^^ Type2 is a type export, try `type Type2`
    3 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-5 - 1]
-Diagnostic 1: typeOverValue (1:1 - 1:57)
+Diagnostic 1: typeOverValue (1:1 - 1:6)
 Message: All exports in the declaration are only used as types. Use `export type`.
    1 | export { Type2 as Foo } from './consistent-type-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~
 ---
 
 [TestConsistentTypeExportsRule/invalid-6 - 1]
-Diagnostic 1: singleExportIsType (2:1 - 2:65)
+Diagnostic 1: singleExportIsType (2:10 - 2:21)
 Message: Type export Type2 as Foo is not a value and should be exported using `export type`.
+Help: Try adding the `type` keyword: `type Type2 as Foo`
    1 | 
    2 | export { Type2 as Foo, value1 } from './consistent-type-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |          ~~~~~~~~~~~~
    3 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-7 - 1]
-Diagnostic 1: singleExportIsType (2:1 - 6:35)
+Diagnostic 1: singleExportIsType (3:3 - 3:14)
 Message: Type export Type2 as Foo is not a value and should be exported using `export type`.
-   1 | 
+Help: Try adding the `type` keyword: `type Type2 as Foo`
    2 | export {
-     | ~~~~~~~~
    3 |   Type2 as Foo,
-     | ~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~
    4 |   value1 as BScope,
-     | ~~~~~~~~~~~~~~~~~~~
-   5 |   value2 as CScope,
-     | ~~~~~~~~~~~~~~~~~~~
-   6 | } from './consistent-type-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   7 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-8 - 1]
-Diagnostic 1: typeOverValue (3:1 - 3:17)
+Diagnostic 1: typeOverValue (3:1 - 3:6)
 Message: All exports in the declaration are only used as types. Use `export type`.
    2 | import { Type2 } from './consistent-type-exports';
    3 | export { Type2 };
-     | ~~~~~~~~~~~~~~~~~
+     | ~~~~~~
    4 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-9 - 1]
-Diagnostic 1: singleExportIsType (3:1 - 3:25)
+Diagnostic 1: singleExportIsType (3:18 - 3:22)
 Message: Type export Type2 is not a value and should be exported using `export type`.
+Help: Try adding the `type` keyword: `type Type2`
    2 | import { value2, Type2 } from './consistent-type-exports';
    3 | export { value2, Type2 };
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                  ~~~~~
    4 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-10 - 1]
-Diagnostic 1: multipleExportsAreTypes (9:1 - 9:32)
+Diagnostic 1: multipleExportsAreTypes
 Message: Type exports Alias and IFace are not values and should be exported using `export type`.
+  Label: Alias is a type export, try `type Alias` (9:10 - 9:14)
    8 | 
    9 | export { Alias, IFace, TypeNS };
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |          ^^^^^ Alias is a type export, try `type Alias`
+  10 |       
+  Label: IFace is a type export, try `type IFace` (9:17 - 9:21)
+   8 | 
+   9 | export { Alias, IFace, TypeNS };
+     |                 ^^^^^ IFace is a type export, try `type IFace`
   10 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-11 - 1]
-Diagnostic 1: typeOverValue (6:1 - 6:18)
+Diagnostic 1: typeOverValue (6:1 - 6:6)
 Message: All exports in the declaration are only used as types. Use `export type`.
    5 | 
    6 | export { TypeNS };
-     | ~~~~~~~~~~~~~~~~~~
+     | ~~~~~~
    7 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-12 - 1]
-Diagnostic 1: typeOverValue (3:1 - 3:21)
+Diagnostic 1: typeOverValue (3:1 - 3:6)
 Message: All exports in the declaration are only used as types. Use `export type`.
    2 | type T = 1;
    3 | export { type T, T };
-     | ~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~
    4 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-13 - 1]
-Diagnostic 1: typeOverValue (3:1 - 3:42)
+Diagnostic 1: typeOverValue (3:1 - 3:6)
 Message: All exports in the declaration are only used as types. Use `export type`.
    2 | type T = 1;
    3 | export { type/* */T, type     /* */T, T };
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~
    4 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-14 - 1]
-Diagnostic 1: singleExportIsType (4:1 - 4:24)
+Diagnostic 1: singleExportIsType (4:18 - 4:18)
 Message: Type export T is not a value and should be exported using `export type`.
+Help: Try adding the `type` keyword: `type T`
    3 | const x = 1;
    4 | export { type T, T, x };
-     | ~~~~~~~~~~~~~~~~~~~~~~~~
+     |                  ~
    5 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-15 - 1]
-Diagnostic 1: singleExportIsType (4:1 - 4:16)
+Diagnostic 1: singleExportIsType (4:10 - 4:10)
 Message: Type export T is not a value and should be exported using `export type`.
+Help: Try adding the `type` keyword: `type T`
    3 | const x = 1;
    4 | export { T, x };
-     | ~~~~~~~~~~~~~~~~
+     |          ~
    5 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-16 - 1]
-Diagnostic 1: typeOverValue (3:1 - 3:21)
+Diagnostic 1: typeOverValue (3:1 - 3:6)
 Message: All exports in the declaration are only used as types. Use `export type`.
    2 | type T = 1;
    3 | export { type T, T };
-     | ~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~
    4 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-17 - 1]
-Diagnostic 1: multipleExportsAreTypes (2:1 - 7:35)
+Diagnostic 1: multipleExportsAreTypes
 Message: Type exports Type1 and Type2 as Foo are not values and should be exported using `export type`.
-   1 | 
+  Label: Type1 is a type export, try `type Type1` (3:3 - 3:7)
    2 | export {
-     | ~~~~~~~~
    3 |   Type1,
-     | ~~~~~~~~
+     |   ^^^^^ Type1 is a type export, try `type Type1`
    4 |   Type2 as Foo,
-     | ~~~~~~~~~~~~~~~
+  Label: Type2 as Foo is a type export, try `type Type2 as Foo` (4:3 - 4:14)
+   3 |   Type1,
+   4 |   Type2 as Foo,
+     |   ^^^^^^^^^^^^ Type2 as Foo is a type export, try `type Type2 as Foo`
    5 |   type value1 as BScope,
-     | ~~~~~~~~~~~~~~~~~~~~~~~~
-   6 |   value2 as CScope,
-     | ~~~~~~~~~~~~~~~~~~~
-   7 | } from './consistent-type-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   8 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-18 - 1]
-Diagnostic 1: multipleExportsAreTypes (2:1 - 7:35)
+Diagnostic 1: multipleExportsAreTypes
 Message: Type exports Type1 and Type2 as Foo are not values and should be exported using `export type`.
-   1 | 
+  Label: Type1 is a type export, try `type Type1` (3:3 - 3:7)
    2 | export {
-     | ~~~~~~~~
    3 |   Type1,
-     | ~~~~~~~~
+     |   ^^^^^ Type1 is a type export, try `type Type1`
    4 |   Type2 as Foo,
-     | ~~~~~~~~~~~~~~~
+  Label: Type2 as Foo is a type export, try `type Type2 as Foo` (4:3 - 4:14)
+   3 |   Type1,
+   4 |   Type2 as Foo,
+     |   ^^^^^^^^^^^^ Type2 as Foo is a type export, try `type Type2 as Foo`
    5 |   type value1 as BScope,
-     | ~~~~~~~~~~~~~~~~~~~~~~~~
-   6 |   value2 as CScope,
-     | ~~~~~~~~~~~~~~~~~~~
-   7 | } from './consistent-type-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   8 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-19 - 1]
-Diagnostic 1: typeOverValue (2:9 - 2:68)
+Diagnostic 1: typeOverValue (2:9 - 2:14)
 Message: All exports in the declaration are only used as types. Use `export type`.
    1 | 
    2 |         export * from './consistent-type-exports/type-only-exports';
-     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~
    3 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-20 - 1]
-Diagnostic 1: typeOverValue (2:25 - 5:63)
+Diagnostic 1: typeOverValue (2:25 - 2:30)
 Message: All exports in the declaration are only used as types. Use `export type`.
    1 | 
    2 |         /* comment 1 */ export
      |                         ~~~~~~
    3 |           /* comment 2 */ *
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   4 |             // comment 3
-     | ~~~~~~~~~~~~~~~~~~~~~~~~
-   5 |             from './consistent-type-exports/type-only-exports';
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   6 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-21 - 1]
-Diagnostic 1: typeOverValue (2:9 - 2:69)
+Diagnostic 1: typeOverValue (2:9 - 2:14)
 Message: All exports in the declaration are only used as types. Use `export type`.
    1 | 
    2 |         export * from './consistent-type-exports/type-only-reexport';
-     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~
    3 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-22 - 1]
-Diagnostic 1: typeOverValue (2:9 - 2:76)
+Diagnostic 1: typeOverValue (2:9 - 2:14)
 Message: All exports in the declaration are only used as types. Use `export type`.
    1 | 
    2 |         export * as foo from './consistent-type-exports/type-only-reexport';
-     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~
    3 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-23 - 1]
-Diagnostic 1: typeOverValue (4:9 - 4:23)
+Diagnostic 1: typeOverValue (4:9 - 4:14)
 Message: All exports in the declaration are only used as types. Use `export type`.
    3 |         type Foo = 1;
    4 |         export { Foo };
-     |         ~~~~~~~~~~~~~~~
+     |         ~~~~~~
    5 |       
 ---
 
 [TestConsistentTypeExportsRule/invalid-24 - 1]
-Diagnostic 1: typeOverValue (3:9 - 3:23)
+Diagnostic 1: typeOverValue (3:9 - 3:14)
 Message: All exports in the declaration are only used as types. Use `export type`.
    2 |         import { type NAME as Foo } from './consistent-type-exports';
    3 |         export { Foo };
-     |         ~~~~~~~~~~~~~~~
+     |         ~~~~~~
    4 |       
 ---

--- a/internal/rules/consistent_type_exports/consistent_type_exports.go
+++ b/internal/rules/consistent_type_exports/consistent_type_exports.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/typescript-eslint/tsgolint/internal/rule"
 	"github.com/typescript-eslint/tsgolint/internal/utils"
@@ -23,6 +24,7 @@ func buildSingleExportIsTypeMessage(exportName string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "singleExportIsType",
 		Description: "Type export " + exportName + " is not a value and should be exported using `export type`.",
+		Help:        "Try adding the `type` keyword: `type " + exportName + "`",
 	}
 }
 
@@ -114,6 +116,20 @@ func getExportSpecifierText(sourceFile *ast.SourceFile, specifierNode *ast.Node)
 	return localText + " as " + exportedText
 }
 
+func getExportKeywordRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	s := scanner.GetScannerForSourceFile(sourceFile, node.Pos())
+	for {
+		if s.Token() == ast.KindExportKeyword {
+			return s.TokenRange()
+		}
+		if s.Token() == ast.KindEndOfFile || s.TokenRange().Pos() >= node.End() {
+			break
+		}
+		s.Scan()
+	}
+	return utils.TrimNodeTextRange(sourceFile, node)
+}
+
 func joinWordList(words []string) string {
 	switch len(words) {
 	case 0:
@@ -175,7 +191,11 @@ var ConsistentTypeExportsRule = rule.Rule{
 				return
 			}
 
-			ctx.ReportNodeWithFixes(node, buildTypeOverValueMessage(), func() []rule.RuleFix {
+			exportKeywordRange := getExportKeywordRange(ctx.SourceFile, node)
+			ctx.ReportDiagnosticWithFixes(rule.RuleDiagnostic{
+				Range:   exportKeywordRange,
+				Message: buildTypeOverValueMessage(),
+			}, func() []rule.RuleFix {
 				s := scanner.GetScannerForSourceFile(ctx.SourceFile, node.Pos())
 				for {
 					if s.Token() == ast.KindAsteriskToken {
@@ -249,8 +269,13 @@ var ConsistentTypeExportsRule = rule.Rule{
 				return
 			}
 
+			exportKeywordRange := getExportKeywordRange(ctx.SourceFile, report.node)
+
 			if len(report.valueTexts) == 0 {
-				ctx.ReportNodeWithFixes(report.node, buildTypeOverValueMessage(), func() []rule.RuleFix {
+				ctx.ReportDiagnosticWithFixes(rule.RuleDiagnostic{
+					Range:   exportKeywordRange,
+					Message: buildTypeOverValueMessage(),
+				}, func() []rule.RuleFix {
 					return []rule.RuleFix{
 						rule.RuleFixReplace(
 							ctx.SourceFile,
@@ -262,12 +287,28 @@ var ConsistentTypeExportsRule = rule.Rule{
 				return
 			}
 
-			msg := buildMultipleExportsAreTypesMessage(joinWordList(report.typeBasedNames))
+			var msg rule.RuleMessage
+			var labeledRanges []rule.RuleLabeledRange
+			var primaryRange core.TextRange
 			if len(report.typeBasedNames) == 1 {
 				msg = buildSingleExportIsTypeMessage(report.typeBasedNames[0])
+				primaryRange = utils.TrimNodeTextRange(ctx.SourceFile, report.typeBasedNodes[0])
+			} else {
+				msg = buildMultipleExportsAreTypesMessage(joinWordList(report.typeBasedNames))
+				labeledRanges = make([]rule.RuleLabeledRange, 0, len(report.typeBasedNodes))
+				for i, specifierNode := range report.typeBasedNodes {
+					labeledRanges = append(labeledRanges, rule.RuleLabeledRange{
+						Label: report.typeBasedNames[i] + " is a type export, try `type " + report.typeBasedNames[i] + "`",
+						Range: utils.TrimNodeTextRange(ctx.SourceFile, specifierNode),
+					})
+				}
 			}
 
-			ctx.ReportNodeWithFixes(report.node, msg, func() []rule.RuleFix {
+			ctx.ReportDiagnosticWithFixes(rule.RuleDiagnostic{
+				Range:         primaryRange,
+				Message:       msg,
+				LabeledRanges: labeledRanges,
+			}, func() []rule.RuleFix {
 				if opts.FixMixedExportsWithInlineTypeSpecifier {
 					fixes := make([]rule.RuleFix, 0, len(report.typeBasedNodes))
 					for _, specifierNode := range report.typeBasedNodes {

--- a/internal/rules/consistent_type_exports/consistent_type_exports_test.go
+++ b/internal/rules/consistent_type_exports/consistent_type_exports_test.go
@@ -133,7 +133,7 @@ export { A };
 				Code: `export { Type1, value1 } from './consistent-type-exports';`,
 				Output: []string{`export type { Type1 } from './consistent-type-exports';
 export { value1 } from './consistent-type-exports';`},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`, Line: 1, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`}},
 			},
 			{
 				Code: `
@@ -143,7 +143,7 @@ export { Type1, value1, value2 } from './consistent-type-exports';
 export type { Type1 } from './consistent-type-exports';
 export { value1, value2 } from './consistent-type-exports';
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`, Line: 2, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`}},
 			},
 			{
 				Code: `
@@ -153,7 +153,7 @@ export { Type1, value1, Type2, value2 } from './consistent-type-exports';
 export type { Type1, Type2 } from './consistent-type-exports';
 export { value1, value2 } from './consistent-type-exports';
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `multipleExportsAreTypes`, Line: 2, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `multipleExportsAreTypes`}},
 			},
 			{
 				Code:   `export { Type2 as Foo } from './consistent-type-exports';`,
@@ -168,7 +168,7 @@ export { Type2 as Foo, value1 } from './consistent-type-exports';
 export type { Type2 as Foo } from './consistent-type-exports';
 export { value1 } from './consistent-type-exports';
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`, Line: 2, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`}},
 			},
 			{
 				Code: `
@@ -182,7 +182,7 @@ export {
 export type { Type2 as Foo } from './consistent-type-exports';
 export { value1 as BScope, value2 as CScope } from './consistent-type-exports';
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`, Line: 2, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`}},
 			},
 			{
 				Code: `
@@ -205,7 +205,7 @@ import { value2, Type2 } from './consistent-type-exports';
 export type { Type2 };
 export { value2 };
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`, Line: 3, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`}},
 			},
 			{
 				Code: `
@@ -229,7 +229,7 @@ namespace TypeNS {
 export type { Alias, IFace };
 export { TypeNS };
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `multipleExportsAreTypes`, Line: 9, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `multipleExportsAreTypes`}},
 			},
 			{
 				Code: `
@@ -282,7 +282,7 @@ const x = 1;
 export type { T, T };
 export { x };
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`, Line: 4, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`}},
 			},
 			{
 				Code: `
@@ -296,7 +296,7 @@ type T = 1;
 const x = 1;
 export { type T, x };
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`, Line: 4, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `singleExportIsType`}},
 			},
 			{
 				Code: `
@@ -324,7 +324,7 @@ export {
 export type { Type1, Type2 as Foo, value1 as BScope } from './consistent-type-exports';
 export { value2 as CScope } from './consistent-type-exports';
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `multipleExportsAreTypes`, Line: 2, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `multipleExportsAreTypes`}},
 			},
 			{
 				Code: `
@@ -344,7 +344,7 @@ export {
   value2 as CScope,
 } from './consistent-type-exports';
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `multipleExportsAreTypes`, Line: 2, Column: 1}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `multipleExportsAreTypes`}},
 			},
 			{
 				Code: `
@@ -353,7 +353,7 @@ export {
 				Output: []string{`
         export type * from './consistent-type-exports/type-only-exports';
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 2, Column: 9, EndLine: 2, EndColumn: 69}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 2, Column: 9, EndLine: 2, EndColumn: 15}},
 			},
 			{
 				Code: `
@@ -368,7 +368,7 @@ export {
             // comment 3
             from './consistent-type-exports/type-only-exports';
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 2, Column: 25, EndLine: 5, EndColumn: 64}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 2, Column: 25, EndLine: 2, EndColumn: 31}},
 			},
 			{
 				Code: `
@@ -377,7 +377,7 @@ export {
 				Output: []string{`
         export type * from './consistent-type-exports/type-only-reexport';
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 2, Column: 9, EndLine: 2, EndColumn: 70}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 2, Column: 9, EndLine: 2, EndColumn: 15}},
 			},
 			{
 				Code: `
@@ -386,7 +386,7 @@ export {
 				Output: []string{`
         export type * as foo from './consistent-type-exports/type-only-reexport';
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 2, Column: 9, EndLine: 2, EndColumn: 77}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 2, Column: 9, EndLine: 2, EndColumn: 15}},
 			},
 			{
 				Code: `
@@ -399,7 +399,7 @@ export {
         type Foo = 1;
         export type { Foo };
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 4, Column: 9, EndLine: 4, EndColumn: 24}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 4, Column: 9, EndLine: 4, EndColumn: 15}},
 			},
 			{
 				Code: `
@@ -410,7 +410,7 @@ export {
         import { type NAME as Foo } from './consistent-type-exports';
         export type { Foo };
       `},
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 3, Column: 9, EndLine: 3, EndColumn: 24}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: `typeOverValue`, Line: 3, Column: 9, EndLine: 3, EndColumn: 15}},
 			},
 		})
 }


### PR DESCRIPTION
Moves the primary range for the diagnostic to point at the `export` keyword when `export type` should be used, and otherwise point to the individual types themselves. This makes it clearer where the specific issue lies, rather than highlighting the entire export.