### PR TITLE
fix(no-meaningless-void-operator): align with typescript-eslint union handling

### DIFF
--- a/internal/rule_tester/__snapshots__/no-meaningless-void-operator.snap
+++ b/internal/rule_tester/__snapshots__/no-meaningless-void-operator.snap
@@ -24,3 +24,12 @@ Message: void operator shouldn't be used on never; it should convey that a retur
    4 | }
   Suggestion 1: [removeVoid] Remove 'void'
 ---
+
+[TestNoMeaninglessVoidOperatorRule/invalid-3 - 1]
+Diagnostic 1: meaninglessVoidOperator (3:1 - 3:12)
+Message: void operator shouldn't be used on void | undefined; it should convey that a return value is being ignored
+   2 | const foo = (() => {}) as (() => void) | undefined;
+   3 | void foo?.();
+     | ~~~~~~~~~~~~
+   4 |       
+---

--- a/internal/rules/no_meaningless_void_operator/no_meaningless_void_operator.go
+++ b/internal/rules/no_meaningless_void_operator/no_meaningless_void_operator.go
@@ -32,19 +32,22 @@ var NoMeaninglessVoidOperatorRule = rule.Rule{
 				arg := node.AsVoidExpression().Expression
 				argType := ctx.TypeChecker.GetTypeAtLocation(arg)
 
-				mask := checker.TypeFlagsVoidLike | checker.TypeFlagsNever
+				unionParts := utils.UnionTypeParts(argType)
 
-				for _, t := range utils.UnionTypeParts(argType) {
-					mask &= checker.Type_flags(t)
-				}
+				isAlwaysVoidLike := utils.Every(unionParts, func(t *checker.Type) bool {
+					return utils.IsTypeFlagSet(t, checker.TypeFlagsVoidLike)
+				})
+				isAlwaysVoidLikeOrNever := utils.Every(unionParts, func(t *checker.Type) bool {
+					return utils.IsTypeFlagSet(t, checker.TypeFlagsVoidLike|checker.TypeFlagsNever)
+				})
 
 				fixRemoveVoidKeyword := func() rule.RuleFix {
 					return rule.RuleFixRemoveRange(utils.TrimNodeTextRange(ctx.SourceFile, node).WithEnd(arg.Pos()))
 				}
 
-				if mask&checker.TypeFlagsVoidLike != 0 {
+				if isAlwaysVoidLike {
 					ctx.ReportNodeWithFixes(node, buildMeaninglessVoidOperatorMessage(ctx.TypeChecker.TypeToString(argType)), func() []rule.RuleFix { return []rule.RuleFix{fixRemoveVoidKeyword()} })
-				} else if opts.CheckNever && mask&checker.TypeFlagsNever != 0 {
+				} else if opts.CheckNever && isAlwaysVoidLikeOrNever {
 					ctx.ReportNodeWithSuggestions(node, buildMeaninglessVoidOperatorMessage(ctx.TypeChecker.TypeToString(argType)), func() []rule.RuleSuggestion {
 						return []rule.RuleSuggestion{{
 							Message:  buildRemoveVoidMessage(),

--- a/internal/rules/no_meaningless_void_operator/no_meaningless_void_operator_test.go
+++ b/internal/rules/no_meaningless_void_operator/no_meaningless_void_operator_test.go
@@ -82,5 +82,23 @@ function bar(x: never) {
 				},
 			},
 		},
+		{
+			Code: `
+const foo = (() => {}) as (() => void) | undefined;
+void foo?.();
+      `,
+			Output: []string{`
+const foo = (() => {}) as (() => void) | undefined;
+ foo?.();
+      `,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "meaninglessVoidOperator",
+					Line:      3,
+					Column:    1,
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/21373