### PR TITLE
fix(no-deprecated): avoid false positive on array destructuring bindings

### DIFF
--- a/internal/rules/no_deprecated/no_deprecated.go
+++ b/internal/rules/no_deprecated/no_deprecated.go
@@ -504,6 +504,12 @@ var NoDeprecatedRule = rule.Rule{
 			}
 
 			switch parent.Kind {
+			case ast.KindBindingElement:
+				// Array binding elements only declare locals. Object binding patterns are
+				// handled separately because they also represent property reads.
+				return parent.Parent != nil &&
+					parent.Parent.Kind == ast.KindArrayBindingPattern &&
+					parent.Name() == node
 			case ast.KindClassExpression:
 				fallthrough
 			case ast.KindVariableDeclaration:

--- a/internal/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/rules/no_deprecated/no_deprecated_test.go
@@ -508,6 +508,10 @@ exists('/foo');
 	}
 }
 	`},
+		{Code: `const DISALLOWED_CATEGORY_ITEM_REGEXP: RegExp = /regexp/;
+			const content = "";
+			const result = [...content.matchAll(DISALLOWED_CATEGORY_ITEM_REGEXP)].map(([, term, description, name, link]) => ({ link, }));`,
+		},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Tsx: true,


### PR DESCRIPTION
fixes #889