### PR TITLE
revert(no-unnecessary-type-arguments): drop inference reporting

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -1395,30 +1395,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     ],
     "kind": 0,
     "message": {
-      "description": "This value can be trivially inferred for this type parameter, so it can be omitted.",
-      "id": "canBeInferred",
-    },
-    "range": {
-      "end": 213,
-      "pos": 207,
-    },
-    "rule": "no-unnecessary-type-arguments",
-  },
-  {
-    "file_path": "fixtures/basic/rules/no-unnecessary-type-arguments/index.ts",
-    "fixes": [
-      {
-        "range": {
-          "end": 214,
-          "pos": 206,
-        },
-        "text": "",
-      },
-    ],
-    "kind": 0,
-    "message": {
       "description": "This is the default value for this type parameter, so it can be omitted.",
-      "id": "isDefaultParameterValue",
+      "id": "unnecessaryTypeParameter",
     },
     "range": {
       "end": 213,

--- a/internal/rule_tester/__snapshots__/no-unnecessary-type-arguments.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-type-arguments.snap
@@ -1,6 +1,6 @@
 
 [TestNoUnnecessaryTypeArguments/invalid-0 - 1]
-Diagnostic 1: isDefaultParameterValue (3:3 - 3:8)
+Diagnostic 1: unnecessaryTypeParameter (3:3 - 3:8)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | function f<T = number>() {}
    3 | f<number>();
@@ -9,156 +9,7 @@ Message: This is the default value for this type parameter, so it can be omitted
 ---
 
 [TestNoUnnecessaryTypeArguments/invalid-1 - 1]
-Diagnostic 1: canBeInferred (3:3 - 3:8)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   2 | function f<T>(x: T) {}
-   3 | f<number>(10);
-     |   ~~~~~~
-   4 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-2 - 1]
-Diagnostic 1: canBeInferred (4:3 - 4:8)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   3 | declare const x: number;
-   4 | f<number>(x);
-     |   ~~~~~~
-   5 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-3 - 1]
-Diagnostic 1: canBeInferred (4:3 - 4:5)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   3 | declare const x: any;
-   4 | f<any>(x);
-     |   ~~~
-   5 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-4 - 1]
-Diagnostic 1: canBeInferred (4:3 - 4:4)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   3 | declare const x: {};
-   4 | f<{}>(x);
-     |   ~~
-   5 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-5 - 1]
-Diagnostic 1: canBeInferred (4:3 - 4:23)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   3 | declare const x: Record<string, never>;
-   4 | f<Record<string, never>>(x);
-     |   ~~~~~~~~~~~~~~~~~~~~~
-   5 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-6 - 1]
-Diagnostic 1: canBeInferred (5:3 - 5:3)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   4 | declare const x: F;
-   5 | f<F>(x);
-     |   ~
-   6 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-7 - 1]
-Diagnostic 1: canBeInferred (4:3 - 4:8)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   3 | declare function y(): number;
-   4 | f<number>(y());
-     |   ~~~~~~
-   5 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-8 - 1]
-Diagnostic 1: canBeInferred (7:3 - 7:3)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   6 | function f<T>(x: T) {}
-   7 | f<E>(E.A);
-     |   ~
-   8 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-9 - 1]
-Diagnostic 1: canBeInferred (3:3 - 3:8)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   2 | function f<T = number>(x: T) {}
-   3 | f<number>(10);
-     |   ~~~~~~
-   4 |       
-
-Diagnostic 2: isDefaultParameterValue (3:3 - 3:8)
-Message: This is the default value for this type parameter, so it can be omitted.
-   2 | function f<T = number>(x: T) {}
-   3 | f<number>(10);
-     |   ~~~~~~
-   4 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-10 - 1]
-Diagnostic 1: canBeInferred (3:3 - 3:8)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   2 | function f<T extends number>(x: T) {}
-   3 | f<number>(10);
-     |   ~~~~~~
-   4 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-11 - 1]
-Diagnostic 1: canBeInferred (3:3 - 3:8)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   2 | function f<T extends number | string>(x: T) {}
-   3 | f<number>(10);
-     |   ~~~~~~
-   4 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-12 - 1]
-Diagnostic 1: canBeInferred (5:21 - 5:26)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   4 |   <Inner,>(inner: Inner) => {};
-   5 | curried<number>(10)<number>(10);
-     |                     ~~~~~~
-   6 |       
-
-Diagnostic 2: canBeInferred (5:9 - 5:14)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   4 |   <Inner,>(inner: Inner) => {};
-   5 | curried<number>(10)<number>(10);
-     |         ~~~~~~
-   6 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-13 - 1]
-Diagnostic 1: canBeInferred (4:3 - 4:8)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   3 | declare function f<T>(): [T | undefined, (x: T | undefined) => void];
-   4 | f<number>(10);
-     |   ~~~~~~
-   5 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-14 - 1]
-Diagnostic 1: canBeInferred (3:3 - 3:8)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   2 | function f<T>(x: T) {}
-   3 | f<number>(10, 10);
-     |   ~~~~~~
-   4 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-15 - 1]
-Diagnostic 1: canBeInferred (3:3 - 3:8)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   2 | function f<T>(x: T, y: number) {}
-   3 | f<number>(10, 10);
-     |   ~~~~~~
-   4 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-16 - 1]
-Diagnostic 1: isDefaultParameterValue (3:11 - 3:16)
+Diagnostic 1: unnecessaryTypeParameter (3:11 - 3:16)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | function g<T = number, U = string>() {}
    3 | g<string, string>();
@@ -166,17 +17,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-17 - 1]
-Diagnostic 1: canBeInferred (3:11 - 3:16)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   2 | function g<T, U>(x: T, y: U) {}
-   3 | g<number, number>(10, 10);
-     |           ~~~~~~
-   4 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-18 - 1]
-Diagnostic 1: isDefaultParameterValue (3:3 - 3:8)
+[TestNoUnnecessaryTypeArguments/invalid-2 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:3 - 3:8)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | function f<T = number>(templates: TemplateStringsArray, arg: T) {}
    3 | f<number>`${1}`;
@@ -184,8 +26,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-19 - 1]
-Diagnostic 1: isDefaultParameterValue (3:17 - 3:22)
+[TestNoUnnecessaryTypeArguments/invalid-3 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:17 - 3:22)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | class C<T = number> {}
    3 | function h(c: C<number>) {}
@@ -193,8 +35,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-20 - 1]
-Diagnostic 1: isDefaultParameterValue (3:7 - 3:12)
+[TestNoUnnecessaryTypeArguments/invalid-4 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:7 - 3:12)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | class C<T = number> {}
    3 | new C<number>();
@@ -202,8 +44,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-21 - 1]
-Diagnostic 1: isDefaultParameterValue (3:19 - 3:24)
+[TestNoUnnecessaryTypeArguments/invalid-5 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:19 - 3:24)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | class C<T = number> {}
    3 | class D extends C<number> {}
@@ -211,8 +53,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-22 - 1]
-Diagnostic 1: isDefaultParameterValue (3:25 - 3:30)
+[TestNoUnnecessaryTypeArguments/invalid-6 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:25 - 3:30)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | interface I<T = number> {}
    3 | class Impl implements I<number> {}
@@ -220,8 +62,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-23 - 1]
-Diagnostic 1: isDefaultParameterValue (3:21 - 3:26)
+[TestNoUnnecessaryTypeArguments/invalid-7 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:21 - 3:26)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | class Foo<T = number> {}
    3 | const foo = new Foo<number>();
@@ -229,17 +71,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-24 - 1]
-Diagnostic 1: canBeInferred (5:21 - 5:26)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   4 | }
-   5 | const foo = new Foo<number>(10);
-     |                     ~~~~~~
-   6 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-25 - 1]
-Diagnostic 1: isDefaultParameterValue (3:38 - 3:43)
+[TestNoUnnecessaryTypeArguments/invalid-8 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:38 - 3:43)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | interface Bar<T = string> {}
    3 | class Foo<T = number> implements Bar<string> {}
@@ -247,8 +80,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-26 - 1]
-Diagnostic 1: isDefaultParameterValue (3:35 - 3:40)
+[TestNoUnnecessaryTypeArguments/invalid-9 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:35 - 3:40)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | class Bar<T = string> {}
    3 | class Foo<T = number> extends Bar<string> {}
@@ -256,8 +89,17 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-28 - 1]
-Diagnostic 1: isDefaultParameterValue (4:12 - 4:19)
+[TestNoUnnecessaryTypeArguments/invalid-10 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:35 - 3:40)
+Message: This is the default value for this type parameter, so it can be omitted.
+   2 | class Bar<T = string> {}
+   3 | class Foo<T = number> extends Bar<string> {}
+     |                                   ~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeArguments/invalid-11 - 1]
+Diagnostic 1: unnecessaryTypeParameter (4:12 - 4:19)
 Message: This is the default value for this type parameter, so it can be omitted.
    3 | type T<E = DefaultE> = { box: E };
    4 | type G = T<DefaultE>;
@@ -265,8 +107,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    5 | declare module 'bar' {
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-29 - 1]
-Diagnostic 1: isDefaultParameterValue (3:12 - 3:30)
+[TestNoUnnecessaryTypeArguments/invalid-12 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:12 - 3:30)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | type A<T = Map<string, string>> = T;
    3 | type B = A<Map<string, string>>;
@@ -274,8 +116,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-30 - 1]
-Diagnostic 1: isDefaultParameterValue (4:12 - 4:12)
+[TestNoUnnecessaryTypeArguments/invalid-13 - 1]
+Diagnostic 1: unnecessaryTypeParameter (4:12 - 4:12)
 Message: This is the default value for this type parameter, so it can be omitted.
    3 | type B<T = A> = T;
    4 | type C = B<A>;
@@ -283,8 +125,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    5 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-31 - 1]
-Diagnostic 1: isDefaultParameterValue (4:12 - 4:30)
+[TestNoUnnecessaryTypeArguments/invalid-14 - 1]
+Diagnostic 1: unnecessaryTypeParameter (4:12 - 4:30)
 Message: This is the default value for this type parameter, so it can be omitted.
    3 | type B<T = A> = T;
    4 | type C = B<Map<string, string>>;
@@ -292,8 +134,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    5 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-32 - 1]
-Diagnostic 1: isDefaultParameterValue (5:12 - 5:12)
+[TestNoUnnecessaryTypeArguments/invalid-15 - 1]
+Diagnostic 1: unnecessaryTypeParameter (5:12 - 5:12)
 Message: This is the default value for this type parameter, so it can be omitted.
    4 | type C<T = A> = T;
    5 | type D = C<B>;
@@ -301,8 +143,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    6 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-33 - 1]
-Diagnostic 1: isDefaultParameterValue (7:12 - 7:12)
+[TestNoUnnecessaryTypeArguments/invalid-16 - 1]
+Diagnostic 1: unnecessaryTypeParameter (7:12 - 7:12)
 Message: This is the default value for this type parameter, so it can be omitted.
    6 | type E<T = B> = T;
    7 | type F = E<D>;
@@ -310,8 +152,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    8 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-34 - 1]
-Diagnostic 1: isDefaultParameterValue (6:23 - 6:28)
+[TestNoUnnecessaryTypeArguments/invalid-17 - 1]
+Diagnostic 1: unnecessaryTypeParameter (6:23 - 6:28)
 Message: This is the default value for this type parameter, so it can be omitted.
    5 | };
    6 | class Bar extends Foo<string> {}
@@ -319,8 +161,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    7 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-35 - 1]
-Diagnostic 1: isDefaultParameterValue (6:23 - 6:28)
+[TestNoUnnecessaryTypeArguments/invalid-18 - 1]
+Diagnostic 1: unnecessaryTypeParameter (6:23 - 6:28)
 Message: This is the default value for this type parameter, so it can be omitted.
    5 | interface Foo {}
    6 | class Bar extends Foo<string> {}
@@ -328,8 +170,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    7 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-36 - 1]
-Diagnostic 1: isDefaultParameterValue (4:26 - 4:31)
+[TestNoUnnecessaryTypeArguments/invalid-19 - 1]
+Diagnostic 1: unnecessaryTypeParameter (4:26 - 4:31)
 Message: This is the default value for this type parameter, so it can be omitted.
    3 | interface Foo<T = string> {}
    4 | class Bar implements Foo<string> {}
@@ -337,8 +179,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    5 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-37 - 1]
-Diagnostic 1: isDefaultParameterValue (6:23 - 6:28)
+[TestNoUnnecessaryTypeArguments/invalid-20 - 1]
+Diagnostic 1: unnecessaryTypeParameter (6:23 - 6:28)
 Message: This is the default value for this type parameter, so it can be omitted.
    5 | }
    6 | class Bar extends Foo<string> {}
@@ -346,8 +188,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    7 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-38 - 1]
-Diagnostic 1: isDefaultParameterValue (5:24 - 5:29)
+[TestNoUnnecessaryTypeArguments/invalid-21 - 1]
+Diagnostic 1: unnecessaryTypeParameter (5:24 - 5:29)
 Message: This is the default value for this type parameter, so it can be omitted.
    4 | }
    5 | const button = <Button<string>></Button>;
@@ -355,8 +197,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    6 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-39 - 1]
-Diagnostic 1: isDefaultParameterValue (5:24 - 5:29)
+[TestNoUnnecessaryTypeArguments/invalid-22 - 1]
+Diagnostic 1: unnecessaryTypeParameter (5:24 - 5:29)
 Message: This is the default value for this type parameter, so it can be omitted.
    4 | }
    5 | const button = <Button<string> />;
@@ -364,8 +206,17 @@ Message: This is the default value for this type parameter, so it can be omitted
    6 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-40 - 1]
-Diagnostic 1: isDefaultParameterValue (3:5 - 3:7)
+[TestNoUnnecessaryTypeArguments/invalid-23 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:3 - 3:8)
+Message: This is the default value for this type parameter, so it can be omitted.
+   2 | function f<T = number>(x: T) {}
+   3 | f<number>(10);
+     |   ~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeArguments/invalid-24 - 1]
+Diagnostic 1: unnecessaryTypeParameter (3:5 - 3:7)
 Message: This is the default value for this type parameter, so it can be omitted.
    2 | function foo<T = any>() {}
    3 | foo<any>();
@@ -373,8 +224,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    4 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-41 - 1]
-Diagnostic 1: isDefaultParameterValue (4:5 - 4:15)
+[TestNoUnnecessaryTypeArguments/invalid-25 - 1]
+Diagnostic 1: unnecessaryTypeParameter (4:5 - 4:15)
 Message: This is the default value for this type parameter, so it can be omitted.
    3 | function foo<T = Foo<string>>() {}
    4 | foo<Foo<number>>();
@@ -382,8 +233,8 @@ Message: This is the default value for this type parameter, so it can be omitted
    5 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-42 - 1]
-Diagnostic 1: isDefaultParameterValue (2:55 - 2:57)
+[TestNoUnnecessaryTypeArguments/invalid-26 - 1]
+Diagnostic 1: unnecessaryTypeParameter (2:55 - 2:57)
 Message: This is the default value for this type parameter, so it can be omitted.
    1 | 
    2 | declare type MessageEventHandler = ((ev: MessageEvent<any>) => any) | null;
@@ -391,29 +242,11 @@ Message: This is the default value for this type parameter, so it can be omitted
    3 |       
 ---
 
-[TestNoUnnecessaryTypeArguments/invalid-43 - 1]
-Diagnostic 1: isDefaultParameterValue (10:3 - 10:5)
+[TestNoUnnecessaryTypeArguments/invalid-27 - 1]
+Diagnostic 1: unnecessaryTypeParameter (10:3 - 10:5)
 Message: This is the default value for this type parameter, so it can be omitted.
    9 | function f<T = Foo>() {}
   10 | f<Bar>();
      |   ~~~
   11 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-44 - 1]
-Diagnostic 1: canBeInferred (3:52 - 3:62)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   2 | declare function useState<T>(initialState: T | (() => T)): [T, (value: T) => void];
-   3 | const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set());
-     |                                                    ~~~~~~~~~~~
-   4 |       
----
-
-[TestNoUnnecessaryTypeArguments/invalid-45 - 1]
-Diagnostic 1: canBeInferred (3:33 - 3:43)
-Message: This value can be trivially inferred for this type parameter, so it can be omitted.
-   2 | declare function useRef<T>(initialValue: T): { current: T };
-   3 | const activeIndexesRef = useRef<Set<number>>(new Set());
-     |                                 ~~~~~~~~~~~
-   4 |       
 ---

--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
@@ -11,16 +11,9 @@ import (
 	"github.com/typescript-eslint/tsgolint/internal/utils"
 )
 
-func buildCanBeInferredMessage() rule.RuleMessage {
+func buildUnnecessaryTypeParameterMessage() rule.RuleMessage {
 	return rule.RuleMessage{
-		Id:          "canBeInferred",
-		Description: "This value can be trivially inferred for this type parameter, so it can be omitted.",
-	}
-}
-
-func buildIsDefaultParameterValueMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "isDefaultParameterValue",
+		Id:          "unnecessaryTypeParameter",
 		Description: "This is the default value for this type parameter, so it can be omitted.",
 	}
 }
@@ -53,6 +46,35 @@ func areTypesEquivalent(typeChecker *checker.Checker, a *checker.Type, b *checke
 	}
 
 	return checker.Checker_isTypeAssignableTo(typeChecker, a, b) && checker.Checker_isTypeAssignableTo(typeChecker, b, a)
+}
+
+func resolveSymbol(typeChecker *checker.Checker, symbol *ast.Symbol) *ast.Symbol {
+	if symbol == nil || symbol.Flags&ast.SymbolFlagsAlias == 0 {
+		return symbol
+	}
+
+	resolved, found := typeChecker.ResolveAlias(symbol)
+	if !found {
+		return symbol
+	}
+
+	return resolved
+}
+
+func hasShadowedTypeReferenceName(typeChecker *checker.Checker, defaultType *ast.Node, typeArgument *ast.Node) bool {
+	if !ast.IsTypeReferenceNode(defaultType) || !ast.IsTypeReferenceNode(typeArgument) {
+		return false
+	}
+
+	defaultName := defaultType.AsTypeReferenceNode().TypeName
+	typeArgumentName := typeArgument.AsTypeReferenceNode().TypeName
+	if !ast.IsIdentifier(defaultName) || !ast.IsIdentifier(typeArgumentName) || defaultName.Text() != typeArgumentName.Text() {
+		return false
+	}
+
+	defaultSymbol := resolveSymbol(typeChecker, typeChecker.GetSymbolAtLocation(defaultName))
+	typeArgumentSymbol := resolveSymbol(typeChecker, typeChecker.GetSymbolAtLocation(typeArgumentName))
+	return defaultSymbol != nil && typeArgumentSymbol != nil && defaultSymbol != typeArgumentSymbol
 }
 
 var NoUnnecessaryTypeArgumentsRule = rule.Rule{
@@ -131,7 +153,7 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 			return nil
 		}
 
-		checkArgsAndParameters := func(arguments *ast.NodeList, parameters []*ast.Node, callOrNewExpr *ast.Node) {
+		checkArgsAndParameters := func(arguments *ast.NodeList, parameters []*ast.Node) {
 			if arguments == nil || parameters == nil || len(arguments.Nodes) == 0 || len(parameters) == 0 {
 				return
 			}
@@ -148,51 +170,12 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 
 			typeArgumentType := ctx.TypeChecker.GetTypeAtLocation(typeArgument)
 
-			if callOrNewExpr != nil {
-				signature := checker.Checker_getResolvedSignature(ctx.TypeChecker, callOrNewExpr, nil, checker.CheckModeNormal)
-				for argumentIndex, argument := range callOrNewExpr.Arguments() {
-					if signature == nil {
-						break
-					}
-
-					parameters := checker.Signature_parameters(signature)
-					if argumentIndex >= len(parameters) {
-						continue
-					}
-
-					parameter := parameters[argumentIndex]
-					if parameter == nil || parameter.ValueDeclaration == nil || !ast.IsParameterDeclaration(parameter.ValueDeclaration) {
-						continue
-					}
-
-					parameterDecl := parameter.ValueDeclaration.AsParameterDeclaration()
-					if parameterDecl.Type == nil {
-						continue
-					}
-
-					typeParameterType := ctx.TypeChecker.GetTypeAtLocation(typeParameter)
-					parameterTypeFromDeclaration := checker.Checker_getTypeFromTypeNode(ctx.TypeChecker, parameterDecl.Type)
-					if utils.IsTypeAnyType(parameterTypeFromDeclaration) || !checker.Checker_isTypeAssignableTo(ctx.TypeChecker, typeParameterType, parameterTypeFromDeclaration) {
-						continue
-					}
-
-					argumentType := checker.Checker_getBaseTypeOfLiteralType(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(argument))
-					if areTypesEquivalent(ctx.TypeChecker, typeArgumentType, argumentType) {
-						ctx.ReportNodeWithFixes(typeArgument, buildCanBeInferredMessage(), func() []rule.RuleFix {
-							var removeRange core.TextRange
-							if lastParamIndex == 0 {
-								removeRange = scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, arguments.End()).WithPos(arguments.Pos() - 1)
-							} else {
-								removeRange = typeArgument.Loc.WithPos(arguments.Nodes[lastParamIndex-1].End())
-							}
-							return []rule.RuleFix{rule.RuleFixRemoveRange(removeRange)}
-						})
-					}
-				}
-			}
-
 			defaultType := typeParameter.AsTypeParameterDeclaration().DefaultType
 			if defaultType == nil {
+				return
+			}
+
+			if hasShadowedTypeReferenceName(ctx.TypeChecker, defaultType, typeArgument) {
 				return
 			}
 
@@ -201,7 +184,7 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 				return
 			}
 
-			ctx.ReportNodeWithFixes(typeArgument, buildIsDefaultParameterValueMessage(), func() []rule.RuleFix {
+			ctx.ReportNodeWithFixes(typeArgument, buildUnnecessaryTypeParameterMessage(), func() []rule.RuleFix {
 				var removeRange core.TextRange
 				if lastParamIndex == 0 {
 					removeRange = scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, arguments.End()).WithPos(arguments.Pos() - 1)
@@ -215,32 +198,32 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 		return rule.RuleListeners{
 			ast.KindExpressionWithTypeArguments: func(node *ast.Node) {
 				expr := node.AsExpressionWithTypeArguments()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromType(node, expr.Expression), nil)
+				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromType(node, expr.Expression))
 			},
 			ast.KindTypeReference: func(node *ast.Node) {
 				expr := node.AsTypeReferenceNode()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromType(node, expr.TypeName), nil)
+				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromType(node, expr.TypeName))
 			},
 
 			ast.KindCallExpression: func(node *ast.Node) {
 				expr := node.AsCallExpression()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node), node)
+				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindNewExpression: func(node *ast.Node) {
 				expr := node.AsNewExpression()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node), node)
+				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindTaggedTemplateExpression: func(node *ast.Node) {
 				expr := node.AsTaggedTemplateExpression()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node), nil)
+				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindJsxOpeningElement: func(node *ast.Node) {
 				expr := node.AsJsxOpeningElement()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node), nil)
+				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindJsxSelfClosingElement: func(node *ast.Node) {
 				expr := node.AsJsxSelfClosingElement()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node), nil)
+				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 		}
 	},

--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
@@ -25,6 +25,177 @@ function f<T = number>() {}
 f<string>();
     `},
 		{Code: `
+declare const f: (<T = number>() => void) | null;
+f?.();
+    `},
+		{Code: `
+declare const f: (<T = number>() => void) | null;
+f?.<string>();
+    `},
+		{Code: `
+declare const f: any;
+f();
+    `},
+		{Code: `
+declare const f: any;
+f<string>();
+    `},
+		{Code: `
+declare const f: unknown;
+f();
+    `},
+		{Code: `
+declare const f: unknown;
+f<string>();
+    `},
+		{Code: `
+function g<T = number, U = string>() {}
+g<number, number>();
+    `},
+		{Code: `
+declare const g: any;
+g<string, string>();
+    `},
+		{Code: `
+declare const g: unknown;
+g<string, string>();
+    `},
+		{Code: `
+declare const f: unknown;
+f<string>` + "`" + `` + "`" + `;
+    `},
+		{Code: `
+function f<T = number>(template: TemplateStringsArray) {}
+f<string>` + "`" + `` + "`" + `;
+    `},
+		{Code: `
+class C<T = number> {}
+new C<string>();
+    `},
+		{Code: `
+declare const C: any;
+new C<string>();
+    `},
+		{Code: `
+declare const C: unknown;
+new C<string>();
+    `},
+		{Code: `
+class C<T = number> {}
+class D extends C<string> {}
+    `},
+		{Code: `
+declare const C: any;
+class D extends C<string> {}
+    `},
+		{Code: `
+declare const C: unknown;
+class D extends C<string> {}
+    `},
+		{Code: `
+interface I<T = number> {}
+class Impl implements I<string> {}
+    `},
+		{Code: `
+class C<TC = number> {}
+class D<TD = number> extends C {}
+    `},
+		{Code: `
+declare const C: any;
+class D<TD = number> extends C {}
+    `},
+		{Code: `
+declare const C: unknown;
+class D<TD = number> extends C {}
+    `},
+		{Code: "let a: A<number>;"},
+		{Code: `
+class Foo<T> {}
+const foo = new Foo<number>();
+    `},
+		{Code: "type Foo<T> = import('foo').Foo<T>;"},
+		{Code: `
+class Bar<T = number> {}
+class Foo<T = number> extends Bar<T> {}
+    `},
+		{Code: `
+interface Bar<T = number> {}
+class Foo<T = number> implements Bar<T> {}
+    `},
+		{Code: `
+class Bar<T = number> {}
+class Foo<T = number> extends Bar<string> {}
+    `},
+		{Code: `
+interface Bar<T = number> {}
+class Foo<T = number> implements Bar<string> {}
+    `},
+		{Code: `
+import { F } from './missing';
+function bar<T = F>() {}
+bar<F<number>>();
+    `},
+		{
+			Code: `
+type A<T = Element> = T;
+type B = A<HTMLInputElement>;
+      `,
+			TSConfig: "tsconfig.lib-dom.json",
+		},
+		{Code: `
+type A<T = Map<string, string>> = T;
+type B = A<Map<string, number>>;
+    `},
+		{Code: `
+type A = Map<string, string>;
+type B<T = A> = T;
+type C2 = B<Map<string, number>>;
+    `},
+		{Code: `
+interface Foo<T = string> {}
+declare var Foo: {
+  new <T>(type: T): any;
+};
+class Bar extends Foo<string> {}
+    `},
+		{Code: `
+interface Foo<T = string> {}
+class Foo<T> {}
+class Bar extends Foo<string> {}
+    `},
+		{Code: `
+class Foo<T = string> {}
+interface Foo<T> {}
+class Bar implements Foo<string> {}
+    `},
+		{Code: `
+class Foo<T> {}
+namespace Foo {
+  export class Bar {}
+}
+class Bar extends Foo<string> {}
+    `},
+		{
+			Code: `
+function Button<T>() {
+  return <div></div>;
+}
+const button = <Button<string>></Button>;
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+function Button<T>() {
+  return <div></div>;
+}
+const button = <Button<string> />;
+      `,
+			Tsx: true,
+		},
+
+		// OXC-specific cases not present in upstream.
+		{Code: `
 function f<T>(x: T) {}
 f(10);
     `},
@@ -110,165 +281,14 @@ function f<T>(x: T) {}
 f<boolean | null>(true);
     `},
 		{Code: `
-declare const f: (<T = number>() => void) | null;
-f?.();
-    `},
-		{Code: `
-declare const f: (<T = number>() => void) | null;
-f?.<string>();
-    `},
-		{Code: `
-declare const f: any;
-f();
-    `},
-		{Code: `
-declare const f: any;
-f<string>();
-    `},
-		{Code: `
-declare const f: unknown;
-f();
-    `},
-		{Code: `
-declare const f: unknown;
-f<string>();
-    `},
-		{Code: `
-function g<T = number, U = string>() {}
-g<number, number>();
-    `},
-		{Code: `
-declare const g: any;
-g<string, string>();
-    `},
-		{Code: `
-declare const g: unknown;
-g<string, string>();
-    `},
-		{Code: `
-declare const f: unknown;
-f<string>` + "`" + `` + "`" + `;
-    `},
-		{Code: `
-function f<T = number>(template: TemplateStringsArray) {}
-f<string>` + "`" + `` + "`" + `;
-    `},
-		{Code: `
-class C<T = number> {}
-new C<string>();
-    `},
-		{Code: `
 class C<T> {}
 new C<string>();
-    `},
-		{Code: `
-declare const C: any;
-new C<string>();
-    `},
-		{Code: `
-declare const C: unknown;
-new C<string>();
-    `},
-		{Code: `
-class C<T = number> {}
-class D extends C<string> {}
-    `},
-		{Code: `
-declare const C: any;
-class D extends C<string> {}
-    `},
-		{Code: `
-declare const C: unknown;
-class D extends C<string> {}
-    `},
-		{Code: `
-interface I<T = number> {}
-class Impl implements I<string> {}
-    `},
-		{Code: `
-class C<TC = number> {}
-class D<TD = number> extends C {}
-    `},
-		{Code: `
-declare const C: any;
-class D<TD = number> extends C {}
-    `},
-		{Code: `
-declare const C: unknown;
-class D<TD = number> extends C {}
-    `},
-		{Code: "let a: A<number>;"},
-		{Code: `
-class Foo<T> {}
-const foo = new Foo<number>();
     `},
 		{Code: `
 class Foo<T> {
   constructor<T>(x: T) {}
 }
 const foo = new Foo(10);
-    `},
-		{Code: "type Foo<T> = import('foo').Foo<T>;"},
-		{Code: `
-class Bar<T = number> {}
-class Foo<T = number> extends Bar<T> {}
-    `},
-		{Code: `
-interface Bar<T = number> {}
-class Foo<T = number> implements Bar<T> {}
-    `},
-		{Code: `
-class Bar<T = number> {}
-class Foo<T = number> extends Bar<string> {}
-    `},
-		{Code: `
-interface Bar<T = number> {}
-class Foo<T = number> implements Bar<string> {}
-    `},
-		{Code: `
-import { F } from './missing';
-function bar<T = F>() {}
-bar<F<number>>();
-    `},
-		{
-			Code: `
-type A<T = Element> = T;
-type B = A<HTMLInputElement>;
-      `,
-			TSConfig: "tsconfig.lib-dom.json",
-		},
-		{Code: `
-type A<T = Map<string, string>> = T;
-type B = A<Map<string, number>>;
-    `},
-		{Code: `
-type A = Map<string, string>;
-type B<T = A> = T;
-type C2 = B<Map<string, number>>;
-    `},
-		{Code: `
-interface Foo<T = string> {}
-declare var Foo: {
-  new <T>(type: T): any;
-};
-class Bar extends Foo<string> {}
-    `},
-		{Code: `
-interface Foo<T = string> {}
-class Foo<T> {}
-class Bar extends Foo<string> {}
-    `},
-		{Code: `
-class Foo<T = string> {}
-interface Foo<T> {}
-class Bar implements Foo<string> {}
-    `},
-		{Code: `
-class Foo<T> {}
-namespace Foo {
-  export class Bar {}
-}
-class Bar extends Foo<string> {}
     `},
 		// Ignore invalid type arguments.
 		{Code: `
@@ -284,26 +304,6 @@ interface Bar {
 }
 let foo = new Foo<Bar>(0, 0, 0, { val: 0 });
     `},
-		{
-			Code: `
-function Button<T>() {
-  return <div></div>;
-}
-const button = <Button<string>></Button>;
-      `,
-			Tsx: true,
-		},
-		{
-			Code: `
-function Button<T>() {
-  return <div></div>;
-}
-const button = <Button<string> />;
-      `,
-			Tsx: true,
-		},
-
-		// Local regressions not present in upstream.
 		{Code: `
 function f<T = string>() {}
 f<any>();
@@ -311,6 +311,15 @@ f<any>();
 		{Code: `
 function f<T = any>() {}
 f<string>();
+    `},
+		// Inference reporting was reverted upstream and remains disabled locally.
+		{Code: `
+declare function useState<T>(initialState: T | (() => T)): [T, (value: T) => void];
+const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set());
+    `},
+		{Code: `
+declare function useRef<T>(initialValue: T): { current: T };
+const activeIndexesRef = useRef<Set<number>>(new Set());
     `},
 		// https://github.com/oxc-project/oxc/issues/13164
 		{Code: `
@@ -350,6 +359,21 @@ interface Wrapper {
   value: LocaleData<Data2>
 }
     `},
+		{Code: `
+
+type SessionDataT = Record<string, any>
+type SessionData<T extends SessionDataT = SessionDataT> = Partial<T>;
+declare function useSession<T extends SessionData = SessionData>(): any;
+
+
+export function scoped() {
+  interface SessionData {
+    userId?: string;
+  }
+
+  return useSession<SessionData>()
+}
+    `},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `
@@ -364,282 +388,7 @@ f();
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Column:    3,
-					MessageId: "isDefaultParameterValue",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T>(x: T) {}
-f<number>(10);
-      `,
-			Output: []string{`
-function f<T>(x: T) {}
-f(10);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T>(x: T) {}
-declare const x: number;
-f<number>(x);
-      `,
-			Output: []string{`
-function f<T>(x: T) {}
-declare const x: number;
-f(x);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T>(x: T) {}
-declare const x: any;
-f<any>(x);
-      `,
-			Output: []string{`
-function f<T>(x: T) {}
-declare const x: any;
-f(x);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T>(x: T) {}
-declare const x: {};
-f<{}>(x);
-      `,
-			Output: []string{`
-function f<T>(x: T) {}
-declare const x: {};
-f(x);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T>(x: T) {}
-declare const x: Record<string, never>;
-f<Record<string, never>>(x);
-      `,
-			Output: []string{`
-function f<T>(x: T) {}
-declare const x: Record<string, never>;
-f(x);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T>(x: T) {}
-interface F {}
-declare const x: F;
-f<F>(x);
-      `,
-			Output: []string{`
-function f<T>(x: T) {}
-interface F {}
-declare const x: F;
-f(x);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T>(x: T) {}
-declare function y(): number;
-f<number>(y());
-      `,
-			Output: []string{`
-function f<T>(x: T) {}
-declare function y(): number;
-f(y());
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-enum E {
-  A,
-  B,
-}
-function f<T>(x: T) {}
-f<E>(E.A);
-      `,
-			Output: []string{`
-enum E {
-  A,
-  B,
-}
-function f<T>(x: T) {}
-f(E.A);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T = number>(x: T) {}
-f<number>(10);
-      `,
-			Output: []string{`
-function f<T = number>(x: T) {}
-f(10);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-				{
-					MessageId: "isDefaultParameterValue",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T extends number>(x: T) {}
-f<number>(10);
-      `,
-			Output: []string{`
-function f<T extends number>(x: T) {}
-f(10);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T extends number | string>(x: T) {}
-f<number>(10);
-      `,
-			Output: []string{`
-function f<T extends number | string>(x: T) {}
-f(10);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-const curried =
-  <Outer,>(outer: Outer) =>
-  <Inner,>(inner: Inner) => {};
-curried<number>(10)<number>(10);
-      `,
-			Output: []string{`
-const curried =
-  <Outer,>(outer: Outer) =>
-  <Inner,>(inner: Inner) => {};
-curried(10)(10);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-declare function f<T>(x: T | (() => T)): [T, (x: T) => void];
-declare function f<T>(): [T | undefined, (x: T | undefined) => void];
-f<number>(10);
-      `,
-			Output: []string{`
-declare function f<T>(x: T | (() => T)): [T, (x: T) => void];
-declare function f<T>(): [T | undefined, (x: T | undefined) => void];
-f(10);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		// Ignore invalid arguments, check just ones we know the types of.
-		{
-			Code: `
-function f<T>(x: T) {}
-f<number>(10, 10);
-      `,
-			Output: []string{`
-function f<T>(x: T) {}
-f(10, 10);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-function f<T>(x: T, y: number) {}
-f<number>(10, 10);
-      `,
-			Output: []string{`
-function f<T>(x: T, y: number) {}
-f(10, 10);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -656,27 +405,7 @@ g<string>();
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Column:    11,
-					MessageId: "isDefaultParameterValue",
-				},
-			},
-		},
-		{
-			Code: `
-function g<T, U>(x: T, y: U) {}
-g<number, number>(10, 10);
-      `,
-			Output: []string{`
-function g<T, U>(x: T, y: U) {}
-g<number>(10, 10);
-      `,
-				`
-function g<T, U>(x: T, y: U) {}
-g(10, 10);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -693,7 +422,7 @@ f` + "`" + `${1}` + "`" + `;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Column:    3,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -709,7 +438,7 @@ function h(c: C) {}
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -725,7 +454,7 @@ new C();
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -741,7 +470,7 @@ class D extends C {}
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -757,7 +486,7 @@ class Impl implements I {}
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -773,27 +502,7 @@ const foo = new Foo();
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
-					MessageId: "isDefaultParameterValue",
-				},
-			},
-		},
-		{
-			Code: `
-class Foo<T> {
-  constructor(x: T) {}
-}
-const foo = new Foo<number>(10);
-      `,
-			Output: []string{`
-class Foo<T> {
-  constructor(x: T) {}
-}
-const foo = new Foo(10);
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "canBeInferred",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -809,7 +518,7 @@ class Foo<T = number> implements Bar {}
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -825,7 +534,7 @@ class Foo<T = number> extends Bar {}
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -847,7 +556,7 @@ bar();
 				{
 					Column:    5,
 					Line:      4,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -875,7 +584,7 @@ declare module 'bar' {
 				{
 					Column:    12,
 					Line:      4,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -892,7 +601,7 @@ type B = A;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      3,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -911,7 +620,7 @@ type C = B;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      4,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -930,7 +639,7 @@ type C = B;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      4,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -951,7 +660,7 @@ type D = C;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      5,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -976,7 +685,7 @@ type F = E;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      7,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -999,7 +708,7 @@ class Bar extends Foo {}
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      6,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -1022,7 +731,7 @@ class Bar extends Foo {}
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      6,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -1041,7 +750,7 @@ class Bar implements Foo {}
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      4,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -1064,7 +773,7 @@ class Bar extends Foo {}
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      6,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -1086,7 +795,7 @@ const button = <Button></Button>;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      5,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -1108,12 +817,28 @@ const button = <Button />;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      5,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
 
-		// Local regressions not present in upstream.
+		// OXC-specific cases not present in upstream.
+		{
+			Code: `
+function f<T = number>(x: T) {}
+f<number>(10);
+      `,
+			Output: []string{`
+function f<T = number>(x: T) {}
+f(10);
+      `,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryTypeParameter",
+				},
+			},
+		},
 		{
 			Code: `
 function foo<T = any>() {}
@@ -1127,7 +852,7 @@ foo();
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      3,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -1146,7 +871,7 @@ foo();
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      4,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -1161,7 +886,7 @@ declare type MessageEventHandler = ((ev: MessageEvent) => any) | null;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      2,
-					MessageId: "isDefaultParameterValue",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},
@@ -1192,41 +917,7 @@ f();
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      10,
-					MessageId: "isDefaultParameterValue",
-				},
-			},
-		},
-		{
-			Code: `
-declare function useState<T>(initialState: T | (() => T)): [T, (value: T) => void];
-const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set());
-      `,
-			Output: []string{`
-declare function useState<T>(initialState: T | (() => T)): [T, (value: T) => void];
-const [bookmarkedIds, setBookmarkedIds] = useState(new Set());
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					Line:      3,
-					MessageId: "canBeInferred",
-				},
-			},
-		},
-		{
-			Code: `
-declare function useRef<T>(initialValue: T): { current: T };
-const activeIndexesRef = useRef<Set<number>>(new Set());
-      `,
-			Output: []string{`
-declare function useRef<T>(initialValue: T): { current: T };
-const activeIndexesRef = useRef(new Set());
-      `,
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					Line:      3,
-					MessageId: "canBeInferred",
+					MessageId: "unnecessaryTypeParameter",
 				},
 			},
 		},


### PR DESCRIPTION
Align with typescript-eslint/typescript-eslint#12199 by reverting the #853 port of inferred-type reporting.

Keep the later default-type equivalence fix from #862.

Validation:
- go test ./internal/rules/no_unnecessary_type_arguments/...
- cd e2e && pnpm test --run snapshot.test.ts


fixes oxc-project/oxc#21464
fixes https://github.com/oxc-project/tsgolint/issues/875
fixes oxc-project/oxc#21096
fises oxc-project/oxc#20933