### PR TITLE
ci: add security analysis workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,12 +5,12 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
 
 permissions: {}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Security Analysis
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  security:
+    name: Security Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oxc-project/security-action@fbbd523b1e765ceb174cb819b92c453bb1da265e # v1.0.0

--- a/internal/rules/fixtures/repro.js
+++ b/internal/rules/fixtures/repro.js
@@ -1,0 +1,4 @@
+/** @type {string} */
+const s = "foo";
+
+const s2 = /** @type {string} */ (s);


### PR DESCRIPTION
## Summary
- add the canonical Security Analysis workflow using `oxc-project/security-action`
- replace legacy zizmor workflow files where present

## Testing
- Not run; workflow-only change.
