### PR TITLE
ci: make security analysis required-check friendly

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
-    paths:
-      - ".github/workflows/**"
   push:
     branches:
       - main
@@ -21,6 +19,6 @@ concurrency:
 jobs:
   security:
     name: Security Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: oxc-project/security-action@fbbd523b1e765ceb174cb819b92c453bb1da265e # v1.0.0


### PR DESCRIPTION
Updates the security workflow so the required check is always created for pull requests, while keeping the workflow-file path filter on pushes to main. Also switches the job to the ubuntu-slim runner for this lightweight security scan.

Validation:
- /tmp/zizmor-1.24.1/bin/zizmor --config /Users/boshen/github/oxc-project/security-action/zizmor.yml --strict-collection --show-audit-urls=always --min-severity=medium .
- git diff --check