### PR TITLE
fix: add warning for unsupported tsgolint CLI entrypoint

### DIFF
--- a/cmd/tsgolint/main.go
+++ b/cmd/tsgolint/main.go
@@ -368,7 +368,9 @@ func printDiagnostic(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOptions 
 	w.WriteString("  \x1b[2m╰────────────────────────────────\x1b[0m\n\n")
 }
 
-const usage = `✨ tsgolint - speedy TypeScript linter
+const unsupportedCliWarning = "Warning: the `tsgolint` CLI entrypoint is unsupported!\nUse Oxlint type-aware linting instead: https://oxc.rs/docs/guide/usage/linter/type-aware\n\n"
+
+const usage = unsupportedCliWarning + `✨ tsgolint - speedy TypeScript linter
 
 Usage:
     tsgolint [OPTIONS]
@@ -411,6 +413,8 @@ func runMain() int {
 		flag.Usage()
 		return 0
 	}
+
+	fmt.Fprintf(os.Stderr, unsupportedCliWarning)
 
 	enableVirtualTerminalProcessing()
 	timeBefore := time.Now()


### PR DESCRIPTION
this entrypoint isn't designed to be used - lets log a warning when it is.

demo:

![Screenshot 2026-04-22 at 20.58.23.png](https://app.graphite.com/user-attachments/assets/4a42322b-c8bf-4020-a271-ff9809e84615.png)