### PR TITLE
fix(no-useless-default-assignment): make default assignment removal a suggestion

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -2472,15 +2472,6 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   },
   {
     "file_path": "fixtures/basic/rules/no-useless-default-assignment/index.ts",
-    "fixes": [
-      {
-        "range": {
-          "end": 21,
-          "pos": 16,
-        },
-        "text": "",
-      },
-    ],
     "kind": 0,
     "labeled_ranges": [
       {
@@ -2508,6 +2499,23 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
       "pos": 19,
     },
     "rule": "no-useless-default-assignment",
+    "suggestions": [
+      {
+        "fixes": [
+          {
+            "range": {
+              "end": 21,
+              "pos": 16,
+            },
+            "text": "",
+          },
+        ],
+        "message": {
+          "description": "Remove the default assignment.",
+          "id": "removeDefaultAssignment",
+        },
+      },
+    ],
   },
   {
     "file_path": "fixtures/basic/rules/non-nullable-type-assertion-style/index.ts",

--- a/internal/rule_tester/__snapshots__/no-useless-default-assignment.snap
+++ b/internal/rule_tester/__snapshots__/no-useless-default-assignment.snap
@@ -17,6 +17,7 @@ Help: Remove the default assignment
    2 |         function Bar({ foo = '' }: { foo: string }) {
      |                        ^^^ property type `string` is not nullish
    3 |           return foo;
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-1 - 1]
@@ -37,6 +38,7 @@ Help: Remove the default assignment
    3 |           public method({ foo = '' }: { foo: string }) {
      |                           ^^^ property type `string` is not nullish
    4 |             return foo;
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-2 - 1]
@@ -57,6 +59,7 @@ Help: Remove the default assignment
    2 |         const { 'literal-key': literalKey = 'default' } = { 'literal-key': 'value' };
      |                                ^^^^^^^^^^ property type `"value"` is not nullish
    3 |       
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-3 - 1]
@@ -77,6 +80,7 @@ Help: Remove the default assignment
    2 |         [1, 2, 3].map((a = 42) => a + 1);
      |                        ^ parameter type `number` is not nullish
    3 |       
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-4 - 1]
@@ -97,6 +101,7 @@ Help: Remove the default assignment
    4 |         function getValue({ value = '' }: { value: string } = {}): string | undefined {
      |                             ^^^^^ property type `string` is not nullish
    5 |           return value;
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-5 - 1]
@@ -117,6 +122,7 @@ Help: Remove the default assignment
    2 |         function getValue([value = '']: [string]) {
      |                            ^^^^^ property type `string` is not nullish
    3 |           return value;
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-6 - 1]
@@ -137,6 +143,7 @@ Help: Remove the default assignment
    5 |           hello: { world = '' },
      |                    ^^^^^ property type `string` is not nullish
    6 |         } = x;
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-7 - 1]
@@ -157,6 +164,7 @@ Help: Remove the default assignment
    5 |           hello: [{ world = '' }],
      |                     ^^^^^ property type `string` is not nullish
    6 |         } = x;
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-8 - 1]
@@ -172,6 +180,7 @@ Help: Remove the default assignment
    7 |           foo: (b = false) => {},
      |                     ^^^^^ Default value
    8 |         };
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-9 - 1]
@@ -253,6 +262,7 @@ Help: Remove the default assignment
    2 |         function Bar({ foo = '' }: { foo: string }) {
      |                        ^^^ property type `string` is not nullish
    3 |           return foo;
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-16 - 1]
@@ -281,6 +291,7 @@ Help: Remove the default assignment
    2 |         const { a = 'baz' } = Math.random() < 0.5 ? { a: 'foo' } : { a: 'bar' };
      |                     ^^^^^ Default value
    3 |       
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-18 - 1]
@@ -296,6 +307,7 @@ Help: Remove the default assignment
    2 |         const { a = 'baz' } =
      |                     ^^^^^ Default value
    3 |           Math.random() < 0.5
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-19 - 1]
@@ -311,6 +323,7 @@ Help: Remove the default assignment
    2 |         const { a = 'baz' } = cond ? { ['a']: 'foo' } : { ['a']: 'bar' };
      |                     ^^^^^ Default value
    3 |       
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-20 - 1]
@@ -326,6 +339,7 @@ Help: Remove the default assignment
    2 |         const { a = 'baz' } = cond ? { a() {} } : { a: 'bar' };
      |                     ^^^^^ Default value
    3 |       
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---
 
 [TestNoUselessDefaultAssignmentRule/invalid-21 - 1]
@@ -341,18 +355,5 @@ Help: Remove the default assignment
    2 |         const { a = 'b' } = Math.random() < 0.5 ? { [`a`]: 'a' } : { a: 'b' };
      |                     ^^^ Default value
    3 |       
----
-
-[TestNoUselessDefaultAssignmentRule/invalid-22 - 1]
-Diagnostic 1: uselessDefaultAssignment (2:21 - 2:23)
-Message: Default value is useless because the property is not nullish. This default assignment will never be used.
-   1 | 
-   2 |         const { a = 'b' } = Math.random() < 0.5 ? { [`a`]: 'a' } : { a: 'b' };
-     |                     ~~~
-   3 |       
-  Label: Default value (2:21 - 2:23)
-   1 | 
-   2 |         const { a = 'b' } = Math.random() < 0.5 ? { [`a`]: 'a' } : { a: 'b' };
-     |                     ^^^ Default value
-   3 |       
+  Suggestion 1: [removeDefaultAssignment] Remove the default assignment.
 ---

--- a/internal/rules/no_useless_default_assignment/no_useless_default_assignment.go
+++ b/internal/rules/no_useless_default_assignment/no_useless_default_assignment.go
@@ -43,6 +43,13 @@ func buildUselessDefaultAssignmentWithTypeMessage(assignmentType string, typeTex
 	}
 }
 
+func buildRemoveDefaultAssignmentSuggestionMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "removeDefaultAssignment",
+		Description: "Remove the default assignment.",
+	}
+}
+
 func buildUselessUndefinedMessage(pluralAssignmentType string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "uselessUndefined",
@@ -365,11 +372,15 @@ var NoUselessDefaultAssignmentRule = rule.Rule{
 				}
 			}
 
-			ctx.ReportDiagnostic(rule.RuleDiagnostic{
+			ctx.ReportDiagnosticWithSuggestions(rule.RuleDiagnostic{
 				Range:         diagnosticRange,
 				Message:       message,
-				FixesPtr:      &fixes,
 				LabeledRanges: labeledRanges,
+			}, func() []rule.RuleSuggestion {
+				return []rule.RuleSuggestion{{
+					Message:  buildRemoveDefaultAssignmentSuggestionMessage(),
+					FixesArr: fixes,
+				}}
 			})
 		}
 

--- a/internal/rules/no_useless_default_assignment/no_useless_default_assignment_test.go
+++ b/internal/rules/no_useless_default_assignment/no_useless_default_assignment_test.go
@@ -201,127 +201,154 @@ func TestNoUselessDefaultAssignmentRule(t *testing.T) {
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: "\n        function Bar({ foo = '' }: { foo: string }) {\n          return foo;\n        }\n      ",
-			Output: []string{
-				"\n        function Bar({ foo }: { foo: string }) {\n          return foo;\n        }\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      2,
 					Column:    30,
 					EndColumn: 32,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        function Bar({ foo }: { foo: string }) {\n          return foo;\n        }\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        class C {\n          public method({ foo = '' }: { foo: string }) {\n            return foo;\n          }\n        }\n      ",
-			Output: []string{
-				"\n        class C {\n          public method({ foo }: { foo: string }) {\n            return foo;\n          }\n        }\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      3,
 					Column:    33,
 					EndColumn: 35,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        class C {\n          public method({ foo }: { foo: string }) {\n            return foo;\n          }\n        }\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        const { 'literal-key': literalKey = 'default' } = { 'literal-key': 'value' };\n      ",
-			Output: []string{
-				"\n        const { 'literal-key': literalKey } = { 'literal-key': 'value' };\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      2,
 					Column:    45,
 					EndColumn: 54,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        const { 'literal-key': literalKey } = { 'literal-key': 'value' };\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        [1, 2, 3].map((a = 42) => a + 1);\n      ",
-			Output: []string{
-				"\n        [1, 2, 3].map((a) => a + 1);\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      2,
 					Column:    28,
 					EndColumn: 30,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        [1, 2, 3].map((a) => a + 1);\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        function getValue(): undefined;\n        function getValue(box: { value: string }): string;\n        function getValue({ value = '' }: { value: string } = {}): string | undefined {\n          return value;\n        }\n      ",
-			Output: []string{
-				"\n        function getValue(): undefined;\n        function getValue(box: { value: string }): string;\n        function getValue({ value }: { value: string } = {}): string | undefined {\n          return value;\n        }\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      4,
 					Column:    37,
 					EndColumn: 39,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        function getValue(): undefined;\n        function getValue(box: { value: string }): string;\n        function getValue({ value }: { value: string } = {}): string | undefined {\n          return value;\n        }\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        function getValue([value = '']: [string]) {\n          return value;\n        }\n      ",
-			Output: []string{
-				"\n        function getValue([value]: [string]) {\n          return value;\n        }\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      2,
 					Column:    36,
 					EndColumn: 38,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        function getValue([value]: [string]) {\n          return value;\n        }\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        declare const x: { hello: { world: string } };\n\n        const {\n          hello: { world = '' },\n        } = x;\n      ",
-			Output: []string{
-				"\n        declare const x: { hello: { world: string } };\n\n        const {\n          hello: { world },\n        } = x;\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      5,
 					Column:    28,
 					EndColumn: 30,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        declare const x: { hello: { world: string } };\n\n        const {\n          hello: { world },\n        } = x;\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        declare const x: { hello: Array<{ world: string }> };\n\n        const {\n          hello: [{ world = '' }],\n        } = x;\n      ",
-			Output: []string{
-				"\n        declare const x: { hello: Array<{ world: string }> };\n\n        const {\n          hello: [{ world }],\n        } = x;\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      5,
 					Column:    29,
 					EndColumn: 31,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        declare const x: { hello: Array<{ world: string }> };\n\n        const {\n          hello: [{ world }],\n        } = x;\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        interface B {\n          foo: (b: boolean | string) => void;\n        }\n\n        const h: B = {\n          foo: (b = false) => {},\n        };\n      ",
-			Output: []string{
-				"\n        interface B {\n          foo: (b: boolean | string) => void;\n        }\n\n        const h: B = {\n          foo: (b) => {},\n        };\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      7,
 					Column:    21,
 					EndColumn: 26,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        interface B {\n          foo: (b: boolean | string) => void;\n        }\n\n        const h: B = {\n          foo: (b) => {},\n        };\n      ",
+						},
+					},
 				},
 			},
 		},
@@ -412,9 +439,6 @@ func TestNoUselessDefaultAssignmentRule(t *testing.T) {
 		{
 			Code:     "\n        function Bar({ foo = '' }: { foo: string }) {\n          return foo;\n        }\n      ",
 			TSConfig: "tsconfig.unstrict.json",
-			Output: []string{
-				"\n        function Bar({ foo }: { foo: string }) {\n          return foo;\n        }\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "noStrictNullCheck",
@@ -426,6 +450,12 @@ func TestNoUselessDefaultAssignmentRule(t *testing.T) {
 					Line:      2,
 					Column:    30,
 					EndColumn: 32,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        function Bar({ foo }: { foo: string }) {\n          return foo;\n        }\n      ",
+						},
+					},
 				},
 			},
 		},
@@ -451,71 +481,86 @@ func TestNoUselessDefaultAssignmentRule(t *testing.T) {
 		},
 		{
 			Code: "\n        const { a = 'baz' } = Math.random() < 0.5 ? { a: 'foo' } : { a: 'bar' };\n      ",
-			Output: []string{
-				"\n        const { a } = Math.random() < 0.5 ? { a: 'foo' } : { a: 'bar' };\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      2,
 					Column:    21,
 					EndColumn: 26,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        const { a } = Math.random() < 0.5 ? { a: 'foo' } : { a: 'bar' };\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        const { a = 'baz' } =\n          Math.random() < 0.5\n            ? { a: 'foo' }\n            : Math.random() > 0.2\n              ? { a: 'bar' }\n              : { a: 'qux' };\n      ",
-			Output: []string{
-				"\n        const { a } =\n          Math.random() < 0.5\n            ? { a: 'foo' }\n            : Math.random() > 0.2\n              ? { a: 'bar' }\n              : { a: 'qux' };\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      2,
 					Column:    21,
 					EndColumn: 26,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        const { a } =\n          Math.random() < 0.5\n            ? { a: 'foo' }\n            : Math.random() > 0.2\n              ? { a: 'bar' }\n              : { a: 'qux' };\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        const { a = 'baz' } = cond ? { ['a']: 'foo' } : { ['a']: 'bar' };\n      ",
-			Output: []string{
-				"\n        const { a } = cond ? { ['a']: 'foo' } : { ['a']: 'bar' };\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      2,
 					Column:    21,
 					EndColumn: 26,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        const { a } = cond ? { ['a']: 'foo' } : { ['a']: 'bar' };\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        const { a = 'baz' } = cond ? { a() {} } : { a: 'bar' };\n      ",
-			Output: []string{
-				"\n        const { a } = cond ? { a() {} } : { a: 'bar' };\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      2,
 					Column:    21,
 					EndColumn: 26,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        const { a } = cond ? { a() {} } : { a: 'bar' };\n      ",
+						},
+					},
 				},
 			},
 		},
 		{
 			Code: "\n        const { a = 'b' } = Math.random() < 0.5 ? { [`a`]: 'a' } : { a: 'b' };\n      ",
-			Output: []string{
-				"\n        const { a } = Math.random() < 0.5 ? { [`a`]: 'a' } : { a: 'b' };\n      ",
-			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "uselessDefaultAssignment",
 					Line:      2,
 					Column:    21,
 					EndColumn: 24,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeDefaultAssignment",
+							Output:    "\n        const { a } = Math.random() < 0.5 ? { [`a`]: 'a' } : { a: 'b' };\n      ",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/21716

Although this being a fix aligns with the type system, it could technically break users if their runtime values don't match their typescript types.