### PR TITLE
fix(prefer-optional-chain): avoid access comparison false positive

### DIFF
--- a/internal/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -1533,14 +1533,11 @@ outer3:
 		leftIsAccess := utils.IsAccessExpression(left)
 		rightIsAccess := utils.IsAccessExpression(right)
 
-		// If both sides are access expressions with the same base, we can't convert
-		// to optional chaining (e.g., foo && foo.bar === foo.baz)
+		// If both sides are access expressions, we can't convert to optional
+		// chaining without changing when the other side is evaluated.
+		// For example, `x && y && x.a === y.a` must keep both guards.
 		if leftIsAccess && rightIsAccess {
-			leftBase := getBaseIdentifier(left)
-			rightBase := getBaseIdentifier(right)
-			if areNodesStructurallyEqual(leftBase, rightBase) {
-				return Operand{typ: OperandTypeInvalid, node: node}
-			}
+			return Operand{typ: OperandTypeInvalid, node: node}
 		}
 
 		comparedExpr := left
@@ -1578,14 +1575,10 @@ outer3:
 		leftIsAccess := utils.IsAccessExpression(left)
 		rightIsAccess := utils.IsAccessExpression(right)
 
-		// If both sides are access expressions with the same base, we can't convert
-		// to optional chaining (e.g., foo == null || foo.bar === foo.baz)
+		// If both sides are access expressions, we can't convert to optional
+		// chaining without changing when the other side is evaluated.
 		if leftIsAccess && rightIsAccess {
-			leftBase := getBaseIdentifier(left)
-			rightBase := getBaseIdentifier(right)
-			if areNodesStructurallyEqual(leftBase, rightBase) {
-				return Operand{typ: OperandTypeInvalid, node: node}
-			}
+			return Operand{typ: OperandTypeInvalid, node: node}
 		}
 
 		comparedExpr := left

--- a/internal/rules/prefer_optional_chain/prefer_optional_chain_test.go
+++ b/internal/rules/prefer_optional_chain/prefer_optional_chain_test.go
@@ -1008,6 +1008,14 @@ if (!a || b === a || b.indexOf('input, button, a')) {
   console.log('Hello, World');
 }`,
 		},
+		{Code: `
+			function test() {
+				let x: undefined | { a: string }, y: undefined | { a: string }
+				if (x && y && x.a === y.a) {
+					console.log("x and y are equal")
+				}
+			}
+		`},
 	}
 
 	invalidCases := []rule_tester.InvalidTestCase{


### PR DESCRIPTION
Prevents `prefer-optional-chain` from reporting access-vs-access comparisons like `x && y && x.a === y.a`, where optional chaining would change when the other side is evaluated.

Adds a regression test for the valid guarded comparison case; fixes https://github.com/oxc-project/oxc/issues/21849.