### PR TITLE
fix(prefer-nullish-coalescing): parenthesize mixed logical fixes

### DIFF
--- a/internal/rule_tester/__snapshots__/prefer-nullish-coalescing.snap
+++ b/internal/rule_tester/__snapshots__/prefer-nullish-coalescing.snap
@@ -1146,3 +1146,39 @@ Message: Prefer using nullish coalescing operator (`??`) instead of a logical or
      |                  ~~
    6 |       
 ---
+
+[TestPreferNullishCoalescingRule/invalid-122 - 1]
+Diagnostic 1: preferNullishOverOr (5:46 - 5:47)
+Message: Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`), as it is a safer operator.
+   4 | declare const fallback: boolean;
+   5 | export const result = isLoading || isPending || fallback;
+     |                                              ~~
+   6 |       
+---
+
+[TestPreferNullishCoalescingRule/invalid-123 - 1]
+Diagnostic 1: preferNullishOverOr (5:29 - 5:30)
+Message: Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`), as it is a safer operator.
+   4 | declare const alternate: string;
+   5 | export const result = value || fallback && alternate;
+     |                             ~~
+   6 |       
+---
+
+[TestPreferNullishCoalescingRule/invalid-124 - 1]
+Diagnostic 1: preferNullishOverOr (5:29 - 5:30)
+Message: Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`), as it is a safer operator.
+   4 | declare const alternate: string;
+   5 | export const result = value || (fallback && alternate);
+     |                             ~~
+   6 |       
+---
+
+[TestPreferNullishCoalescingRule/invalid-125 - 1]
+Diagnostic 1: preferNullishOverOr (6:29 - 6:30)
+Message: Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`), as it is a safer operator.
+   5 | declare const finalFallback: string;
+   6 | export const result = value || fallback && alternate || finalFallback;
+     |                             ~~
+   7 |       
+---

--- a/internal/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.go
+++ b/internal/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.go
@@ -522,6 +522,7 @@ var PreferNullishCoalescingRule = rule.Rule{
 
 			ctx.ReportNodeWithFixes(binExpr.OperatorToken, buildPreferNullishOverOrMessage(description, equals), func() []rule.RuleFix {
 				fixes := []rule.RuleFix{}
+				leftOperandStartsInsideLeftExpression := false
 
 				// If parent is a logical or expression (skipping parentheses), wrap with parentheses
 				// But don't add parentheses if already wrapped in parentheses
@@ -540,10 +541,26 @@ var PreferNullishCoalescingRule = rule.Rule{
 						// See: https://github.com/oxc-project/tsgolint/issues/604
 						if ast.IsBinaryExpression(leftExpr) && ast.IsLogicalExpression(leftExpr) && !isLogicalOrOperator(leftExpr.AsBinaryExpression().Left) {
 							fixes = append(fixes, rule.RuleFixInsertBefore(ctx.SourceFile, leftExpr.AsBinaryExpression().Right, "("))
+							leftOperandStartsInsideLeftExpression = true
 						} else {
 							fixes = append(fixes, rule.RuleFixInsertBefore(ctx.SourceFile, binExpr.Left, "("))
 						}
 						fixes = append(fixes, rule.RuleFixInsertAfter(binExpr.Right, ")"))
+					}
+				}
+
+				if binExpr.OperatorToken.Kind == ast.KindBarBarToken {
+					if !leftOperandStartsInsideLeftExpression && ast.IsLogicalExpression(binExpr.Left) && !ast.IsParenthesizedExpression(binExpr.Left) {
+						fixes = append(fixes,
+							rule.RuleFixInsertBefore(ctx.SourceFile, binExpr.Left, "("),
+							rule.RuleFixInsertAfter(binExpr.Left, ")"),
+						)
+					}
+					if ast.IsLogicalExpression(binExpr.Right) && !ast.IsParenthesizedExpression(binExpr.Right) {
+						fixes = append(fixes,
+							rule.RuleFixInsertBefore(ctx.SourceFile, binExpr.Right, "("),
+							rule.RuleFixInsertAfter(binExpr.Right, ")"),
+						)
 					}
 				}
 

--- a/internal/rules/prefer_nullish_coalescing/prefer_nullish_coalescing_test.go
+++ b/internal/rules/prefer_nullish_coalescing/prefer_nullish_coalescing_test.go
@@ -2827,7 +2827,86 @@ const x = a && (b ?? c) || 'd';
 declare let a: string | null;
 declare let b: string;
 declare let c: string;
-const x = a && (b ?? c) ?? 'd';
+const x = (a && (b ?? c)) ?? 'd';
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferNullishOverOr",
+				},
+			},
+		},
+		// https://github.com/oxc-project/oxc/issues/21978
+		{
+			Code: `
+declare const isLoading: boolean;
+declare const isPending: boolean | undefined;
+declare const fallback: boolean;
+export const result = isLoading || isPending || fallback;
+      `,
+			Output: []string{`
+declare const isLoading: boolean;
+declare const isPending: boolean | undefined;
+declare const fallback: boolean;
+export const result = (isLoading || isPending) ?? fallback;
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferNullishOverOr",
+				},
+			},
+		},
+		{
+			Code: `
+declare const value: string | undefined;
+declare const fallback: string;
+declare const alternate: string;
+export const result = value || fallback && alternate;
+      `,
+			Output: []string{`
+declare const value: string | undefined;
+declare const fallback: string;
+declare const alternate: string;
+export const result = value ?? (fallback && alternate);
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferNullishOverOr",
+				},
+			},
+		},
+		{
+			Code: `
+declare const value: string | undefined;
+declare const fallback: string;
+declare const alternate: string;
+export const result = value || (fallback && alternate);
+      `,
+			Output: []string{`
+declare const value: string | undefined;
+declare const fallback: string;
+declare const alternate: string;
+export const result = value ?? (fallback && alternate);
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferNullishOverOr",
+				},
+			},
+		},
+		{
+			Code: `
+declare const value: string | undefined;
+declare const fallback: string;
+declare const alternate: string;
+declare const finalFallback: string;
+export const result = value || fallback && alternate || finalFallback;
+      `,
+			Output: []string{`
+declare const value: string | undefined;
+declare const fallback: string;
+declare const alternate: string;
+declare const finalFallback: string;
+export const result = (value ?? (fallback && alternate)) || finalFallback;
       `},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{


### PR DESCRIPTION
Parenthesizes logical operands when `prefer-nullish-coalescing` fixes `||` to `??`, preventing invalid mixed logical expressions; fixes oxc-project/oxc#21978.