### PR TITLE
tests(return-await): cover non-async arrow functions

### DIFF
--- a/internal/rules/return_await/return_await_test.go
+++ b/internal/rules/return_await/return_await_test.go
@@ -494,6 +494,10 @@ class C<R extends unknown> {
 }
       `,
 		},
+		{
+			Code:    `const example = () => Promise.resolve();`,
+			Options: rule_tester.OptionsFromJSON[ReturnAwaitOptions](`"always"`),
+		},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `


### PR DESCRIPTION
originally fixed by https://github.com/oxc-project/tsgolint/pull/751

Fixes https://github.com/oxc-project/oxc/issues/18452