### PR TITLE
chore: update typescript-go submodule

### DIFF
--- a/patches/0001-Adapt-project-service-for-single-run-mode.patch
+++ b/patches/0001-Adapt-project-service-for-single-run-mode.patch
@@ -1,4 +1,4 @@
-From 9a5721e4d7fce56334300329ec7a4cda13b47e6b Mon Sep 17 00:00:00 2001
+From 6af00a3f8964c8a706a3dd1588871ec646070058 Mon Sep 17 00:00:00 2001
 From: Cameron Clark <cameron.clark@hey.com>
 Date: Fri, 14 Nov 2025 11:09:52 +0000
 Subject: [PATCH 1/5] Adapt project service for single run mode

--- a/patches/0002-patch-expose-more-functions-via-the-shim-with-type-f.patch
+++ b/patches/0002-patch-expose-more-functions-via-the-shim-with-type-f.patch
@@ -1,4 +1,4 @@
-From 3946aab31967fb0e99157c9fe4234579930040b5 Mon Sep 17 00:00:00 2001
+From e04127631dd7818d0f890cc64722516c789e625f Mon Sep 17 00:00:00 2001
 From: Cameron Clark <cameron.clark@hey.com>
 Date: Fri, 17 Apr 2026 10:40:11 +0100
 Subject: [PATCH 2/5] patch: expose more functions via the shim with type fixes
@@ -49,7 +49,7 @@ index 212601d4b..73e4b4316 100644
  }
  
 diff --git a/internal/project/configfileregistrybuilder.go b/internal/project/configfileregistrybuilder.go
-index f543951f1..1660cda40 100644
+index 209cfc626..e5d0ef231 100644
 --- a/internal/project/configfileregistrybuilder.go
 +++ b/internal/project/configfileregistrybuilder.go
 @@ -16,14 +16,14 @@ import (
@@ -241,7 +241,7 @@ index f543951f1..1660cda40 100644
  	searchPath := tspath.GetDirectoryPath(fileName)
  	// Prefer custom config file if provided; search ancestors with correct skip behavior.
  	if c.customConfigFileName != "" {
-@@ -623,7 +623,7 @@ func (c *configFileRegistryBuilder) computeConfigFileName(fileName string, skipS
+@@ -631,7 +631,7 @@ func (c *configFileRegistryBuilder) computeConfigFileName(fileName string, skipS
  	return result
  }
  
@@ -250,7 +250,7 @@ index f543951f1..1660cda40 100644
  	if tspath.IsDynamicFileName(fileName) {
  		return ""
  	}
-@@ -632,7 +632,7 @@ func (c *configFileRegistryBuilder) getConfigFileNameForFile(fileName string, pa
+@@ -640,7 +640,7 @@ func (c *configFileRegistryBuilder) getConfigFileNameForFile(fileName string, pa
  		return entry.Value().nearestConfigFileName
  	}
  
@@ -259,7 +259,7 @@ index f543951f1..1660cda40 100644
  	if c.isOpenFile(path) {
  		c.configFileNames.Add(path, &configFileNames{
  			nearestConfigFileName: configName,
-@@ -641,7 +641,7 @@ func (c *configFileRegistryBuilder) getConfigFileNameForFile(fileName string, pa
+@@ -649,7 +649,7 @@ func (c *configFileRegistryBuilder) getConfigFileNameForFile(fileName string, pa
  	return configName
  }
  
@@ -268,7 +268,7 @@ index f543951f1..1660cda40 100644
  	if tspath.IsDynamicFileName(string(path)) {
  		return
  	}
-@@ -659,7 +659,7 @@ func (c *configFileRegistryBuilder) forEachConfigFileNameFor(path tspath.Path, c
+@@ -667,7 +667,7 @@ func (c *configFileRegistryBuilder) forEachConfigFileNameFor(path tspath.Path, c
  	}
  }
  
@@ -277,7 +277,7 @@ index f543951f1..1660cda40 100644
  	if tspath.IsDynamicFileName(fileName) {
  		return ""
  	}
-@@ -674,7 +674,7 @@ func (c *configFileRegistryBuilder) getAncestorConfigFileName(fileName string, p
+@@ -682,7 +682,7 @@ func (c *configFileRegistryBuilder) getAncestorConfigFileName(fileName string, p
  	}
  
  	// Look for config in parent folders of config file
@@ -286,7 +286,7 @@ index f543951f1..1660cda40 100644
  
  	if c.isOpenFile(path) {
  		entry.Change(func(value *configFileNames) {
-@@ -688,17 +688,17 @@ func (c *configFileRegistryBuilder) getAncestorConfigFileName(fileName string, p
+@@ -696,17 +696,17 @@ func (c *configFileRegistryBuilder) getAncestorConfigFileName(fileName string, p
  }
  
  // FS implements tsoptions.ParseConfigHost.
@@ -307,7 +307,7 @@ index f543951f1..1660cda40 100644
  	var content string
  	fh := c.fs.GetFileByPath(fileName, path)
  	if fh != nil {
-@@ -715,7 +715,7 @@ func (c *configFileRegistryBuilder) GetExtendedConfig(fileName string, path tspa
+@@ -723,7 +723,7 @@ func (c *configFileRegistryBuilder) GetExtendedConfig(fileName string, path tspa
  	}).ExtendedConfigCacheEntry
  }
  

--- a/patches/0003-fix-early-return-from-invalid-tsconfig-for-better-er.patch
+++ b/patches/0003-fix-early-return-from-invalid-tsconfig-for-better-er.patch
@@ -1,4 +1,4 @@
-From f7e897762a2020d8a5d65c879d6da3becf2436d8 Mon Sep 17 00:00:00 2001
+From 094dcce1b4bd6b2aca7f89b8607f35a6c8dde01b Mon Sep 17 00:00:00 2001
 From: Cameron Clark <cameron.clark@hey.com>
 Date: Mon, 3 Nov 2025 12:44:32 +0000
 Subject: [PATCH 3/5] fix: early return from invalid tsconfig for better errors
@@ -8,7 +8,7 @@ Subject: [PATCH 3/5] fix: early return from invalid tsconfig for better errors
  1 file changed, 11 insertions(+)
 
 diff --git a/internal/tsoptions/tsconfigparsing.go b/internal/tsoptions/tsconfigparsing.go
-index 15118ae27..e12cb0e86 100644
+index db45adfcd..1d8b270b5 100644
 --- a/internal/tsoptions/tsconfigparsing.go
 +++ b/internal/tsoptions/tsconfigparsing.go
 @@ -189,6 +189,17 @@ func parseOwnConfigOfJsonSourceFile(

--- a/patches/0004-fix-collections-avoid-internal-json-import-in-ordere.patch
+++ b/patches/0004-fix-collections-avoid-internal-json-import-in-ordere.patch
@@ -1,4 +1,4 @@
-From ab010dd89e9011df783848f6c455a720d6627f09 Mon Sep 17 00:00:00 2001
+From a3bf95f568ac59a87a8b4da89f77ff9d42c3bf51 Mon Sep 17 00:00:00 2001
 From: Cameron Clark <cameron.clark@hey.com>
 Date: Fri, 13 Feb 2026 18:37:25 +0000
 Subject: [PATCH 4/5] fix(collections): avoid internal json import in

--- a/patches/0005-perf-vfs-cache-ReadFile-results-in-cachedvfs.patch
+++ b/patches/0005-perf-vfs-cache-ReadFile-results-in-cachedvfs.patch
@@ -1,4 +1,4 @@
-From ba6adee005058b19c1fb61920f0d072470df2b19 Mon Sep 17 00:00:00 2001
+From 7ec9f04ebe12d52db52402dac2c50b354810afab Mon Sep 17 00:00:00 2001
 From: Codex <codex@example.com>
 Date: Thu, 12 Feb 2026 13:55:47 +0900
 Subject: [PATCH 5/5] perf(vfs): cache ReadFile results in cachedvfs

--- a/shim/ast/shim.go
+++ b/shim/ast/shim.go
@@ -804,7 +804,7 @@ func IsEqualityOperatorOrHigher(kind ast.Kind) bool
 //go:linkname IsExclusivelyTypeOnlyImportOrExport github.com/microsoft/typescript-go/internal/ast.IsExclusivelyTypeOnlyImportOrExport
 func IsExclusivelyTypeOnlyImportOrExport(node *ast.Node) bool
 //go:linkname IsExpandoInitializer github.com/microsoft/typescript-go/internal/ast.IsExpandoInitializer
-func IsExpandoInitializer(initializer *ast.Node) bool
+func IsExpandoInitializer(declaration *ast.Node, initializer *ast.Node) bool
 //go:linkname IsExpandoPropertyDeclaration github.com/microsoft/typescript-go/internal/ast.IsExpandoPropertyDeclaration
 func IsExpandoPropertyDeclaration(node *ast.Node) bool
 //go:linkname IsExponentiationOperator github.com/microsoft/typescript-go/internal/ast.IsExponentiationOperator


### PR DESCRIPTION
## Summary

- Update the `typescript-go` submodule from `25963e42b8a5d7da694c6ee555fed3cc93de1e71` to `dcc16d93144623ac56191861d76c1eb0f997a089`
- Refresh the existing `patches/*.patch` stack against the new upstream base
- Regenerate shims for the upstream `IsExpandoInitializer` signature change
