### PR TITLE
chore: configure typescript-go renovate schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>Boshen/renovate"],
+  "timezone": "Europe/London",
   "ignorePaths": [
     "benchmarks/Containerfile",
     "shim/**/go.mod"
@@ -19,9 +20,9 @@
     {
       "matchManagers": ["git-submodules"],
       "matchDepNames": ["typescript-go"],
-      "automerge": true,
-      "automergeSchedule": ["at any time"],
-      "schedule": ["before 9am"]
+      "automerge": false,
+      "updateNotScheduled": false,
+      "schedule": ["* 7 * * 5"]
     }
   ]
 }


### PR DESCRIPTION
this is too nosy to have running every time there's a change upstream.

this PR changes the behaviour to run 1x per week
