### PR TITLE
feat: add per-rule debug timings

### DIFF
--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -33,10 +33,12 @@ type headlessOptions struct {
 	allocsOut      string
 	fix            bool
 	fixSuggestions bool
+	debugTimings   bool
 }
 
 func parseHeadlessOptions(args []string) (*headlessOptions, error) {
 	var opts headlessOptions
+	var debug string
 
 	flag.StringVar(&opts.traceOut, "trace", "", "file to put trace to")
 	flag.StringVar(&opts.cpuprofOut, "cpuprof", "", "file to put cpu profiling to")
@@ -44,10 +46,17 @@ func parseHeadlessOptions(args []string) (*headlessOptions, error) {
 	flag.StringVar(&opts.allocsOut, "allocs", "", "file to put allocs profiling to")
 	flag.BoolVar(&opts.fix, "fix", false, "generate fixes for code problems")
 	flag.BoolVar(&opts.fixSuggestions, "fix-suggestions", false, "generate suggestions for code problems")
+	flag.StringVar(&debug, "debug", "", "enable debug output options")
 
 	if err := flag.CommandLine.Parse(args); err != nil {
 		return nil, err
 	}
+
+	debugTimings, err := parseDebugTimings(debug)
+	if err != nil {
+		return nil, err
+	}
+	opts.debugTimings = debugTimings
 
 	return &opts, nil
 }
@@ -136,10 +145,33 @@ type headlessMessageType uint8
 const (
 	headlessMessageTypeError headlessMessageType = iota
 	headlessMessageTypeDiagnostic
+	headlessMessageTypeTiming
 )
 
 type headlessMessagePayloadError struct {
 	Error string `json:"error"`
+}
+
+type headlessTimingPayload struct {
+	Rules []headlessRuleTiming `json:"rules"`
+}
+
+type headlessRuleTiming struct {
+	RuleName string `json:"rule_name"`
+	Duration uint64 `json:"duration"`
+	Calls    uint64 `json:"calls"`
+}
+
+func headlessTimingPayloadFromRecords(records []linter.RuleTimingRecord) headlessTimingPayload {
+	rules := make([]headlessRuleTiming, len(records))
+	for i, record := range records {
+		rules[i] = headlessRuleTiming{
+			RuleName: record.RuleName,
+			Duration: uint64(record.Duration),
+			Calls:    record.Calls,
+		}
+	}
+	return headlessTimingPayload{Rules: rules}
 }
 
 // Unified diagnostic type for channel
@@ -365,19 +397,23 @@ func runHeadless(args []string) int {
 		}
 	})
 
-	suppressProgramDiagnostics := os.Getenv("OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS") == "true"
+	requestTimings := opts.debugTimings || os.Getenv("OXLINT_TSGOLINT_TIMINGS") == "1"
+	var timingStore *linter.RuleTimingStore
+	if requestTimings {
+		timingStore = linter.NewRuleTimingStore()
+	}
 
 	if logLevel == utils.LogLevelDebug {
 		log.Printf("Running Linter")
 	}
 
-	err = linter.RunLinter(
-		logLevel,
-		cwd,
-		workload,
-		runtime.GOMAXPROCS(0),
-		fs,
-		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+	err = linter.RunLinter(linter.RunLinterOptions{
+		LogLevel:         logLevel,
+		CurrentDirectory: cwd,
+		Workload:         workload,
+		Workers:          runtime.GOMAXPROCS(0),
+		FS:               fs,
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 			cfg := fileConfigs[sourceFile.FileName()]
 			rules := make([]linter.ConfiguredRule, len(cfg))
 
@@ -396,22 +432,19 @@ func runHeadless(args []string) int {
 
 			return rules
 		},
-		func(d rule.RuleDiagnostic) {
-			diagnosticsChan <- ruleToAny(d)
-		},
-		func(d diagnostic.Internal) {
-			diagnosticsChan <- internalToAny(d)
-		},
-		linter.Fixes{
+		OnRuleDiagnostic:     func(d rule.RuleDiagnostic) { diagnosticsChan <- ruleToAny(d) },
+		OnInternalDiagnostic: func(d diagnostic.Internal) { diagnosticsChan <- internalToAny(d) },
+		Fixes: linter.Fixes{
 			Fix:            opts.fix,
 			FixSuggestions: opts.fixSuggestions,
 		},
-		linter.TypeErrors{
+		TypeErrors: linter.TypeErrors{
 			ReportSyntactic: payload.ReportSyntactic,
 			ReportSemantic:  payload.ReportSemantic,
 		},
-		suppressProgramDiagnostics,
-	)
+		SuppressProgramDiagnostics: os.Getenv("OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS") == "true",
+		TimingStore:                timingStore,
+	})
 
 	close(diagnosticsChan)
 	if err != nil {
@@ -421,6 +454,13 @@ func runHeadless(args []string) int {
 	}
 
 	wg.Wait()
+
+	if requestTimings {
+		if err := writeMessage(os.Stdout, headlessMessageTypeTiming, headlessTimingPayloadFromRecords(timingStore.Collect())); err != nil {
+			log.Printf("ERROR: failed to write timing output: %v", err)
+			return 1
+		}
+	}
 
 	if logLevel == utils.LogLevelDebug {
 		log.Printf("Linting Complete")

--- a/cmd/tsgolint/headless_bench_test.go
+++ b/cmd/tsgolint/headless_bench_test.go
@@ -98,17 +98,15 @@ func runAllRulesBenchmark(b *testing.B, singleThreaded bool) {
 
 	// Warm up: run once to ensure everything is initialized
 	var diagnosticCount int64
-	err := linter.RunLinterOnProgram(
-		utils.LogLevelNormal,
-		env.program,
-		env.files,
-		workers,
-		env.getRulesForFile,
-		func(_ rule.RuleDiagnostic) { atomic.AddInt64(&diagnosticCount, 1) },
-		func(_ diagnostic.Internal) {},
-		linter.Fixes{},
-		linter.TypeErrors{},
-	)
+	err := linter.RunLinterOnProgram(linter.RunLinterOnProgramOptions{
+		LogLevel:             utils.LogLevelNormal,
+		Program:              env.program,
+		Files:                env.files,
+		Workers:              workers,
+		GetRulesForFile:      env.getRulesForFile,
+		OnDiagnostic:         func(_ rule.RuleDiagnostic) { atomic.AddInt64(&diagnosticCount, 1) },
+		OnInternalDiagnostic: func(_ diagnostic.Internal) {},
+	})
 	if err != nil {
 		b.Fatal("warmup linter failed:", err)
 	}
@@ -118,17 +116,15 @@ func runAllRulesBenchmark(b *testing.B, singleThreaded bool) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		err := linter.RunLinterOnProgram(
-			utils.LogLevelNormal,
-			env.program,
-			env.files,
-			workers,
-			env.getRulesForFile,
-			func(_ rule.RuleDiagnostic) {},
-			func(_ diagnostic.Internal) {},
-			linter.Fixes{},
-			linter.TypeErrors{},
-		)
+		err := linter.RunLinterOnProgram(linter.RunLinterOnProgramOptions{
+			LogLevel:             utils.LogLevelNormal,
+			Program:              env.program,
+			Files:                env.files,
+			Workers:              workers,
+			GetRulesForFile:      env.getRulesForFile,
+			OnDiagnostic:         func(_ rule.RuleDiagnostic) {},
+			OnInternalDiagnostic: func(_ diagnostic.Internal) {},
+		})
 		if err != nil {
 			b.Fatal("linter failed:", err)
 		}
@@ -218,19 +214,16 @@ func BenchmarkE2E(b *testing.B) {
 		}
 
 		var diagnosticCount int64
-		err := linter.RunLinter(
-			utils.LogLevelNormal,
-			dir,
-			workload,
-			workers,
-			fs,
-			getRulesForFile,
-			func(_ rule.RuleDiagnostic) { atomic.AddInt64(&diagnosticCount, 1) },
-			func(_ diagnostic.Internal) {},
-			linter.Fixes{},
-			linter.TypeErrors{},
-			false,
-		)
+		err := linter.RunLinter(linter.RunLinterOptions{
+			LogLevel:             utils.LogLevelNormal,
+			CurrentDirectory:     dir,
+			Workload:             workload,
+			Workers:              workers,
+			FS:                   fs,
+			GetRulesForFile:      getRulesForFile,
+			OnRuleDiagnostic:     func(_ rule.RuleDiagnostic) { atomic.AddInt64(&diagnosticCount, 1) },
+			OnInternalDiagnostic: func(_ diagnostic.Internal) {},
+		})
 		if err != nil {
 			b.Fatal("warmup linter failed:", err)
 		}
@@ -244,19 +237,16 @@ func BenchmarkE2E(b *testing.B) {
 		// and diagnostic serialization to io.Discard.
 		workload, fs := buildWorkload()
 
-		err := linter.RunLinter(
-			utils.LogLevelNormal,
-			dir,
-			workload,
-			workers,
-			fs,
-			getRulesForFile,
-			func(_ rule.RuleDiagnostic) {},
-			func(_ diagnostic.Internal) {},
-			linter.Fixes{},
-			linter.TypeErrors{},
-			false,
-		)
+		err := linter.RunLinter(linter.RunLinterOptions{
+			LogLevel:             utils.LogLevelNormal,
+			CurrentDirectory:     dir,
+			Workload:             workload,
+			Workers:              workers,
+			FS:                   fs,
+			GetRulesForFile:      getRulesForFile,
+			OnRuleDiagnostic:     func(_ rule.RuleDiagnostic) {},
+			OnInternalDiagnostic: func(_ diagnostic.Internal) {},
+		})
 		if err != nil {
 			b.Fatal("linter failed:", err)
 		}

--- a/cmd/tsgolint/main.go
+++ b/cmd/tsgolint/main.go
@@ -371,8 +371,61 @@ Usage:
 Options:
     --tsconfig PATH   Which tsconfig to use. Defaults to tsconfig.json.
 		--list-files      List matched files
+    --debug OPTIONS   Enable debug output options. Possible values: timings.
     -h, --help        Show help
 `
+
+func parseDebugTimings(options string) (bool, error) {
+	if options == "" {
+		return false, nil
+	}
+
+	timings := false
+	for _, option := range strings.Split(options, ",") {
+		if option == "" {
+			continue
+		}
+		switch option {
+		case "timings":
+			timings = true
+		default:
+			return false, fmt.Errorf("unknown debug option %q", option)
+		}
+	}
+
+	return timings, nil
+}
+
+func formatRuleTimingTable(records []linter.RuleTimingRecord) string {
+	if len(records) == 0 {
+		return ""
+	}
+
+	ruleWidth := len("Rule")
+	callsWidth := len("Calls")
+	var total time.Duration
+	for _, record := range records {
+		ruleWidth = max(ruleWidth, len(record.RuleName))
+		callsWidth = max(callsWidth, len(strconv.FormatUint(record.Calls, 10)))
+		total += record.Duration
+	}
+
+	var output strings.Builder
+	fmt.Fprintf(&output, "\nRule timings:\n")
+	fmt.Fprintf(&output, "%-*s  %10s  %8s  %*s\n", ruleWidth, "Rule", "Time (ms)", "Relative", callsWidth, "Calls")
+	fmt.Fprintf(&output, "%-*s  %-10s  %-8s  %-*s\n", ruleWidth, strings.Repeat("-", ruleWidth), strings.Repeat("-", 10), strings.Repeat("-", 8), callsWidth, strings.Repeat("-", callsWidth))
+
+	for _, record := range records {
+		millis := float64(record.Duration) / float64(time.Millisecond)
+		relative := 0.0
+		if total > 0 {
+			relative = float64(record.Duration) / float64(total) * 100
+		}
+		fmt.Fprintf(&output, "%-*s  %10.3f  %7.1f%%  %*d\n", ruleWidth, record.RuleName, millis, relative, callsWidth, record.Calls)
+	}
+
+	return output.String()
+}
 
 func runMain() int {
 	if len(os.Args) > 1 && os.Args[1] == "headless" {
@@ -385,6 +438,7 @@ func runMain() int {
 		help      bool
 		tsconfig  string
 		listFiles bool
+		debug     string
 
 		traceOut       string
 		cpuprofOut     string
@@ -393,6 +447,7 @@ func runMain() int {
 
 	flag.StringVar(&tsconfig, "tsconfig", "", "which tsconfig to use")
 	flag.BoolVar(&listFiles, "list-files", false, "list matched files")
+	flag.StringVar(&debug, "debug", "", "enable debug output options")
 	flag.BoolVar(&help, "help", false, "show help")
 	flag.BoolVar(&help, "h", false, "show help")
 
@@ -405,6 +460,12 @@ func runMain() int {
 	if help {
 		flag.Usage()
 		return 0
+	}
+
+	debugTimings, err := parseDebugTimings(debug)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing debug options: %v\n", err)
+		return 1
 	}
 
 	fmt.Fprintf(os.Stderr, unsupportedCliWarning)
@@ -513,12 +574,16 @@ func runMain() int {
 		}
 	})
 
-	err = linter.RunLinterOnProgram(
-		utils.GetLogLevel(),
-		program,
-		files,
-		runtime.GOMAXPROCS(0),
-		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+	var timingStore *linter.RuleTimingStore
+	if debugTimings {
+		timingStore = linter.NewRuleTimingStore()
+	}
+	err = linter.RunLinterOnProgram(linter.RunLinterOnProgramOptions{
+		LogLevel: utils.GetLogLevel(),
+		Program:  program,
+		Files:    files,
+		Workers:  runtime.GOMAXPROCS(0),
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 			return utils.Map(allRules, func(r rule.Rule) linter.ConfiguredRule {
 				return linter.ConfiguredRule{
 					Name: r.Name,
@@ -528,21 +593,18 @@ func runMain() int {
 				}
 			})
 		},
-		func(d rule.RuleDiagnostic) {
-			diagnosticsChan <- d
-		},
-		func(d diagnostic.Internal) {
-			// Internal diagnostics are not used in this mode
-		},
-		linter.Fixes{
+		OnDiagnostic:         func(d rule.RuleDiagnostic) { diagnosticsChan <- d },
+		OnInternalDiagnostic: func(d diagnostic.Internal) {},
+		Fixes: linter.Fixes{
 			Fix:            true,
 			FixSuggestions: true,
 		},
-		linter.TypeErrors{
+		TypeErrors: linter.TypeErrors{
 			ReportSyntactic: false,
 			ReportSemantic:  false,
 		},
-	)
+		TimingStore: timingStore,
+	})
 
 	close(diagnosticsChan)
 	if err != nil {
@@ -585,6 +647,9 @@ func runMain() int {
 		time.Since(timeBefore).Round(time.Millisecond),
 		threadsCount,
 	)
+	if timingStore != nil {
+		os.Stdout.WriteString(formatRuleTimingTable(timingStore.Collect()))
+	}
 
 	return 0
 }

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/typescript-eslint/tsgolint/internal/diagnostic"
 	"github.com/typescript-eslint/tsgolint/internal/rule"
@@ -41,19 +42,54 @@ type TypeErrors struct {
 	ReportSemantic  bool
 }
 
-func RunLinter(
-	logLevel utils.LogLevel,
-	currentDirectory string,
-	workload Workload,
-	workers int,
-	fs vfs.FS,
-	getRulesForFile func(sourceFile *ast.SourceFile) []ConfiguredRule,
-	onRuleDiagnostic func(diagnostic rule.RuleDiagnostic),
-	onInternalDiagnostic func(d diagnostic.Internal),
-	fixState Fixes,
-	typeErrors TypeErrors,
-	suppressProgramDiagnostics bool,
-) error {
+type checkerWorkload struct {
+	checker *checker.Checker
+	program *compiler.Program
+	queue   chan *ast.SourceFile
+}
+
+type RunLinterOptions struct {
+	LogLevel                   utils.LogLevel
+	CurrentDirectory           string
+	Workload                   Workload
+	Workers                    int
+	FS                         vfs.FS
+	GetRulesForFile            func(sourceFile *ast.SourceFile) []ConfiguredRule
+	OnRuleDiagnostic           func(diagnostic rule.RuleDiagnostic)
+	OnInternalDiagnostic       func(d diagnostic.Internal)
+	Fixes                      Fixes
+	TypeErrors                 TypeErrors
+	SuppressProgramDiagnostics bool
+	TimingStore                *RuleTimingStore
+}
+
+// This is same as `RunLinterOptions` but for a single program.
+type RunLinterOnProgramOptions struct {
+	LogLevel             utils.LogLevel
+	Program              *compiler.Program
+	Files                []*ast.SourceFile
+	Workers              int
+	GetRulesForFile      func(sourceFile *ast.SourceFile) []ConfiguredRule
+	OnDiagnostic         func(diagnostic rule.RuleDiagnostic)
+	OnInternalDiagnostic func(d diagnostic.Internal)
+	Fixes                Fixes
+	TypeErrors           TypeErrors
+	TimingStore          *RuleTimingStore
+}
+
+func RunLinter(options RunLinterOptions) error {
+	logLevel := options.LogLevel
+	currentDirectory := options.CurrentDirectory
+	workload := options.Workload
+	workers := options.Workers
+	fs := options.FS
+	getRulesForFile := options.GetRulesForFile
+	onRuleDiagnostic := options.OnRuleDiagnostic
+	onInternalDiagnostic := options.OnInternalDiagnostic
+	fixState := options.Fixes
+	typeErrors := options.TypeErrors
+	suppressProgramDiagnostics := options.SuppressProgramDiagnostics
+	timingStore := options.TimingStore
 
 	idx := 0
 	for configFileName, filePaths := range workload.Programs {
@@ -112,7 +148,18 @@ func RunLinter(
 			panic(fmt.Sprintf("Expected file '%s' to be in program '%s'", unmatchedFilesString, configFileName))
 		}
 
-		err = RunLinterOnProgram(logLevel, program, sourceFiles, workers, getRulesForFile, onRuleDiagnostic, onInternalDiagnostic, fixState, typeErrors)
+		err = RunLinterOnProgram(RunLinterOnProgramOptions{
+			LogLevel:             logLevel,
+			Program:              program,
+			Files:                sourceFiles,
+			Workers:              workers,
+			GetRulesForFile:      getRulesForFile,
+			OnDiagnostic:         onRuleDiagnostic,
+			OnInternalDiagnostic: onInternalDiagnostic,
+			Fixes:                fixState,
+			TypeErrors:           typeErrors,
+			TimingStore:          timingStore,
+		})
 		if err != nil {
 			return err
 		}
@@ -143,7 +190,18 @@ func RunLinter(
 			files = append(files, sf)
 		}
 
-		err = RunLinterOnProgram(logLevel, program, files, workers, getRulesForFile, onRuleDiagnostic, onInternalDiagnostic, fixState, typeErrors)
+		err = RunLinterOnProgram(RunLinterOnProgramOptions{
+			LogLevel:             logLevel,
+			Program:              program,
+			Files:                files,
+			Workers:              workers,
+			GetRulesForFile:      getRulesForFile,
+			OnDiagnostic:         onRuleDiagnostic,
+			OnInternalDiagnostic: onInternalDiagnostic,
+			Fixes:                fixState,
+			TypeErrors:           typeErrors,
+			TimingStore:          timingStore,
+		})
 		if err != nil {
 			return err
 		}
@@ -239,21 +297,20 @@ func (b *ruleContextBuilder) reportNodeWithSuggestions(node *ast.Node, msg rule.
 	})
 }
 
-func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, files []*ast.SourceFile, workers int, getRulesForFile func(sourceFile *ast.SourceFile) []ConfiguredRule, onDiagnostic func(diagnostic rule.RuleDiagnostic), onInternalDiagnostic func(d diagnostic.Internal), fixState Fixes, typeErrors TypeErrors) error {
-	type checkerWorkload struct {
-		checker *checker.Checker
-		program *compiler.Program
-		queue   chan *ast.SourceFile
+func newRuleContext(ctxBuilder *ruleContextBuilder) rule.RuleContext {
+	return rule.RuleContext{
+		ReportDiagnostic:                ctxBuilder.emitDiagnostic,
+		ReportDiagnosticWithFixes:       ctxBuilder.reportDiagnosticWithFixes,
+		ReportDiagnosticWithSuggestions: ctxBuilder.reportDiagnosticWithSuggestions,
+		ReportRange:                     ctxBuilder.reportRange,
+		ReportRangeWithSuggestions:      ctxBuilder.reportRangeWithSuggestions,
+		ReportNode:                      ctxBuilder.reportNode,
+		ReportNodeWithFixes:             ctxBuilder.reportNodeWithFixes,
+		ReportNodeWithSuggestions:       ctxBuilder.reportNodeWithSuggestions,
 	}
-	flatQueue := []checkerWorkload{}
-	queue := make(chan *ast.SourceFile, len(files))
+}
 
-	for _, f := range files {
-		queue <- f
-	}
-
-	close(queue)
-
+func reportTypeScriptDiagnostics(program *compiler.Program, files []*ast.SourceFile, typeErrors TypeErrors, onInternalDiagnostic func(d diagnostic.Internal)) {
 	ctx := core.WithRequestID(context.Background(), "__single_run__")
 
 	if typeErrors.ReportSyntactic {
@@ -302,9 +359,21 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 				}
 			}
 		}
-
 	}
+}
 
+func makeSourceFileQueue(files []*ast.SourceFile) chan *ast.SourceFile {
+	queue := make(chan *ast.SourceFile, len(files))
+	for _, file := range files {
+		queue <- file
+	}
+	close(queue)
+	return queue
+}
+
+func makeCheckerWorkloadQueue(program *compiler.Program, files []*ast.SourceFile) chan checkerWorkload {
+	queue := makeSourceFileQueue(files)
+	flatQueue := []checkerWorkload{}
 	var flatQueueMu sync.Mutex
 	program.ForEachCheckerParallel(func(idx int, ch *checker.Checker) {
 		flatQueueMu.Lock()
@@ -317,18 +386,96 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 		workloadQueue <- w
 	}
 	close(workloadQueue)
+	return workloadQueue
+}
+
+func visitLintNodes(file *ast.SourceFile, runListeners func(kind ast.Kind, node *ast.Node)) {
+	/* convert.ts -> allowPattern:
+	catch name
+	variabledeclaration name
+	forinstatement initializer
+	forofstatement initializer
+	(propagation) allowPattern > arrayliteralexpression elements
+	(propagation) allowPattern > objectliteralexpression properties
+	(propagation) allowPattern > spreadassignment,spreadelement expression
+	(propagation) allowPattern > propertyassignment value
+	arraybindingpattern elements
+	objectbindingpattern elements
+	(init) binaryexpression(with '=' operator') left
+	*/
+
+	var childVisitor ast.Visitor
+	var patternVisitor func(node *ast.Node)
+	patternVisitor = func(node *ast.Node) {
+		runListeners(node.Kind, node)
+		kind := rule.ListenerOnAllowPattern(node.Kind)
+		runListeners(kind, node)
+
+		switch node.Kind {
+		case ast.KindArrayLiteralExpression:
+			for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
+				patternVisitor(element)
+			}
+		case ast.KindObjectLiteralExpression:
+			for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
+				patternVisitor(property)
+			}
+		case ast.KindSpreadElement, ast.KindSpreadAssignment:
+			patternVisitor(node.Expression())
+		case ast.KindPropertyAssignment:
+			patternVisitor(node.Initializer())
+		default:
+			node.ForEachChild(childVisitor)
+		}
+
+		runListeners(rule.ListenerOnExit(kind), node)
+		runListeners(rule.ListenerOnExit(node.Kind), node)
+	}
+	childVisitor = func(node *ast.Node) bool {
+		runListeners(node.Kind, node)
+
+		switch node.Kind {
+		case ast.KindArrayLiteralExpression, ast.KindObjectLiteralExpression:
+			kind := rule.ListenerOnNotAllowPattern(node.Kind)
+			runListeners(kind, node)
+			node.ForEachChild(childVisitor)
+			runListeners(rule.ListenerOnExit(kind), node)
+		default:
+			if ast.IsAssignmentExpression(node, true) {
+				expr := node.AsBinaryExpression()
+				patternVisitor(expr.Left)
+				childVisitor(expr.OperatorToken)
+				childVisitor(expr.Right)
+			} else {
+				node.ForEachChild(childVisitor)
+			}
+		}
+
+		runListeners(rule.ListenerOnExit(node.Kind), node)
+
+		return false
+	}
+	file.Node.ForEachChild(childVisitor)
+}
+
+func RunLinterOnProgram(options RunLinterOnProgramOptions) error {
+	logLevel := options.LogLevel
+	program := options.Program
+	files := options.Files
+	workers := options.Workers
+	getRulesForFile := options.GetRulesForFile
+	onDiagnostic := options.OnDiagnostic
+	onInternalDiagnostic := options.OnInternalDiagnostic
+	fixState := options.Fixes
+	typeErrors := options.TypeErrors
+	timingStore := options.TimingStore
+
+	reportTypeScriptDiagnostics(program, files, typeErrors, onInternalDiagnostic)
+	workloadQueue := makeCheckerWorkloadQueue(program, files)
 
 	wg := core.NewWorkGroup(workers == 1)
 	for range workers {
 		wg.Queue(func() {
-			// Listeners are tagged with the rule that is associated with, so that when a diagnostic
-			// is emitted we know what rule it is coming from.
-			type taggedListener struct {
-				ruleName string
-				fn       func(node *ast.Node)
-			}
-			registeredListeners := make(map[ast.Kind][]taggedListener, 20)
-
 			ctxBuilder := &ruleContextBuilder{
 				fixState:     fixState,
 				onDiagnostic: onDiagnostic,
@@ -336,15 +483,73 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 
 			// These closures remain valid for the length of linting, as we mutate the fields
 			// of `ctxBuilder`, but `ctxBuilder` itself will not change.
-			ctx := rule.RuleContext{
-				ReportDiagnostic:                ctxBuilder.emitDiagnostic,
-				ReportDiagnosticWithFixes:       ctxBuilder.reportDiagnosticWithFixes,
-				ReportDiagnosticWithSuggestions: ctxBuilder.reportDiagnosticWithSuggestions,
-				ReportRange:                     ctxBuilder.reportRange,
-				ReportRangeWithSuggestions:      ctxBuilder.reportRangeWithSuggestions,
-				ReportNode:                      ctxBuilder.reportNode,
-				ReportNodeWithFixes:             ctxBuilder.reportNodeWithFixes,
-				ReportNodeWithSuggestions:       ctxBuilder.reportNodeWithSuggestions,
+			ctx := newRuleContext(ctxBuilder)
+
+			if timingStore == nil {
+				// Listeners are tagged with the rule that is associated with, so that when a diagnostic
+				// is emitted we know what rule it is coming from.
+				type taggedListener struct {
+					ruleName string
+					fn       func(node *ast.Node)
+				}
+				registeredListeners := make(map[ast.Kind][]taggedListener, 20)
+
+				for w := range workloadQueue {
+					ctxBuilder.program = w.program
+					ctxBuilder.checker = w.checker
+					ctx.Program = w.program
+					ctx.TypeChecker = w.checker
+
+					for file := range w.queue {
+						if logLevel == utils.LogLevelDebug {
+							log.Print(file.FileName())
+						}
+						ctxBuilder.file = file
+						ctx.SourceFile = file
+
+						rules := getRulesForFile(file)
+						for _, r := range rules {
+							ctxBuilder.ruleName = r.Name
+							for kind, listener := range r.Run(ctx) {
+								listeners, ok := registeredListeners[kind]
+								if !ok {
+									listeners = make([]taggedListener, 0, len(rules))
+								}
+								registeredListeners[kind] = append(listeners, taggedListener{ruleName: r.Name, fn: listener})
+							}
+						}
+
+						runListeners := func(kind ast.Kind, node *ast.Node) {
+							if listeners, ok := registeredListeners[kind]; ok {
+								for _, listener := range listeners {
+									ctxBuilder.ruleName = listener.ruleName
+									listener.fn(node)
+								}
+							}
+						}
+
+						visitLintNodes(file, runListeners)
+						// Instead of clearing the map, we clear the slices in-place to avoid re-allocating memory for the listeners on each file.
+						for k := range registeredListeners {
+							registeredListeners[k] = registeredListeners[k][:0]
+						}
+					}
+				}
+
+				return
+			}
+
+			type timedTaggedListener struct {
+				ruleName string
+				ruleIdx  int
+				fn       func(node *ast.Node)
+			}
+			registeredListeners := make(map[ast.Kind][]timedTaggedListener, 20)
+			localTimings := make(map[string]RuleTimingStat, 64)
+
+			recordTiming := func(stat *RuleTimingStat, duration time.Duration) {
+				stat.Duration += duration
+				stat.Calls++
 			}
 
 			for w := range workloadQueue {
@@ -361,14 +566,18 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 					ctx.SourceFile = file
 
 					rules := getRulesForFile(file)
-					for _, r := range rules {
+					timingStats := make([]RuleTimingStat, len(rules))
+					for ruleIdx, r := range rules {
 						ctxBuilder.ruleName = r.Name
-						for kind, listener := range r.Run(ctx) {
+						start := time.Now()
+						listenersByKind := r.Run(ctx)
+						recordTiming(&timingStats[ruleIdx], time.Since(start))
+						for kind, listener := range listenersByKind {
 							listeners, ok := registeredListeners[kind]
 							if !ok {
-								listeners = make([]taggedListener, 0, len(rules))
+								listeners = make([]timedTaggedListener, 0, len(rules))
 							}
-							registeredListeners[kind] = append(listeners, taggedListener{ruleName: r.Name, fn: listener})
+							registeredListeners[kind] = append(listeners, timedTaggedListener{ruleName: r.Name, ruleIdx: ruleIdx, fn: listener})
 						}
 					}
 
@@ -376,83 +585,30 @@ func RunLinterOnProgram(logLevel utils.LogLevel, program *compiler.Program, file
 						if listeners, ok := registeredListeners[kind]; ok {
 							for _, listener := range listeners {
 								ctxBuilder.ruleName = listener.ruleName
+								start := time.Now()
 								listener.fn(node)
+								recordTiming(&timingStats[listener.ruleIdx], time.Since(start))
 							}
 						}
 					}
 
-					/* convert.ts -> allowPattern:
-					catch name
-					variabledeclaration name
-					forinstatement initializer
-					forofstatement initializer
-					(propagation) allowPattern > arrayliteralexpression elements
-					(propagation) allowPattern > objectliteralexpression properties
-					(propagation) allowPattern > spreadassignment,spreadelement expression
-					(propagation) allowPattern > propertyassignment value
-					arraybindingpattern elements
-					objectbindingpattern elements
-					(init) binaryexpression(with '=' operator') left
-					*/
-
-					var childVisitor ast.Visitor
-					var patternVisitor func(node *ast.Node)
-					patternVisitor = func(node *ast.Node) {
-						runListeners(node.Kind, node)
-						kind := rule.ListenerOnAllowPattern(node.Kind)
-						runListeners(kind, node)
-
-						switch node.Kind {
-						case ast.KindArrayLiteralExpression:
-							for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
-								patternVisitor(element)
-							}
-						case ast.KindObjectLiteralExpression:
-							for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
-								patternVisitor(property)
-							}
-						case ast.KindSpreadElement, ast.KindSpreadAssignment:
-							patternVisitor(node.Expression())
-						case ast.KindPropertyAssignment:
-							patternVisitor(node.Initializer())
-						default:
-							node.ForEachChild(childVisitor)
+					visitLintNodes(file, runListeners)
+					for idx, stat := range timingStats {
+						if stat.Calls == 0 {
+							continue
 						}
-
-						runListeners(rule.ListenerOnExit(kind), node)
-						runListeners(rule.ListenerOnExit(node.Kind), node)
+						merged := localTimings[rules[idx].Name]
+						merged.add(stat)
+						localTimings[rules[idx].Name] = merged
 					}
-					childVisitor = func(node *ast.Node) bool {
-						runListeners(node.Kind, node)
-
-						switch node.Kind {
-						case ast.KindArrayLiteralExpression, ast.KindObjectLiteralExpression:
-							kind := rule.ListenerOnNotAllowPattern(node.Kind)
-							runListeners(kind, node)
-							node.ForEachChild(childVisitor)
-							runListeners(rule.ListenerOnExit(kind), node)
-						default:
-							if ast.IsAssignmentExpression(node, true) {
-								expr := node.AsBinaryExpression()
-								patternVisitor(expr.Left)
-								childVisitor(expr.OperatorToken)
-								childVisitor(expr.Right)
-							} else {
-								node.ForEachChild(childVisitor)
-							}
-						}
-
-						runListeners(rule.ListenerOnExit(node.Kind), node)
-
-						return false
-					}
-					file.Node.ForEachChild(childVisitor)
 					// Instead of clearing the map, we clear the slices in-place to avoid re-allocating memory for the listeners on each file.
 					for k := range registeredListeners {
 						registeredListeners[k] = registeredListeners[k][:0]
 					}
 				}
 			}
+
+			timingStore.merge(localTimings)
 		})
 	}
 	wg.RunAndWait()

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -3,6 +3,7 @@ package linter
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
@@ -54,12 +55,12 @@ function greet(name: string): string {
 	var mu sync.Mutex
 	var diagnostics []rule.RuleDiagnostic
 
-	err = RunLinterOnProgram(
-		utils.LogLevelNormal,
-		program,
-		sourceFiles,
-		1,
-		func(sourceFile *ast.SourceFile) []ConfiguredRule {
+	err = RunLinterOnProgram(RunLinterOnProgramOptions{
+		LogLevel: utils.LogLevelNormal,
+		Program:  program,
+		Files:    sourceFiles,
+		Workers:  1,
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []ConfiguredRule {
 			return []ConfiguredRule{
 				{
 					Name: ruleName,
@@ -76,15 +77,15 @@ function greet(name: string): string {
 				},
 			}
 		},
-		func(d rule.RuleDiagnostic) {
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
 			mu.Lock()
 			defer mu.Unlock()
 			diagnostics = append(diagnostics, d)
 		},
-		func(d diagnostic.Internal) {},
-		Fixes{Fix: false, FixSuggestions: false},
-		TypeErrors{ReportSyntactic: false, ReportSemantic: false},
-	)
+		OnInternalDiagnostic: func(d diagnostic.Internal) {},
+		Fixes:                Fixes{Fix: false, FixSuggestions: false},
+		TypeErrors:           TypeErrors{ReportSyntactic: false, ReportSemantic: false},
+	})
 	assert.NilError(t, err, "unexpected error from RunLinterOnProgram")
 
 	assert.Equal(t, len(diagnostics), 2, "expected exactly two diagnostics")
@@ -137,12 +138,12 @@ function add(a: number, b: number): number {
 	var mu sync.Mutex
 	var diagnostics []rule.RuleDiagnostic
 
-	err = RunLinterOnProgram(
-		utils.LogLevelNormal,
-		program,
-		sourceFiles,
-		1,
-		func(sourceFile *ast.SourceFile) []ConfiguredRule {
+	err = RunLinterOnProgram(RunLinterOnProgramOptions{
+		LogLevel: utils.LogLevelNormal,
+		Program:  program,
+		Files:    sourceFiles,
+		Workers:  1,
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []ConfiguredRule {
 			return []ConfiguredRule{
 				{
 					Name: ruleA,
@@ -166,15 +167,15 @@ function add(a: number, b: number): number {
 				},
 			}
 		},
-		func(d rule.RuleDiagnostic) {
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
 			mu.Lock()
 			defer mu.Unlock()
 			diagnostics = append(diagnostics, d)
 		},
-		func(d diagnostic.Internal) {},
-		Fixes{Fix: false, FixSuggestions: false},
-		TypeErrors{ReportSyntactic: false, ReportSemantic: false},
-	)
+		OnInternalDiagnostic: func(d diagnostic.Internal) {},
+		Fixes:                Fixes{Fix: false, FixSuggestions: false},
+		TypeErrors:           TypeErrors{ReportSyntactic: false, ReportSemantic: false},
+	})
 	assert.NilError(t, err, "unexpected error from RunLinterOnProgram")
 
 	assert.Equal(t, len(diagnostics), 2, "expected exactly two diagnostics")
@@ -226,12 +227,12 @@ func TestRunLinterOnProgram_DiagnosticsEmittedInRun(t *testing.T) {
 	var mu sync.Mutex
 	var diagnostics []rule.RuleDiagnostic
 
-	err = RunLinterOnProgram(
-		utils.LogLevelNormal,
-		program,
-		sourceFiles,
-		1,
-		func(sourceFile *ast.SourceFile) []ConfiguredRule {
+	err = RunLinterOnProgram(RunLinterOnProgramOptions{
+		LogLevel: utils.LogLevelNormal,
+		Program:  program,
+		Files:    sourceFiles,
+		Workers:  1,
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []ConfiguredRule {
 			return []ConfiguredRule{
 				{
 					Name: ruleA,
@@ -255,15 +256,15 @@ func TestRunLinterOnProgram_DiagnosticsEmittedInRun(t *testing.T) {
 				},
 			}
 		},
-		func(d rule.RuleDiagnostic) {
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
 			mu.Lock()
 			defer mu.Unlock()
 			diagnostics = append(diagnostics, d)
 		},
-		func(d diagnostic.Internal) {},
-		Fixes{Fix: false, FixSuggestions: false},
-		TypeErrors{ReportSyntactic: false, ReportSemantic: false},
-	)
+		OnInternalDiagnostic: func(d diagnostic.Internal) {},
+		Fixes:                Fixes{Fix: false, FixSuggestions: false},
+		TypeErrors:           TypeErrors{ReportSyntactic: false, ReportSemantic: false},
+	})
 	assert.NilError(t, err, "unexpected error from RunLinterOnProgram")
 
 	assert.Equal(t, len(diagnostics), 2, "expected exactly two diagnostics")
@@ -280,4 +281,90 @@ func TestRunLinterOnProgram_DiagnosticsEmittedInRun(t *testing.T) {
 
 	assert.Equal(t, diagnostics[1].RuleName, ruleB, "second diagnostic should come from ruleB")
 	assert.Equal(t, diagnostics[1].Message.Id, msgB.Id, "second diagnostic should have ruleB's message")
+}
+
+func TestRunLinterOnProgramWithTimings(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	fileName := "file.ts"
+	filePath := tspath.ResolvePath(rootDir, fileName)
+	code := `
+const x = 1;
+function greet() {
+	return x;
+}
+`
+
+	fs := utils.NewOverlayVFS(
+		cachedBaseFS,
+		map[string]string{filePath: code},
+	)
+	host := utils.CreateCompilerHost(rootDir, fs)
+
+	program, _, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.minimal.json", host, false)
+	assert.NilError(t, err, "couldn't create program")
+
+	sourceFiles := []*ast.SourceFile{program.GetSourceFile(filePath)}
+
+	const ruleA = "timed-variable-rule"
+	const ruleB = "timed-function-rule"
+	const ruleC = "timed-run-only-rule"
+
+	timingStore := NewRuleTimingStore()
+	err = RunLinterOnProgram(RunLinterOnProgramOptions{
+		LogLevel: utils.LogLevelNormal,
+		Program:  program,
+		Files:    sourceFiles,
+		Workers:  1,
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{
+				{
+					Name: ruleA,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						time.Sleep(time.Microsecond)
+						return rule.RuleListeners{
+							ast.KindVariableStatement: func(*ast.Node) {
+								time.Sleep(time.Microsecond)
+							},
+						}
+					},
+				},
+				{
+					Name: ruleB,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return rule.RuleListeners{
+							ast.KindFunctionDeclaration: func(*ast.Node) {
+								time.Sleep(time.Microsecond)
+							},
+						}
+					},
+				},
+				{
+					Name: ruleC,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						time.Sleep(time.Microsecond)
+						return rule.RuleListeners{}
+					},
+				},
+			}
+		},
+		OnDiagnostic:         func(d rule.RuleDiagnostic) {},
+		OnInternalDiagnostic: func(d diagnostic.Internal) {},
+		Fixes:                Fixes{Fix: false, FixSuggestions: false},
+		TypeErrors:           TypeErrors{ReportSyntactic: false, ReportSemantic: false},
+		TimingStore:          timingStore,
+	})
+	assert.NilError(t, err, "unexpected error from RunLinterOnProgramWithTimings")
+
+	records := timingStore.Collect()
+	assert.Equal(t, len(records), 3, "expected timings for each configured rule")
+
+	recordsByRule := make(map[string]RuleTimingRecord, len(records))
+	for _, record := range records {
+		recordsByRule[record.RuleName] = record
+		assert.Assert(t, record.Duration > 0, "timing for %s should record a positive duration", record.RuleName)
+	}
+
+	assert.Equal(t, recordsByRule[ruleA].Calls, uint64(2), "rule A should count Run plus its variable listener")
+	assert.Equal(t, recordsByRule[ruleB].Calls, uint64(2), "rule B should count Run plus its function listener")
+	assert.Equal(t, recordsByRule[ruleC].Calls, uint64(1), "rule C should count its Run call")
 }

--- a/internal/linter/timing.go
+++ b/internal/linter/timing.go
@@ -1,0 +1,70 @@
+package linter
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+type RuleTimingStat struct {
+	Duration time.Duration
+	Calls    uint64
+}
+
+func (s *RuleTimingStat) add(other RuleTimingStat) {
+	s.Duration += other.Duration
+	s.Calls += other.Calls
+}
+
+type RuleTimingRecord struct {
+	RuleName string
+	Duration time.Duration
+	Calls    uint64
+}
+
+type RuleTimingStore struct {
+	mu      sync.Mutex
+	timings map[string]RuleTimingStat
+}
+
+func NewRuleTimingStore() *RuleTimingStore {
+	return &RuleTimingStore{timings: make(map[string]RuleTimingStat)}
+}
+
+func (s *RuleTimingStore) merge(localTimings map[string]RuleTimingStat) {
+	if len(localTimings) == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for ruleName, stat := range localTimings {
+		merged := s.timings[ruleName]
+		merged.add(stat)
+		s.timings[ruleName] = merged
+	}
+}
+
+func (s *RuleTimingStore) Collect() []RuleTimingRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	records := make([]RuleTimingRecord, 0, len(s.timings))
+	for ruleName, stat := range s.timings {
+		records = append(records, RuleTimingRecord{
+			RuleName: ruleName,
+			Duration: stat.Duration,
+			Calls:    stat.Calls,
+		})
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].Duration != records[j].Duration {
+			return records[i].Duration > records[j].Duration
+		}
+		return records[i].RuleName < records[j].RuleName
+	})
+
+	return records
+}

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -112,12 +112,12 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 
 		files := []*ast.SourceFile{sourceFile}
 
-		err = linter.RunLinterOnProgram(
-			utils.LogLevelNormal,
-			program,
-			files,
-			1,
-			func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+		err = linter.RunLinterOnProgram(linter.RunLinterOnProgramOptions{
+			LogLevel: utils.LogLevelNormal,
+			Program:  program,
+			Files:    files,
+			Workers:  1,
+			GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 				return []linter.ConfiguredRule{
 					{
 						Name: "test",
@@ -127,24 +127,24 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 					},
 				}
 			},
-			func(diagnostic rule.RuleDiagnostic) {
+			OnDiagnostic: func(diagnostic rule.RuleDiagnostic) {
 				diagnosticsMu.Lock()
 				defer diagnosticsMu.Unlock()
 
 				diagnostics = append(diagnostics, diagnostic)
 			},
-			func(d diagnostic.Internal) {
+			OnInternalDiagnostic: func(d diagnostic.Internal) {
 				// Internal diagnostics are not used in rule tester
 			},
-			linter.Fixes{
+			Fixes: linter.Fixes{
 				Fix:            true,
 				FixSuggestions: true,
 			},
-			linter.TypeErrors{
+			TypeErrors: linter.TypeErrors{
 				ReportSyntactic: false,
 				ReportSemantic:  false,
 			},
-		)
+		})
 
 		assert.NilError(t, err, "error running linter. code:\n", code)
 


### PR DESCRIPTION
Adds the `--debug timings` option from `oxlint` and serializes it back in headless mode so we can process it in `oxlint`. At the moment, this is enabled from `oxlint` with an environment variable, in order that we don't get an error with using new versions of oxlint with old versions of `tsgolint` that don't support `--debug timings`.

Current overhead with timings enabled is ~8-12%. Hard to tell overhead of the timings code alone, as it is very noisy on my laptop.