### PR TITLE
perf(no-unnecessary-type-parameters): stop counting settled candidates

### DIFF
--- a/internal/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -196,25 +196,35 @@ func classMembers(node *ast.Node) []*ast.Node {
 	}
 }
 
-func countTypeParameterUsage(ctx rule.RuleContext, node *ast.Node) map[*ast.Symbol]int {
+func countTypeParameterUsage(ctx rule.RuleContext, node *ast.Node, targetSymbols map[*ast.Symbol]struct{}) map[*ast.Symbol]int {
 	counts := make(map[*ast.Symbol]int)
+	remainingTargets := len(targetSymbols)
 
 	if ast.IsClassLike(node) {
 		for _, typeParameter := range node.TypeParameters() {
-			collectTypeParameterUsageCounts(ctx, typeParameter, counts, true)
+			if remainingTargets == 0 {
+				break
+			}
+			remainingTargets = collectTypeParameterUsageCounts(ctx, typeParameter, counts, targetSymbols, remainingTargets, true)
 		}
 		if heritageClauses := utils.GetHeritageClauses(node); heritageClauses != nil {
 			for _, heritageClause := range heritageClauses.Nodes {
 				for _, heritageType := range heritageClause.AsHeritageClause().Types.Nodes {
-					collectTypeParameterUsageCounts(ctx, heritageType, counts, true)
+					if remainingTargets == 0 {
+						break
+					}
+					remainingTargets = collectTypeParameterUsageCounts(ctx, heritageType, counts, targetSymbols, remainingTargets, true)
 				}
 			}
 		}
 		for _, member := range classMembers(node) {
-			collectTypeParameterUsageCounts(ctx, member, counts, true)
+			if remainingTargets == 0 {
+				break
+			}
+			remainingTargets = collectTypeParameterUsageCounts(ctx, member, counts, targetSymbols, remainingTargets, true)
 		}
 	} else {
-		collectTypeParameterUsageCounts(ctx, node, counts, false)
+		collectTypeParameterUsageCounts(ctx, node, counts, targetSymbols, remainingTargets, false)
 	}
 
 	return counts
@@ -314,15 +324,26 @@ func collectTypeParameterUsageCounts(
 	ctx rule.RuleContext,
 	node *ast.Node,
 	foundIdentifierUsages map[*ast.Symbol]int,
+	targetSymbols map[*ast.Symbol]struct{},
+	remainingTargets int,
 	fromClass bool,
-) {
+) int {
 	typeUsages := make(map[*checker.Type]int)
 	visitedConstraints := make(map[*ast.Node]bool)
 	visitedDefault := false
 	functionLikeType := false
 
 	incrementIdentifierCount := func(symbol *ast.Symbol, assumeMultipleUses bool) {
+		if remainingTargets == 0 {
+			return
+		}
 		if symbol == nil {
+			return
+		}
+		if _, ok := targetSymbols[symbol]; !ok {
+			return
+		}
+		if foundIdentifierUsages[symbol] > 2 {
 			return
 		}
 		value := 1
@@ -330,6 +351,9 @@ func collectTypeParameterUsageCounts(
 			value = 2
 		}
 		foundIdentifierUsages[symbol] = foundIdentifierUsages[symbol] + value
+		if foundIdentifierUsages[symbol] > 2 {
+			remainingTargets--
+		}
 	}
 
 	incrementTypeUsages := func(t *checker.Type) int {
@@ -345,18 +369,24 @@ func collectTypeParameterUsageCounts(
 
 	visitTypesList = func(types []*checker.Type, assumeMultipleUses bool) {
 		for _, typeNode := range types {
+			if remainingTargets == 0 {
+				return
+			}
 			visitType(typeNode, assumeMultipleUses, false)
 		}
 	}
 
 	visitSymbolsList = func(symbols []*ast.Symbol, assumeMultipleUses bool) {
 		for _, symbol := range symbols {
+			if remainingTargets == 0 {
+				return
+			}
 			visitType(checker.Checker_getTypeOfSymbol(ctx.TypeChecker, symbol), assumeMultipleUses, false)
 		}
 	}
 
 	visitSignature = func(signature *checker.Signature) {
-		if signature == nil {
+		if signature == nil || remainingTargets == 0 {
 			return
 		}
 
@@ -365,10 +395,16 @@ func collectTypeParameterUsageCounts(
 		}
 
 		for _, parameter := range signature.Parameters() {
+			if remainingTargets == 0 {
+				return
+			}
 			visitType(checker.Checker_getTypeOfSymbol(ctx.TypeChecker, parameter), false, false)
 		}
 
 		for _, typeParameter := range signature.TypeParameters() {
+			if remainingTargets == 0 {
+				return
+			}
 			visitType(typeParameter, false, false)
 		}
 
@@ -383,7 +419,7 @@ func collectTypeParameterUsageCounts(
 	}
 
 	visitType = func(typeNode *checker.Type, assumeMultipleUses bool, isReturnType bool) {
-		if typeNode == nil || incrementTypeUsages(typeNode) > 9 {
+		if typeNode == nil || remainingTargets == 0 || incrementTypeUsages(typeNode) > 9 {
 			return
 		}
 
@@ -484,10 +520,16 @@ func collectTypeParameterUsageCounts(
 			visitType(ctx.TypeChecker.GetStringIndexType(typeNode), true, false)
 
 			for _, signature := range ctx.TypeChecker.GetCallSignatures(typeNode) {
+				if remainingTargets == 0 {
+					return
+				}
 				functionLikeType = true
 				visitSignature(signature)
 			}
 			for _, signature := range ctx.TypeChecker.GetConstructSignatures(typeNode) {
+				if remainingTargets == 0 {
+					return
+				}
 				functionLikeType = true
 				visitSignature(signature)
 			}
@@ -510,6 +552,8 @@ func collectTypeParameterUsageCounts(
 	if !functionLikeType {
 		visitType(ctx.TypeChecker.GetTypeAtLocation(node), false, false)
 	}
+
+	return remainingTargets
 }
 
 func checkNoUnnecessaryTypeParametersNode(ctx rule.RuleContext, node *ast.Node, descriptor string) {
@@ -518,9 +562,16 @@ func checkNoUnnecessaryTypeParametersNode(ctx rule.RuleContext, node *ast.Node, 
 		return
 	}
 
-	identifierCounts := countTypeParameterUsage(ctx, node)
 	startOfBody := getStartOfBody(node)
 
+	type candidateTypeParameter struct {
+		node       *ast.Node
+		nameNode   *ast.Node
+		symbol     *ast.Symbol
+		references []*ast.Node
+	}
+
+	candidates := make([]candidateTypeParameter, 0, len(typeParameters))
 	for _, typeParameter := range typeParameters {
 		typeParameterSymbol := symbolFromTypeParameter(ctx, typeParameter)
 		if typeParameterSymbol == nil {
@@ -533,7 +584,24 @@ func checkNoUnnecessaryTypeParametersNode(ctx rule.RuleContext, node *ast.Node, 
 			continue
 		}
 
-		identifierCount, ok := identifierCounts[typeParameterSymbol]
+		candidates = append(candidates, candidateTypeParameter{
+			node:       typeParameter,
+			nameNode:   typeParameterNameNode,
+			symbol:     typeParameterSymbol,
+			references: references,
+		})
+	}
+	if len(candidates) == 0 {
+		return
+	}
+
+	targetSymbols := make(map[*ast.Symbol]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		targetSymbols[candidate.symbol] = struct{}{}
+	}
+	identifierCounts := countTypeParameterUsage(ctx, node, targetSymbols)
+	for _, candidate := range candidates {
+		identifierCount, ok := identifierCounts[candidate.symbol]
 		if !ok || identifierCount > 2 {
 			continue
 		}
@@ -543,26 +611,26 @@ func checkNoUnnecessaryTypeParametersNode(ctx rule.RuleContext, node *ast.Node, 
 			uses = "never used"
 		}
 
-		typeParameterName := typeParameterNameNode.Text()
-		constraintText, constraintNode := getTypeParameterConstraintText(ctx, typeParameter)
-		typeParameterReferenceRange := utils.TrimNodeTextRange(ctx.SourceFile, typeParameterNameNode)
-		if len(references) > 0 {
-			typeParameterReferenceRange = utils.TrimNodeTextRange(ctx.SourceFile, references[0])
+		typeParameterName := candidate.nameNode.Text()
+		constraintText, constraintNode := getTypeParameterConstraintText(ctx, candidate.node)
+		typeParameterReferenceRange := utils.TrimNodeTextRange(ctx.SourceFile, candidate.nameNode)
+		if len(candidate.references) > 0 {
+			typeParameterReferenceRange = utils.TrimNodeTextRange(ctx.SourceFile, candidate.references[0])
 		}
 
 		ctx.ReportDiagnosticWithSuggestions(
 			buildSoleMessage(
-				utils.TrimNodeTextRange(ctx.SourceFile, typeParameter),
+				utils.TrimNodeTextRange(ctx.SourceFile, candidate.node),
 				typeParameterReferenceRange,
 				typeParameterName,
 				uses,
 				descriptor,
 			),
 			func() []rule.RuleSuggestion {
-				removalRange := getTypeParameterListRemovalRange(ctx, typeParameters, typeParameter)
-				fixes := make([]rule.RuleFix, 0, len(references)+1)
+				removalRange := getTypeParameterListRemovalRange(ctx, typeParameters, candidate.node)
+				fixes := make([]rule.RuleFix, 0, len(candidate.references)+1)
 
-				for _, reference := range references {
+				for _, reference := range candidate.references {
 					referenceRange := utils.TrimNodeTextRange(ctx.SourceFile, reference)
 					if referenceRange.Pos() < removalRange.End() && referenceRange.End() > removalRange.Pos() {
 						continue


### PR DESCRIPTION
Improves `no-unnecessary-type-parameters` performance by avoiding the expensive recursive type-usage walk for type parameters that are already obviously safe to skip.

The rule already had an AST-based fast path:

 ```go
isTypeParameterRepeatedInAST(...)
```

but it ran after countTypeParameterUsage, which is the expensive checker-heavy part. This meant we were paying the full recursive type analysis cost even for type parameters that could be ruled out cheaply.

This PR moves that cheap filtering earlier, then narrows the expensive pass to only the remaining candidates.

## Why This Is Faster

The slow path is countTypeParameterUsage, which recursively walks TypeScript types and calls into the checker. On large projects like VS Code, most generic declarations are not reportable because their type parameters are used more than once in the signature.

Before this change, the rule did this for every generic declaration:

 1. recursively count type parameter usage with checker types
 2. collect AST references
 3. skip if the AST already proves the type parameter is repeated

That order wastes work. If the AST can prove the type parameter appears multiple times before the function body, then the rule will not report it, so there is no reason to do the recursive checker walk first.

After this change, the rule does this instead:

 1. collect AST references
 2. keep only type parameters that are still possible reports
 3. recursively count usage only for those candidates
 4. stop counting once every candidate has exceeded the reportable threshold

This keeps the same behavior, but avoids a lot of type-checker and map work on declarations that are never going to produce diagnostics.

## Benchmark

Measured with a shallow clone of microsoft/vscode, using 6,187 src/**/*.ts(x) files through local tsgolint headless.

Environment:

- rule: no-unnecessary-type-parameters

Hyperfine, 3 runs:

| Binary | Mean | User | System |
| --- | ---: | ---: | ---: |
| baseline | 11.333s ± 0.061s | 43.635s | 0.992s |
| patched | 4.002s ± 0.078s | 14.775s | 0.570s |


That is a 2.83x speedup for this isolated rule workload.

fixes #961