### PR TITLE
ci: run windows e2e pnpm commands outside workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
 
       - name: Run e2e tests
         run: |
-          pnpm install --frozen-lockfile
-          pnpm run test
+          pnpm --ignore-workspace install --frozen-lockfile
+          pnpm --ignore-workspace run test
         working-directory: e2e
 
   lint:


### PR DESCRIPTION
Fixes the main-only Windows CI failure exposed after #968 merged.

#968 added a root `pnpm-workspace.yaml` so dprint builds are approved. The Linux e2e job was updated to run the nested `e2e` package with `--ignore-workspace`, but the Windows e2e job only runs on `main` and still used the old workspace-aware commands. That caused the nested e2e install to skip `e2e/node_modules`, leaving `vitest` unavailable.

This applies the same `--ignore-workspace` install and test commands to the Windows e2e job.

Validation:
- `pnpm install --frozen-lockfile`
- `cd e2e && pnpm --ignore-workspace install --frozen-lockfile && pnpm --ignore-workspace exec vitest --version`