### PR TITLE
fix(no-deprecated): fix crash when getting prop name for non-literal

### DIFF
--- a/internal/rules/no_deprecated/no_deprecated.go
+++ b/internal/rules/no_deprecated/no_deprecated.go
@@ -300,7 +300,9 @@ var NoDeprecatedRule = rule.Rule{
 
 				t := ctx.TypeChecker.GetTypeAtLocation(name)
 				if t != nil {
-					if literalType := t.AsLiteralType(); literalType != nil {
+					isLiteralType := t.IsStringLiteral() || t.IsNumberLiteral() || t.IsBigIntLiteral()
+					if isLiteralType {
+						literalType := t.AsLiteralType()
 						if value := literalType.Value(); value != nil {
 							if str, ok := value.(string); ok {
 								return str, true

--- a/internal/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/rules/no_deprecated/no_deprecated_test.go
@@ -501,6 +501,15 @@ exists('/foo');
 		const { [key]: value } = obj;
 	`},
 		{Code: `
+		interface MyInterface {
+			/** @deprecated */
+			prop: string;
+		}
+		declare const obj: MyInterface;
+		declare const key: string;
+		const { [key]: value } = obj;
+	`},
+		{Code: `
 		export class Test {
 	/** @deprecated Use something else instead */
 	public get foo(): number {


### PR DESCRIPTION
Fixes a crash I noticed while linting on `vscode` repository. Related to https://github.com/oxc-project/tsgolint/pull/944. Don't call `.AsLiteralType()` until we've actually checked it is a literal type.