### PR TITLE
test(no-floating-promises): sync tests with typescript-eslint

### DIFF
--- a/internal/rule_tester/__snapshots__/no-floating-promises.snap
+++ b/internal/rule_tester/__snapshots__/no-floating-promises.snap
@@ -310,32 +310,32 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
 ---
 
 [TestNoFloatingPromisesRule/invalid-10 - 1]
-Diagnostic 1: floatingVoid (3:3 - 3:25)
+Diagnostic 1: floatingVoid (3:3 - 3:27)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | async function test() {
-   3 |   Promise.resolve(), 123;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~
-   4 |   123, Promise.resolve();
+   3 |   (Promise.resolve(), 123);
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |   (123, Promise.resolve());
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (4:3 - 4:25)
+Diagnostic 2: floatingVoid (4:3 - 4:27)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
-   3 |   Promise.resolve(), 123;
-   4 |   123, Promise.resolve();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~
-   5 |   123, Promise.resolve(), 123;
+   3 |   (Promise.resolve(), 123);
+   4 |   (123, Promise.resolve());
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 |   (123, Promise.resolve(), 123);
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (5:3 - 5:30)
+Diagnostic 3: floatingVoid (5:3 - 5:32)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
-   4 |   123, Promise.resolve();
-   5 |   123, Promise.resolve(), 123;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |   (123, Promise.resolve());
+   5 |   (123, Promise.resolve(), 123);
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    6 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
@@ -386,12 +386,12 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
 ---
 
 [TestNoFloatingPromisesRule/invalid-15 - 1]
-Diagnostic 1: floating (5:1 - 5:20)
+Diagnostic 1: floating (5:1 - 5:22)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    4 | }
-   5 | 1, returnsPromise();
-     | ~~~~~~~~~~~~~~~~~~~~
+   5 | (1, returnsPromise());
+     | ~~~~~~~~~~~~~~~~~~~~~~
    6 |       
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
@@ -1144,12 +1144,12 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
 ---
 
 [TestNoFloatingPromisesRule/invalid-54 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:41)
+Diagnostic 1: floatingVoid (2:1 - 2:43)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
-   2 | Promise.resolve().finally(() => {}), 123;
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   2 | (Promise.resolve().finally(() => {}), 123);
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
@@ -1632,6 +1632,42 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
    1 | 
    2 | <Promise<number>>{};
      | ~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Suggestion 1: [floatingFixVoid] Add void operator to ignore.
+  Suggestion 2: [floatingFixAwait] Add await operator.
+---
+
+[TestNoFloatingPromisesRule/invalid-97 - 1]
+Diagnostic 1: floatingVoid (2:1 - 2:29)
+Message: Promises must be awaited, add void operator to ignore.
+Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
+   1 | 
+   2 | Promise.reject('foo').then();
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Suggestion 1: [floatingFixVoid] Add void operator to ignore.
+  Suggestion 2: [floatingFixAwait] Add await operator.
+---
+
+[TestNoFloatingPromisesRule/invalid-98 - 1]
+Diagnostic 1: floatingVoid (2:1 - 2:32)
+Message: Promises must be awaited, add void operator to ignore.
+Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
+   1 | 
+   2 | Promise.reject('foo').finally();
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Suggestion 1: [floatingFixVoid] Add void operator to ignore.
+  Suggestion 2: [floatingFixAwait] Add await operator.
+---
+
+[TestNoFloatingPromisesRule/invalid-99 - 1]
+Diagnostic 1: floatingVoid (2:1 - 2:47)
+Message: Promises must be awaited, add void operator to ignore.
+Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
+   1 | 
+   2 | Promise.reject('foo').finally(...[], () => {});
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.

--- a/internal/rules/no_floating_promises/no_floating_promises_test.go
+++ b/internal/rules/no_floating_promises/no_floating_promises_test.go
@@ -105,18 +105,18 @@ async function test() {
     `},
 		{Code: `
 async function test() {
-  Promise.resolve().catch(() => {}), 123;
-  123,
+  (Promise.resolve().catch(() => {}), 123);
+  (123,
     Promise.resolve().then(
       () => {},
       () => {},
-    );
-  123,
+    ));
+  (123,
     Promise.resolve().then(
       () => {},
       () => {},
     ),
-    123;
+    123);
 }
     `},
 		{Code: `
@@ -500,7 +500,7 @@ interface SafeThenable<T> {
   ): SafeThenable<TResult1 | TResult2>;
 }
 let promise: SafeThenable<number> = Promise.resolve(5);
-0, promise;
+(0, promise);
       `,
 			Options: rule_tester.OptionsFromJSON[NoFloatingPromisesOptions](`{"allowForKnownSafePromises": [{"from": "file", "name": "SafeThenable"}]}`),
 		},
@@ -570,7 +570,7 @@ interface SafeThenable<T> {
   ): SafeThenable<TResult1 | TResult2>;
 }
 let promise: () => SafeThenable<number> = () => Promise.resolve(5);
-0, promise();
+(0, promise());
       `,
 			Options: rule_tester.OptionsFromJSON[NoFloatingPromisesOptions](`{"allowForKnownSafePromises": [{"from": "file", "name": "SafeThenable"}]}`),
 		},
@@ -786,6 +786,50 @@ declare function createMyThenable(): MyThenable;
 
 createMyThenable();
     `},
+		{
+			Code: `
+const randomAsyncFunction = async () => {
+  return Promise.resolve(true);
+};
+
+randomAsyncFunction();
+      `,
+			Options: rule_tester.OptionsFromJSON[NoFloatingPromisesOptions](`{"allowForKnownSafeCalls": ["randomAsyncFunction"]}`),
+		},
+		{
+			Code: `
+async function myAsyncFunction() {
+  return Promise.resolve('test');
+}
+
+myAsyncFunction();
+      `,
+			Options: rule_tester.OptionsFromJSON[NoFloatingPromisesOptions](`{"allowForKnownSafeCalls": ["myAsyncFunction"]}`),
+		},
+		{
+			Skip: true,
+			Code: `
+      interface CustomNode<P> {
+        getNextNode: () => CustomNode<P>;
+      }
+
+      declare const createNode: () => {
+        getNextNode: <T>() => CustomNode<T>;
+      };
+
+      function wrapNode<T>(getNode: () => CustomNode<T>) {
+        return getNode;
+      }
+
+      (async () => {
+        wrapNode(() => {
+          const node = createNode();
+
+          return wrapNode<typeof node.getNextNode<any>>(node.getNextNode);
+        });
+      })().catch(() => {});
+    `,
+		},
 		{
 			Code: `
 interface SafePromise<T> extends Promise<T> {
@@ -1928,9 +1972,9 @@ async function test() {
 		{
 			Code: `
 async function test() {
-  Promise.resolve(), 123;
-  123, Promise.resolve();
-  123, Promise.resolve(), 123;
+  (Promise.resolve(), 123);
+  (123, Promise.resolve());
+  (123, Promise.resolve(), 123);
 }
       `,
 			Errors: []rule_tester.InvalidTestCaseError{
@@ -1943,8 +1987,8 @@ async function test() {
 							Output: `
 async function test() {
   void (Promise.resolve(), 123);
-  123, Promise.resolve();
-  123, Promise.resolve(), 123;
+  (123, Promise.resolve());
+  (123, Promise.resolve(), 123);
 }
       `,
 						},
@@ -1953,8 +1997,8 @@ async function test() {
 							Output: `
 async function test() {
   await (Promise.resolve(), 123);
-  123, Promise.resolve();
-  123, Promise.resolve(), 123;
+  (123, Promise.resolve());
+  (123, Promise.resolve(), 123);
 }
       `,
 						},
@@ -1968,9 +2012,9 @@ async function test() {
 							MessageId: "floatingFixVoid",
 							Output: `
 async function test() {
-  Promise.resolve(), 123;
+  (Promise.resolve(), 123);
   void (123, Promise.resolve());
-  123, Promise.resolve(), 123;
+  (123, Promise.resolve(), 123);
 }
       `,
 						},
@@ -1978,9 +2022,9 @@ async function test() {
 							MessageId: "floatingFixAwait",
 							Output: `
 async function test() {
-  Promise.resolve(), 123;
+  (Promise.resolve(), 123);
   await (123, Promise.resolve());
-  123, Promise.resolve(), 123;
+  (123, Promise.resolve(), 123);
 }
       `,
 						},
@@ -1994,8 +2038,8 @@ async function test() {
 							MessageId: "floatingFixVoid",
 							Output: `
 async function test() {
-  Promise.resolve(), 123;
-  123, Promise.resolve();
+  (Promise.resolve(), 123);
+  (123, Promise.resolve());
   void (123, Promise.resolve(), 123);
 }
       `,
@@ -2004,8 +2048,8 @@ async function test() {
 							MessageId: "floatingFixAwait",
 							Output: `
 async function test() {
-  Promise.resolve(), 123;
-  123, Promise.resolve();
+  (Promise.resolve(), 123);
+  (123, Promise.resolve());
   await (123, Promise.resolve(), 123);
 }
       `,
@@ -2121,7 +2165,7 @@ await /* ... */ returnsPromise();
 async function returnsPromise() {
   return 'value';
 }
-1, returnsPromise();
+(1, returnsPromise());
       `,
 			Options: rule_tester.OptionsFromJSON[NoFloatingPromisesOptions](`{"ignoreVoid": false}`),
 			Errors: []rule_tester.InvalidTestCaseError{
@@ -4443,7 +4487,7 @@ await promiseIntersection.finally(() => {});
 		},
 		{
 			Code: `
-Promise.resolve().finally(() => {}), 123;
+(Promise.resolve().finally(() => {}), 123);
       `,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -5459,6 +5503,182 @@ void (<Promise<number>>{});
 							MessageId: "floatingFixAwait",
 							Output: `
 await (<Promise<number>>{});
+      `,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+Promise.reject('foo').then();
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "floatingVoid",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "floatingFixVoid",
+							Output: `
+void Promise.reject('foo').then();
+      `,
+						},
+						{
+							MessageId: "floatingFixAwait",
+							Output: `
+await Promise.reject('foo').then();
+      `,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+Promise.reject('foo').finally();
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "floatingVoid",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "floatingFixVoid",
+							Output: `
+void Promise.reject('foo').finally();
+      `,
+						},
+						{
+							MessageId: "floatingFixAwait",
+							Output: `
+await Promise.reject('foo').finally();
+      `,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+Promise.reject('foo').finally(...[], () => {});
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "floatingVoid",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "floatingFixVoid",
+							Output: `
+void Promise.reject('foo').finally(...[], () => {});
+      `,
+						},
+						{
+							MessageId: "floatingFixAwait",
+							Output: `
+await Promise.reject('foo').finally(...[], () => {});
+      `,
+						},
+					},
+				},
+			},
+		},
+		{
+			Skip: true,
+			Code: `
+Promise.reject('foo').then(...[], () => {});
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "floatingVoid",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "floatingFixVoid",
+							Output: `
+void Promise.reject('foo').then(...[], () => {});
+      `,
+						},
+						{
+							MessageId: "floatingFixAwait",
+							Output: `
+await Promise.reject('foo').then(...[], () => {});
+      `,
+						},
+					},
+				},
+			},
+		},
+		{
+			Skip: true,
+			Code: `
+        interface CustomNode<P> {
+          getNextNode: () => CustomNode<P>;
+        }
+
+        declare const createNode: () => {
+          getNextNode: <T>() => CustomNode<T>;
+        };
+
+        function wrapNode<T>(getNode: () => CustomNode<T>) {
+          return getNode;
+        }
+
+        (async () => {
+          wrapNode(() => {
+            const node = createNode();
+
+            return wrapNode<typeof node.getNextNode<any>>(node.getNextNode);
+          });
+        })();
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "floatingVoid",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "floatingFixVoid",
+							Output: `
+        interface CustomNode<P> {
+          getNextNode: () => CustomNode<P>;
+        }
+
+        declare const createNode: () => {
+          getNextNode: <T>() => CustomNode<T>;
+        };
+
+        function wrapNode<T>(getNode: () => CustomNode<T>) {
+          return getNode;
+        }
+
+        void (async () => {
+          wrapNode(() => {
+            const node = createNode();
+
+            return wrapNode<typeof node.getNextNode<any>>(node.getNextNode);
+          });
+        })();
+      `,
+						},
+						{
+							MessageId: "floatingFixAwait",
+							Output: `
+        interface CustomNode<P> {
+          getNextNode: () => CustomNode<P>;
+        }
+
+        declare const createNode: () => {
+          getNextNode: <T>() => CustomNode<T>;
+        };
+
+        function wrapNode<T>(getNode: () => CustomNode<T>) {
+          return getNode;
+        }
+
+        await (async () => {
+          wrapNode(() => {
+            const node = createNode();
+
+            return wrapNode<typeof node.getNextNode<any>>(node.getNextNode);
+          });
+        })();
       `,
 						},
 					},


### PR DESCRIPTION
## Summary

Sync `no-floating-promises` tests with the current typescript-eslint upstream test file.

Upstream test file: `packages/eslint-plugin/tests/rules/no-floating-promises.test.ts`
Upstream head: `a56a1851806a58814913ba8abd7bfb640be854d0`

Changes from typescript-eslint included here:
- typescript-eslint/typescript-eslint#11430
- typescript-eslint/typescript-eslint#11496
- typescript-eslint/typescript-eslint#11505
- typescript-eslint/typescript-eslint#12294

Notes:
- Preserved the local safe-promise intersection regression case from oxc-project/tsgolint#958.
- Imported the recursive `CustomNode` cases but marked them skipped locally because they currently send typescript-go into indefinite recursion.


This exposes follow-up rule behavior still needed for full upstream parity.