### PR TITLE
fix(no-floating-promises): handle spread arguments before rejection handlers

### DIFF
--- a/internal/rule_tester/__snapshots__/no-floating-promises.snap
+++ b/internal/rule_tester/__snapshots__/no-floating-promises.snap
@@ -1672,3 +1672,15 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
+
+[TestNoFloatingPromisesRule/invalid-100 - 1]
+Diagnostic 1: floatingVoid (2:1 - 2:44)
+Message: Promises must be awaited, add void operator to ignore.
+Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
+   1 | 
+   2 | Promise.reject('foo').then(...[], () => {});
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Suggestion 1: [floatingFixVoid] Add void operator to ignore.
+  Suggestion 2: [floatingFixAwait] Add await operator.
+---

--- a/internal/rules/no_floating_promises/no_floating_promises.go
+++ b/internal/rules/no_floating_promises/no_floating_promises.go
@@ -244,6 +244,18 @@ var NoFloatingPromisesRule = rule.Rule{
 			return len(utils.GetCallSignatures(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(rejectionHandler))) > 0
 		}
 
+		isKnownArgumentAt := func(args *ast.ArgumentList, index int) bool {
+			if len(args.Nodes) <= index {
+				return false
+			}
+			for _, arg := range args.Nodes[:index+1] {
+				if ast.IsSpreadElement(arg) {
+					return false
+				}
+			}
+			return true
+		}
+
 		var isUnhandledPromise func(
 			node *ast.Node,
 		) (
@@ -315,12 +327,18 @@ var NoFloatingPromisesRule = rule.Rule{
 					methodName, _ := checker.Checker_getAccessedPropertyName(ctx.TypeChecker, callee)
 
 					if methodName == "catch" && len(callExpr.Arguments.Nodes) >= 1 {
+						if !isKnownArgumentAt(callExpr.Arguments, 0) {
+							return true, false, false
+						}
 						if isValidRejectionHandler(callExpr.Arguments.Nodes[0]) {
 							return false, false, false
 						}
 						return true, true, false
 					}
 					if methodName == "then" && len(callExpr.Arguments.Nodes) >= 2 {
+						if !isKnownArgumentAt(callExpr.Arguments, 1) {
+							return true, false, false
+						}
 						if isValidRejectionHandler(callExpr.Arguments.Nodes[1]) {
 							return false, false, false
 						}

--- a/internal/rules/no_floating_promises/no_floating_promises_test.go
+++ b/internal/rules/no_floating_promises/no_floating_promises_test.go
@@ -5582,7 +5582,6 @@ await Promise.reject('foo').finally(...[], () => {});
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 Promise.reject('foo').then(...[], () => {});
       `,


### PR DESCRIPTION
Stacked on #975.

This re-enables the spread-argument `.then(...[], handler)` no-floating-promises test by treating arguments after a spread as unknown when deciding whether a rejection handler is definitely present.
