### PR TITLE
test(no-floating-promises): re-enable recursive type argument cases

### DIFF
--- a/internal/rule_tester/__snapshots__/no-floating-promises.snap
+++ b/internal/rule_tester/__snapshots__/no-floating-promises.snap
@@ -1684,3 +1684,38 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
+
+[TestNoFloatingPromisesRule/invalid-101 - 1]
+Diagnostic 1: floatingVoid (14:9 - 20:13)
+Message: Promises must be awaited, add void operator to ignore.
+Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
+  13 | 
+  14 |         (async () => {
+     |         ~~~~~~~~~~~~~~
+  15 |           wrapNode(() => {
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  16 |             const node = createNode();
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  17 | 
+  18 |             return wrapNode<typeof node.getNextNode<any>>(node.getNextNode);
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  19 |           });
+     | ~~~~~~~~~~~~~
+  20 |         })();
+     | ~~~~~~~~~~~~~
+  21 |       
+  Suggestion 1: [floatingFixVoid] Add void operator to ignore.
+  Suggestion 2: [floatingFixAwait] Add await operator.
+---
+
+[TestNoFloatingPromisesRule/invalid-102 - 1]
+Diagnostic 1: floatingVoid (4:1 - 4:22)
+Message: Promises must be awaited, add void operator to ignore.
+Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
+   3 | 
+   4 | maybePromise('value');
+     | ~~~~~~~~~~~~~~~~~~~~~~
+   5 |       
+  Suggestion 1: [floatingFixVoid] Add void operator to ignore.
+  Suggestion 2: [floatingFixAwait] Add await operator.
+---

--- a/internal/rules/no_floating_promises/no_floating_promises.go
+++ b/internal/rules/no_floating_promises/no_floating_promises.go
@@ -200,6 +200,54 @@ var NoFloatingPromisesRule = rule.Rule{
 			}
 			return false
 		}
+		var returnTypeNeedsCallInstantiation func(t *checker.Type) bool
+		returnTypeNeedsCallInstantiation = func(t *checker.Type) bool {
+			if t.Flags()&checker.TypeFlagsInstantiableNonPrimitive != 0 {
+				return true
+			}
+			if t.Flags()&checker.TypeFlagsUnionOrIntersection != 0 {
+				for _, part := range t.Types() {
+					if returnTypeNeedsCallInstantiation(part) {
+						return true
+					}
+				}
+			}
+
+			for _, typePart := range utils.UnionTypeParts(t) {
+				apparent := checker.Checker_getApparentType(ctx.TypeChecker, typePart)
+				if !checker.Checker_isArrayType(ctx.TypeChecker, apparent) && !checker.IsTupleType(apparent) {
+					continue
+				}
+				for _, typeArg := range checker.Checker_getTypeArguments(ctx.TypeChecker, apparent) {
+					if returnTypeNeedsCallInstantiation(typeArg) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+		callReturnsKnownNonPromise := func(callExpr *ast.CallExpression) bool {
+			calleeType := ctx.TypeChecker.GetTypeAtLocation(callExpr.Expression)
+			signatures := utils.GetCallSignatures(ctx.TypeChecker, calleeType)
+			if len(signatures) == 0 {
+				return false
+			}
+
+			for _, signature := range signatures {
+				returnType := checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, signature)
+				if returnType == nil || returnType.Flags()&checker.TypeFlagsTypeParameter != 0 {
+					return false
+				}
+				if returnTypeNeedsCallInstantiation(returnType) {
+					return false
+				}
+				if isPromiseArray(callExpr.AsNode(), returnType) || isPromiseLike(callExpr.AsNode(), returnType) {
+					return false
+				}
+			}
+
+			return true
+		}
 
 		isKnownSafePromiseReturn := func(node *ast.Node) bool {
 			if len(opts.AllowForKnownSafeCalls) == 0 {
@@ -295,6 +343,10 @@ var NoFloatingPromisesRule = rule.Rule{
 
 			// Check the type. At this point it can't be unhandled if it isn't a promise
 			// or array thereof.
+
+			if ast.IsCallExpression(node) && callReturnsKnownNonPromise(node.AsCallExpression()) {
+				return false, false, false
+			}
 
 			t := ctx.TypeChecker.GetTypeAtLocation(node)
 			if isPromiseArray(node, t) {

--- a/internal/rules/no_floating_promises/no_floating_promises_test.go
+++ b/internal/rules/no_floating_promises/no_floating_promises_test.go
@@ -807,7 +807,6 @@ myAsyncFunction();
 			Options: rule_tester.OptionsFromJSON[NoFloatingPromisesOptions](`{"allowForKnownSafeCalls": ["myAsyncFunction"]}`),
 		},
 		{
-			Skip: true,
 			Code: `
       interface CustomNode<P> {
         getNextNode: () => CustomNode<P>;
@@ -5606,7 +5605,6 @@ await Promise.reject('foo').then(...[], () => {});
 			},
 		},
 		{
-			Skip: true,
 			Code: `
         interface CustomNode<P> {
           getNextNode: () => CustomNode<P>;
@@ -5678,6 +5676,36 @@ await Promise.reject('foo').then(...[], () => {});
             return wrapNode<typeof node.getNextNode<any>>(node.getNextNode);
           });
         })();
+      `,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+declare function maybePromise<T>(value: T): T extends string ? Promise<void> : void;
+
+maybePromise('value');
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "floatingVoid",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "floatingFixVoid",
+							Output: `
+declare function maybePromise<T>(value: T): T extends string ? Promise<void> : void;
+
+void maybePromise('value');
+      `,
+						},
+						{
+							MessageId: "floatingFixAwait",
+							Output: `
+declare function maybePromise<T>(value: T): T extends string ? Promise<void> : void;
+
+await maybePromise('value');
       `,
 						},
 					},


### PR DESCRIPTION
Re-enable the valid and invalid recursive `CustomNode` type-argument cases. The handled async call must lint cleanly, while the unhandled call must still report a floating promise.

Both cases now pass with the repository's current typescript-go revision using normal call resolution, so no checker workaround is needed. The snapshot reflects the current diagnostic labels and ranges.

#978 is stacked on this PR.
