### PR TITLE
test(no-floating-promises): re-enable node test allowlist case

### DIFF
--- a/internal/rules/no_floating_promises/no_floating_promises_test.go
+++ b/internal/rules/no_floating_promises/no_floating_promises_test.go
@@ -751,7 +751,6 @@ promise().then(() => {});
 			Options: rule_tester.OptionsFromJSON[NoFloatingPromisesOptions](`{"allowForKnownSafeCalls": [{"from": "package", "name": "it", "package": "abc"}]}`),
 		},
 		{
-			Skip: true,
 			Code: `
         import { it } from 'node:test';
 


### PR DESCRIPTION
Stacked on #977; merge #977 first.

Re-enable the `allowForKnownSafeCalls` case for `it` from `node:test`. Use a self-contained ambient declaration fixture with a promise-returning function and a negative control that reports the same call without the allowlist, so the test does not pass merely because Node's declarations are unavailable.
