### PR TITLE
test(no-deprecated): cover call and jsx deprecated properties

### DIFF
--- a/internal/rule_tester/__snapshots__/no-deprecated.snap
+++ b/internal/rule_tester/__snapshots__/no-deprecated.snap
@@ -1290,3 +1290,19 @@ Message: `statusCode` is deprecated. Use status instead.
      |           ~~~~~~~~~~
   13 |         });
 ---
+
+[TestNoDeprecatedRule/invalid-147 - 1]
+Diagnostic 1: deprecated (9:7 - 9:11)
+Message: `field` is deprecated.
+   8 | }
+   9 | bar({ field: 0 });
+     |       ~~~~~
+---
+
+[TestNoDeprecatedRule/invalid-148 - 1]
+Diagnostic 1: deprecated (9:18 - 9:22)
+Message: `field` is deprecated.
+   8 | }
+   9 | const jsx = <Foo field={0} />;
+     |                  ~~~~~
+---

--- a/internal/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/rules/no_deprecated/no_deprecated_test.go
@@ -2794,5 +2794,44 @@ exists('/foo');
 				},
 			},
 		},
+		{
+			Code: `interface Something {
+  /**
+   * @deprecated
+   */
+  field: number;
+}
+function bar(_options: Something) {
+}
+bar({ field: 0 });`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "deprecated",
+					Line:      9,
+					Column:    7,
+					EndColumn: 12,
+				},
+			},
+		},
+		{
+			Tsx: true,
+			Code: `interface SomethingProps {
+  /**
+   * @deprecated
+   */
+  field: number;
+}
+function Foo(props: SomethingProps) {
+}
+const jsx = <Foo field={0} />;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "deprecated",
+					Line:      9,
+					Column:    18,
+					EndColumn: 23,
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
adds additional tests for https://github.com/oxc-project/oxc/issues/22779
follow on from https://github.com/oxc-project/tsgolint/pull/944