### PR TITLE
fix(prefer-optional-chain): suggest unsafe nullish rewrite

### DIFF
--- a/internal/rule_tester/__snapshots__/prefer-optional-chain.snap
+++ b/internal/rule_tester/__snapshots__/prefer-optional-chain.snap
@@ -5379,3 +5379,13 @@ Message: Prefer using an optional chain expression instead, as it's more concise
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    5 | 
 ---
+
+[TestPreferOptionalChainRule/invalid-600 - 1]
+Diagnostic 1: preferOptionalChain (3:1 - 3:41)
+Message: Prefer using an optional chain expression instead, as it's more concise and easier to read.
+   2 | declare const item: { value: string | null } | undefined;
+   3 | item === undefined || item.value === null;
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 | 
+  Suggestion 1: [optionalChainSuggest] Change to an optional chain.
+---

--- a/internal/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -103,6 +103,32 @@ func isStrictNullComparison(op Operand) bool {
 	return isComparisonAgainst(op, utils.IsNullLiteral)
 }
 
+func isStrictNullCheckForOrChain(op Operand) bool {
+	switch op.typ {
+	case OperandTypeStrictEqualNull, OperandTypeNotStrictEqualNull:
+		return true
+	case OperandTypeComparison:
+		if bin := unwrapBinary(op.node); bin != nil {
+			return bin.operator == ast.KindEqualsEqualsEqualsToken &&
+				(utils.IsNullLiteral(bin.left) || utils.IsNullLiteral(bin.right))
+		}
+	}
+	return false
+}
+
+func isStrictUndefinedCheckForOrChain(op Operand) bool {
+	switch op.typ {
+	case OperandTypeStrictEqualUndef, OperandTypeNotStrictEqualUndef, OperandTypeTypeofCheck:
+		return true
+	case OperandTypeComparison:
+		if bin := unwrapBinary(op.node); bin != nil {
+			return bin.operator == ast.KindEqualsEqualsEqualsToken &&
+				(utils.IsUndefinedLiteral(bin.left) || utils.IsUndefinedLiteral(bin.right))
+		}
+	}
+	return false
+}
+
 func isOrChainNullishCheck(op Operand) bool {
 	switch op.typ {
 	case OperandTypeStrictEqualNull, OperandTypeStrictEqualUndef, OperandTypeEqualNull:
@@ -201,6 +227,34 @@ func analyzeNullishChecks(chain []Operand, orChainMode bool) NullishCheckAnalysi
 	}
 
 	return analysis
+}
+
+func (processor *chainProcessor) hasShorterUndefinedCheckBeforeStrictNullComparison(chain []Operand) bool {
+	if len(chain) < 2 {
+		return false
+	}
+
+	lastOp := chain[len(chain)-1]
+	if !isStrictNullCheckForOrChain(lastOp) || lastOp.comparedExpr == nil {
+		return false
+	}
+
+	lastParts := processor.flattenForFix(lastOp.comparedExpr)
+	for _, op := range chain[:len(chain)-1] {
+		if op.comparedExpr == nil {
+			continue
+		}
+		if !isStrictUndefinedCheckForOrChain(op) {
+			continue
+		}
+
+		opParts := processor.flattenForFix(op.comparedExpr)
+		if len(opParts) < len(lastParts) {
+			return true
+		}
+	}
+
+	return false
 }
 
 type Operand struct {
@@ -3587,6 +3641,9 @@ func (processor *chainProcessor) generateOrChainFixAndReport(node *ast.Node, cha
 					strictCheckRequiresSuggestion = true
 				}
 			}
+		}
+		if !strictCheckRequiresSuggestion {
+			strictCheckRequiresSuggestion = processor.hasShorterUndefinedCheckBeforeStrictNullComparison(chain)
 		}
 		if !strictCheckRequiresSuggestion {
 			useSuggestion = false

--- a/internal/rules/prefer_optional_chain/prefer_optional_chain_test.go
+++ b/internal/rules/prefer_optional_chain/prefer_optional_chain_test.go
@@ -4250,5 +4250,26 @@ declare const text: string | undefined;
 		Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
 	})
 
+	invalidCases = append(invalidCases, rule_tester.InvalidTestCase{
+		Code: `
+declare const item: { value: string | null } | undefined;
+item === undefined || item.value === null;
+`,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				MessageId: "preferOptionalChain",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{
+						MessageId: "optionalChainSuggest",
+						Output: `
+declare const item: { value: string | null } | undefined;
+item?.value === null;
+`,
+					},
+				},
+			},
+		},
+	})
+
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferOptionalChainRule, validCases, invalidCases)
 }


### PR DESCRIPTION
**Summary**

- Treat optional-chain rewrites like `item === undefined || item.value === null` as suggestions instead of autofixes.
- Add a regression case and snapshot for the unsafe strict undefined-prefix plus strict null comparison pattern.
- Keep the new structural check lazy so it only runs when the diagnostic path still needs to decide between a fix and a suggestion.

Fixes oxc-project/oxc#22860