### PR TITLE
fix(no-unnecessary-type-assertion): enable skipped upstream cases

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-type-assertion.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-type-assertion.snap
@@ -1138,3 +1138,495 @@ Message: This assertion is unnecessary since it does not change the type of the 
      |            ^^^^^^^^^^^^^^^^^^^^^ Casting it to 'string' is unnecessary
    5 | 
 ---
+
+[TestNoUnnecessaryTypeAssertion/invalid-72 - 1]
+Diagnostic 1: unnecessaryAssertion (2:25 - 2:36)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   1 | 
+   2 | ((): undefined => {})() as undefined;
+     |                         ~~~~~~~~~~~~
+   3 |       
+  Label: This expression already has the type 'undefined' (2:1 - 2:23)
+   1 | 
+   2 | ((): undefined => {})() as undefined;
+     | ^^^^^^^^^^^^^^^^^^^^^^^ This expression already has the type 'undefined'
+   3 |       
+  Label: Casting it to 'undefined' is unnecessary (2:25 - 2:36)
+   1 | 
+   2 | ((): undefined => {})() as undefined;
+     |                         ^^^^^^^^^^^^ Casting it to 'undefined' is unnecessary
+   3 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-73 - 1]
+Diagnostic 1: unnecessaryAssertion (2:13 - 2:21)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   1 | 
+   2 | (() => 1)() as number;
+     |             ~~~~~~~~~
+   3 |       
+  Label: This expression already has the type 'number' (2:1 - 2:11)
+   1 | 
+   2 | (() => 1)() as number;
+     | ^^^^^^^^^^^ This expression already has the type 'number'
+   3 |       
+  Label: Casting it to 'number' is unnecessary (2:13 - 2:21)
+   1 | 
+   2 | (() => 1)() as number;
+     |             ^^^^^^^^^ Casting it to 'number' is unnecessary
+   3 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-74 - 1]
+Diagnostic 1: unnecessaryAssertion (7:35 - 7:46)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   6 | 
+   7 | ((value => {}) as Overloaded)('') as undefined;
+     |                                   ~~~~~~~~~~~~
+   8 |       
+  Label: This expression already has the type 'undefined' (7:1 - 7:33)
+   6 | 
+   7 | ((value => {}) as Overloaded)('') as undefined;
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This expression already has the type 'undefined'
+   8 |       
+  Label: Casting it to 'undefined' is unnecessary (7:35 - 7:46)
+   6 | 
+   7 | ((value => {}) as Overloaded)('') as undefined;
+     |                                   ^^^^^^^^^^^^ Casting it to 'undefined' is unnecessary
+   8 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-75 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:9 - 3:16)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | function doThing(a: number) {}
+   3 | doThing(5 as any);
+     |         ~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-76 - 1]
+Diagnostic 1: contextuallyUnnecessary (7:9 - 7:51)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   6 | function doThing(a: A) {}
+   7 | doThing({ required: 'yes', alsoRequired: 1 } as any);
+     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   8 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-77 - 1]
+Diagnostic 1: unnecessaryAssertion (1:11 - 1:23)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   1 | const x = 5 as any as 5;
+     |           ~~~~~~~~~~~~~
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-78 - 1]
+Diagnostic 1: unnecessaryAssertion (3:11 - 3:32)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   2 | const v: number = 5;
+   3 | const x = v as unknown as number;
+     |           ~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-79 - 1]
+Diagnostic 1: unnecessaryAssertion (3:11 - 3:28)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   2 | const v: number = 5;
+   3 | const x = v as any as number;
+     |           ~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-80 - 1]
+Diagnostic 1: unnecessaryAssertion (2:11 - 2:34)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   1 | 
+   2 | const x = (1 + 1) as any as number;
+     |           ~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-81 - 1]
+Diagnostic 1: unnecessaryAssertion (2:16 - 2:39)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   1 | 
+   2 | const x = 2 * ((1 + 1) as any as number);
+     |                ~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-82 - 1]
+Diagnostic 1: unnecessaryAssertion (3:11 - 3:26)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   2 | const v: number = 5;
+   3 | const x = <number>(<any>v);
+     |           ~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-83 - 1]
+Diagnostic 1: unnecessaryAssertion (3:18 - 3:34)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   2 | const obj = { id: '' };
+   3 | const obj2 = obj as { id: string };
+     |                  ~~~~~~~~~~~~~~~~~
+   4 |       
+  Label: This expression already has the type '{ id: string; }' (3:14 - 3:16)
+   2 | const obj = { id: '' };
+   3 | const obj2 = obj as { id: string };
+     |              ^^^ This expression already has the type '{ id: string; }'
+   4 |       
+  Label: Casting it to '{ id: string; }' is unnecessary (3:18 - 3:34)
+   2 | const obj = { id: '' };
+   3 | const obj2 = obj as { id: string };
+     |                  ^^^^^^^^^^^^^^^^^ Casting it to '{ id: string; }' is unnecessary
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-84 - 1]
+Diagnostic 1: unnecessaryAssertion (3:14 - 3:41)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   2 | const obj = { id: '' };
+   3 | const obj2 = obj as any as { id: string };
+     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-85 - 1]
+Diagnostic 1: unnecessaryAssertion (3:14 - 3:45)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   2 | const obj = { id: '' };
+   3 | const obj2 = obj as unknown as { id: string };
+     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-86 - 1]
+Diagnostic 1: unnecessaryAssertion (3:16 - 3:39)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   2 | const array = ['a', 'b'];
+   3 | const array2 = array as any as string[];
+     |                ~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-87 - 1]
+Diagnostic 1: unnecessaryAssertion (3:16 - 3:43)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   2 | const array = ['a', 'b'];
+   3 | const array2 = array as unknown as string[];
+     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-88 - 1]
+Diagnostic 1: contextuallyUnnecessary (7:4 - 7:12)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   6 | const a: A = 'a';
+   7 | fn(a as AorB);
+     |    ~~~~~~~~~
+   8 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-89 - 1]
+Diagnostic 1: unnecessaryAssertion (5:11 - 5:38)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   4 | }
+   5 | const x = { a: 1 } as unknown as Props;
+     |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-90 - 1]
+Diagnostic 1: unnecessaryAssertion (5:20 - 5:27)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   4 | }
+   5 | const x = { a: 1 } as Props;
+     |                    ~~~~~~~~
+   6 |       
+  Label: This expression already has the type '{ a: number; }' (5:11 - 5:18)
+   4 | }
+   5 | const x = { a: 1 } as Props;
+     |           ^^^^^^^^ This expression already has the type '{ a: number; }'
+   6 |       
+  Label: Casting it to 'Props' is unnecessary (5:20 - 5:27)
+   4 | }
+   5 | const x = { a: 1 } as Props;
+     |                    ^^^^^^^^ Casting it to 'Props' is unnecessary
+   6 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-91 - 1]
+Diagnostic 1: unnecessaryAssertion (5:25 - 5:54)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   4 | }
+   5 | const fn = (): Props => ({ a: 1 }) as unknown as Props;
+     |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-92 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:4 - 3:26)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function fn(param: number): void;
+   3 | fn(42 as unknown as number);
+     |    ~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-93 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:4 - 3:22)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function fn(param: number): void;
+   3 | fn(42 as any as number);
+     |    ~~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-94 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:13 - 3:24)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function fn(params: { param: number });
+   3 | fn({ param: 42 as number });
+     |             ~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-95 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:13 - 3:21)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function fn(params: { param: number });
+   3 | fn({ param: 42 as any });
+     |             ~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-96 - 1]
+Diagnostic 1: contextuallyUnnecessary (4:4 - 4:30)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   3 | declare function fn(param: StringOrNumber);
+   4 | fn(42 as any as StringOrNumber);
+     |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-97 - 1]
+Diagnostic 1: contextuallyUnnecessary (5:12 - 5:32)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   4 | const data = { a: 1 };
+   5 | fn({ data: data as NumbersRecord });
+     |            ~~~~~~~~~~~~~~~~~~~~~
+   6 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-98 - 1]
+Diagnostic 1: contextuallyUnnecessary (5:9 - 7:20)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   4 | fn({
+   5 |   data: {
+     |         ~
+   6 |     a: 1,
+     | ~~~~~~~~~
+   7 |   } as NumbersRecord,
+     | ~~~~~~~~~~~~~~~~~~~~
+   8 | });
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-99 - 1]
+Diagnostic 1: unnecessaryAssertion (5:16 - 5:74)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   4 | declare const updatedColumn: Json;
+   5 | const result = updatedColumn as unknown as Tables<'my_table'>['my_column'];
+     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-100 - 1]
+Diagnostic 1: contextuallyUnnecessary (6:12 - 6:23)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   5 | declare function fn<U extends T>(args: Pick<U, 'a'>): void;
+   6 | fn<T>({ a: '' as string });
+     |            ~~~~~~~~~~~~
+   7 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-101 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:8 - 3:32)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function update<T extends string>(value: T): void;
+   3 | update('hi' as unknown as string);
+     |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-102 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:8 - 3:21)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function update<T extends string>(value: T): void;
+   3 | update('hi' as string);
+     |        ~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-103 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:4 - 3:19)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function fn(x: string[]): void;
+   3 | fn(['hello'] as any);
+     |    ~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-104 - 1]
+Diagnostic 1: contextuallyUnnecessary (6:16 - 6:29)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   5 | declare const chat: ChatMessage[];
+   6 | update({ chat: chat as Json[] });
+     |                ~~~~~~~~~~~~~~
+   7 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-105 - 1]
+Diagnostic 1: contextuallyUnnecessary (6:16 - 6:29)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   5 | declare const chat: ChatMessage[];
+   6 | update({ chat: chat as Json[] });
+     |                ~~~~~~~~~~~~~~
+   7 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-106 - 1]
+Diagnostic 1: unnecessaryAssertion (7:11 - 7:27)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   6 | function fn2<T extends Node>(node: T): void {
+   7 |   fn(node as NonNullable<T>);
+     |           ~~~~~~~~~~~~~~~~~
+   8 | }
+  Label: This expression already has the type 'T' (7:6 - 7:9)
+   6 | function fn2<T extends Node>(node: T): void {
+   7 |   fn(node as NonNullable<T>);
+     |      ^^^^ This expression already has the type 'T'
+   8 | }
+  Label: Casting it to 'NonNullable<T>' is unnecessary (7:11 - 7:27)
+   6 | function fn2<T extends Node>(node: T): void {
+   7 |   fn(node as NonNullable<T>);
+     |           ^^^^^^^^^^^^^^^^^ Casting it to 'NonNullable<T>' is unnecessary
+   8 | }
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-107 - 1]
+Diagnostic 1: contextuallyUnnecessary (11:4 - 11:9)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+  10 | declare const a: A;
+  11 | fn(a as B);
+     |    ~~~~~~
+  12 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-108 - 1]
+Diagnostic 1: contextuallyUnnecessary (4:38 - 4:50)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   3 | declare const b: readonly string[];
+   4 | const fileNames: string[] = a.concat(b as string[]);
+     |                                      ~~~~~~~~~~~~~
+   5 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-109 - 1]
+Diagnostic 1: contextuallyUnnecessary (4:4 - 4:18)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   3 | declare const value: string | number;
+   4 | fn(value as number);
+     |    ~~~~~~~~~~~~~~~
+   5 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-110 - 1]
+Diagnostic 1: contextuallyUnnecessary (12:6 - 12:16)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+  11 |   type: 'a',
+  12 |   a: a as string,
+     |      ~~~~~~~~~~~
+  13 | };
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-111 - 1]
+Diagnostic 1: contextuallyUnnecessary (12:6 - 12:16)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+  11 |   type: 'a',
+  12 |   a: a as string,
+     |      ~~~~~~~~~~~
+  13 | };
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-112 - 1]
+Diagnostic 1: contextuallyUnnecessary (5:7 - 5:17)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   4 | fn1(() => {
+   5 |   fn2('hi' as any);
+     |       ~~~~~~~~~~~
+   6 | });
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-113 - 1]
+Diagnostic 1: contextuallyUnnecessary (4:4 - 4:22)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   3 | declare function fn(value: Empty<string>): void;
+   4 | fn({} as Empty<number>);
+     |    ~~~~~~~~~~~~~~~~~~~
+   5 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-114 - 1]
+Diagnostic 1: contextuallyUnnecessary (7:9 - 7:34)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   6 | const result: { item: Box<Empty<string>> } = identity({
+   7 |   item: box as Box<Empty<boolean>>,
+     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   8 | });
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-115 - 1]
+Diagnostic 1: contextuallyUnnecessary (4:3 - 4:33)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   3 | const callback: <T extends string>(value: T) => void =
+   4 |   value as (text: string) => void;
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-116 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:26 - 3:35)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | function f<T extends string>(value: string) {
+   3 |   const target: string = value as T;
+     |                          ~~~~~~~~~~
+   4 | }
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-117 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:4 - 3:43)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function fn(value: {}): void;
+   3 | fn({} as string extends string ? {} : never);
+     |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-118 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:4 - 3:28)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function fn(value: void): void;
+   3 | fn((() => {})() as undefined);
+     |    ~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-119 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:4 - 3:28)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function fn(value: unknown): void;
+   3 | fn((() => {})() as undefined);
+     |    ~~~~~~~~~~~~~~~~~~~~~~~~~
+---

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -167,56 +167,246 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 
 		}
 
-		isTypeUnchanged := func(uncast, cast *checker.Type) bool {
-			if uncast == cast {
+		getTypeArguments := func(t *checker.Type) []*checker.Type {
+			if alias := checker.Type_alias(t); alias != nil && len(alias.TypeArguments()) > 0 {
+				return alias.TypeArguments()
+			}
+			if checker.Type_objectFlags(t)&checker.ObjectFlagsReference == 0 {
+				return nil
+			}
+			return checker.Checker_getTypeArguments(ctx.TypeChecker, t)
+		}
+
+		var typeContains func(t *checker.Type, predicate func(*checker.Type) bool, seen map[*checker.Type]struct{}) bool
+		typeContains = func(t *checker.Type, predicate func(*checker.Type) bool, seen map[*checker.Type]struct{}) bool {
+			if t == nil {
+				return false
+			}
+			if _, ok := seen[t]; ok {
+				return false
+			}
+			seen[t] = struct{}{}
+			if predicate(t) {
 				return true
 			}
+			for _, part := range utils.UnionTypeParts(t) {
+				if part != t && typeContains(part, predicate, seen) {
+					return true
+				}
+			}
+			for _, part := range utils.IntersectionTypeParts(t) {
+				if part != t && typeContains(part, predicate, seen) {
+					return true
+				}
+			}
+			for _, typeArgument := range getTypeArguments(t) {
+				if typeContains(typeArgument, predicate, seen) {
+					return true
+				}
+			}
+			for _, sig := range utils.GetCallSignatures(ctx.TypeChecker, t) {
+				if typeContains(checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, sig), predicate, seen) {
+					return true
+				}
+				for _, param := range checker.Signature_parameters(sig) {
+					if typeContains(checker.Checker_getTypeOfSymbol(ctx.TypeChecker, param), predicate, seen) {
+						return true
+					}
+				}
+			}
+			return false
+		}
 
-			if compilerOptions.ExactOptionalPropertyTypes.IsFalseOrUnknown() {
+		containsAny := func(t *checker.Type) bool {
+			return typeContains(t, func(part *checker.Type) bool {
+				return utils.IsTypeFlagSet(part, checker.TypeFlagsAny)
+			}, map[*checker.Type]struct{}{})
+		}
+
+		containsTypeVariable := func(t *checker.Type) bool {
+			return typeContains(t, func(part *checker.Type) bool {
+				return utils.IsTypeFlagSet(part, checker.TypeFlagsTypeVariable|checker.TypeFlagsIndex)
+			}, map[*checker.Type]struct{}{})
+		}
+
+		hasIndexSignature := func(t *checker.Type) bool {
+			return slices.ContainsFunc(utils.UnionTypeParts(t), func(part *checker.Type) bool {
+				return len(checker.Checker_getIndexInfosOfType(ctx.TypeChecker, part)) > 0
+			})
+		}
+
+		hasSameProperties := func(uncast, cast *checker.Type) bool {
+			uncastProps := checker.Checker_getPropertiesOfType(ctx.TypeChecker, uncast)
+			castProps := checker.Checker_getPropertiesOfType(ctx.TypeChecker, cast)
+			if len(uncastProps) != len(castProps) {
 				return false
 			}
 
-			// if !utils.IsTypeFlagSet(uncast, checker.TypeFlagsUndefined) || !utils.IsTypeFlagSet(cast, checker.TypeFlagsUndefined) || !compilerOptions.ExactOptionalPropertyTypes.IsTrue() {
-			// 	return false
-			// }
+			castPropsByName := make(map[string]*ast.Symbol, len(castProps))
+			for _, prop := range castProps {
+				castPropsByName[prop.Name] = prop
+			}
 
+			for _, prop := range uncastProps {
+				castProp := castPropsByName[prop.Name]
+				if castProp == nil ||
+					checker.Checker_isReadonlySymbol(ctx.TypeChecker, prop) != checker.Checker_isReadonlySymbol(ctx.TypeChecker, castProp) {
+					return false
+				}
+			}
+			return true
+		}
+
+		haveSameTypeArguments := func(uncast, cast *checker.Type) bool {
+			uncastArgs := getTypeArguments(uncast)
+			castArgs := getTypeArguments(cast)
+			if len(uncastArgs) != len(castArgs) {
+				return false
+			}
+			for i, arg := range uncastArgs {
+				if arg != castArgs[i] {
+					return false
+				}
+			}
+			return true
+		}
+
+		areUnionPartsEquivalentIgnoringUndefined := func(uncast, cast *checker.Type) bool {
 			uncastParts := utils.Set[*checker.Type]{}
-			uncastHasUndefined := false
 			for _, part := range utils.UnionTypeParts(uncast) {
-				if utils.IsTypeFlagSet(part, checker.TypeFlagsUndefined) {
-					uncastHasUndefined = true
-				} else {
+				if !utils.IsTypeFlagSet(part, checker.TypeFlagsUndefined) {
 					uncastParts.Add(part)
 				}
 			}
 
-			if !uncastHasUndefined {
-				return false
-			}
-
-			uncastPartsCount := uncastParts.Len()
-
 			castPartsCount := 0
-			castHasUndefined := false
 			for _, part := range utils.UnionTypeParts(cast) {
 				if utils.IsTypeFlagSet(part, checker.TypeFlagsUndefined) {
-					castHasUndefined = true
-				} else {
-					if !uncastParts.Has(part) {
-						return false
-					}
-					castPartsCount++
-					if castPartsCount > uncastPartsCount {
-						return false
-					}
+					continue
 				}
+				if !uncastParts.Has(part) {
+					return false
+				}
+				castPartsCount++
 			}
+			return uncastParts.Len() == castPartsCount
+		}
 
-			return castHasUndefined && uncastPartsCount == castPartsCount
+		isEmptyObjectType := func(t *checker.Type) bool {
+			return utils.IsTypeFlagSet(t, checker.TypeFlagsNonPrimitive) ||
+				(len(checker.Checker_getPropertiesOfType(ctx.TypeChecker, t)) == 0 &&
+					len(utils.GetCallSignatures(ctx.TypeChecker, t)) == 0 &&
+					len(utils.GetConstructSignatures(ctx.TypeChecker, t)) == 0 &&
+					len(checker.Checker_getIndexInfosOfType(ctx.TypeChecker, t)) == 0)
+		}
+
+		hasPhantomTypeArguments := func(t *checker.Type) bool {
+			return isEmptyObjectType(t) && len(getTypeArguments(t)) > 0
+		}
+
+		isConceptuallyLiteral := func(node *ast.Node) bool {
+			return ast.IsArrayLiteralExpression(node) ||
+				ast.IsObjectLiteralExpression(node) ||
+				ast.IsClassExpression(node) ||
+				ast.IsFunctionExpression(node) ||
+				ast.IsArrowFunction(node) ||
+				ast.IsJsxElement(node) ||
+				ast.IsJsxFragment(node) ||
+				ast.IsStringLiteral(node) ||
+				node.Kind == ast.KindNumericLiteral ||
+				node.Kind == ast.KindNoSubstitutionTemplateLiteral ||
+				node.Kind == ast.KindTrueKeyword ||
+				node.Kind == ast.KindFalseKeyword ||
+				node.Kind == ast.KindNullKeyword ||
+				ast.IsTemplateExpression(node)
 		}
 
 		isTypeLiteral := func(t *checker.Type) bool {
 			return utils.IsTypeFlagSet(t, checker.TypeFlagsStringLiteral|checker.TypeFlagsNumberLiteral|checker.TypeFlagsBigIntLiteral|checker.TypeFlagsBooleanLiteral)
+		}
+
+		isTypeUnchanged := func(node *ast.Node, expression *ast.Node, uncast, cast *checker.Type) bool {
+			if uncast == cast {
+				return true
+			}
+
+			typeNode := node.Type()
+			if ast.IsIntersectionTypeNode(typeNode) && containsTypeVariable(cast) {
+				return false
+			}
+
+			if compilerOptions.ExactOptionalPropertyTypes.IsTrue() &&
+				utils.IsTypeFlagSet(uncast, checker.TypeFlagsUndefined) &&
+				utils.IsTypeFlagSet(cast, checker.TypeFlagsUndefined) {
+				return areUnionPartsEquivalentIgnoringUndefined(uncast, cast)
+			}
+
+			if (utils.IsTypeFlagSet(uncast, checker.TypeFlagsNonPrimitive) && !utils.IsTypeFlagSet(cast, checker.TypeFlagsNonPrimitive)) ||
+				(hasIndexSignature(uncast) && !hasIndexSignature(cast)) ||
+				containsAny(uncast) ||
+				containsAny(cast) ||
+				(containsTypeVariable(cast) && !containsTypeVariable(uncast)) {
+				return false
+			}
+
+			if isConceptuallyLiteral(expression) &&
+				(!ast.IsObjectLiteralExpression(expression) ||
+					len(expression.AsObjectLiteralExpression().Properties.Nodes) == 0 ||
+					slices.ContainsFunc(checker.Checker_getPropertiesOfType(ctx.TypeChecker, cast), func(prop *ast.Symbol) bool {
+						return isTypeLiteral(checker.Checker_getTypeOfSymbol(ctx.TypeChecker, prop))
+					})) {
+				return false
+			}
+
+			if utils.IsIntersectionType(cast) && !utils.IsIntersectionType(uncast) {
+				castParts := cast.Types()
+				var otherPart *checker.Type
+				for _, part := range castParts {
+					if part != uncast {
+						otherPart = part
+						break
+					}
+				}
+				if utils.IsTypeParameter(uncast) &&
+					len(castParts) == 2 &&
+					slices.Contains(castParts, uncast) &&
+					otherPart != nil &&
+					isEmptyObjectType(otherPart) &&
+					!containsTypeVariable(otherPart) {
+					constraint := checker.Checker_getBaseConstraintOfType(ctx.TypeChecker, uncast)
+					if constraint != nil && !utils.IsNullableType(ctx.TypeChecker, constraint) {
+						return true
+					}
+				}
+				return false
+			}
+
+			if !hasSameProperties(uncast, cast) || !haveSameTypeArguments(uncast, cast) {
+				return false
+			}
+
+			return checker.Checker_isTypeAssignableTo(ctx.TypeChecker, uncast, cast) &&
+				checker.Checker_isTypeAssignableTo(ctx.TypeChecker, cast, uncast)
+		}
+
+		isTypeAny := func(t *checker.Type) bool {
+			return utils.IsTypeFlagSet(t, checker.TypeFlagsAny)
+		}
+
+		isTypeUnknown := func(t *checker.Type) bool {
+			return utils.IsTypeFlagSet(t, checker.TypeFlagsUnknown)
+		}
+
+		isNullableForNonNullAssertion := func(t *checker.Type) bool {
+			if utils.IsNullableType(ctx.TypeChecker, t) {
+				return true
+			}
+			for _, part := range utils.UnionTypeParts(t) {
+				if utils.IsTypeFlagSet(part, checker.TypeFlagsAny|checker.TypeFlagsUnknown|checker.TypeFlagsVoid) {
+					return true
+				}
+			}
+			return false
 		}
 
 		isIIFE := func(expression *ast.Node) bool {
@@ -228,6 +418,7 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			callee := ast.SkipParentheses(expression.AsCallExpression().Expression)
 			return ast.IsArrowFunction(callee) || ast.IsFunctionExpression(callee)
 		}
+
 		var isContextSensitiveCallLikeExpression func(expression *ast.Node) bool
 		isContextSensitiveCallLikeExpression = func(expression *ast.Node) bool {
 			if ast.IsCallExpression(expression) || ast.IsNewExpression(expression) || ast.IsTaggedTemplateExpression(expression) {
@@ -245,15 +436,15 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			expression := ast.SkipParentheses(node.Expression())
 
 			if isIIFE(expression) {
-				if resolvedSignature := checker.Checker_getResolvedSignature(ctx.TypeChecker, expression, nil, checker.CheckModeNormal); resolvedSignature != nil {
-					return ctx.TypeChecker.GetReturnTypeOfSignature(resolvedSignature)
-				}
-
 				callee := ast.SkipParentheses(expression.AsCallExpression().Expression)
 				functionType := ctx.TypeChecker.GetTypeAtLocation(callee)
 				signatures := ctx.TypeChecker.GetCallSignatures(functionType)
 				if len(signatures) > 0 {
-					return ctx.TypeChecker.GetReturnTypeOfSignature(signatures[0])
+					returnType := ctx.TypeChecker.GetReturnTypeOfSignature(signatures[0])
+					if callee.Type() == nil && utils.IsTypeFlagSet(returnType, checker.TypeFlagsUndefined) {
+						return ctx.TypeChecker.GetVoidType()
+					}
+					return returnType
 				}
 			}
 
@@ -269,45 +460,65 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			return ctx.TypeChecker.GetTypeAtLocation(expression)
 		}
 
-		checkTypeAssertion := func(node *ast.Node) {
+		parentThroughParens := func(node *ast.Node) *ast.Node {
+			parent := node.Parent
+			for parent != nil && ast.IsParenthesizedExpression(parent) {
+				parent = parent.Parent
+			}
+			return parent
+		}
+
+		buildAssertionFixes := func(node *ast.Node) []rule.RuleFix {
 			typeNode := node.Type()
-			if slices.Contains(opts.TypesToIgnore, strings.TrimSpace(ctx.SourceFile.Text()[typeNode.Pos():typeNode.End()])) {
-				return
-			}
-
-			castType := ctx.TypeChecker.GetTypeAtLocation(node)
-			castTypeIsLiteral := isTypeLiteral(castType)
-			typeAnnotationIsConstAssertion := isConstAssertion(typeNode)
-
-			if !opts.CheckLiteralConstAssertions && castTypeIsLiteral && typeAnnotationIsConstAssertion {
-				return
-			}
-
 			expression := node.Expression()
-			uncastType := getUncastType(node)
+			if node.Kind == ast.KindAsExpression {
+				s := scanner.GetScannerForSourceFile(ctx.SourceFile, expression.End())
+				asKeywordRange := s.TokenRange()
+				typeNodeRange := typeNode.Loc
 
-			expressionForType := ast.SkipParentheses(expression)
-			if uncastType == castType && ast.IsIdentifier(expressionForType) {
-				if symbol := ctx.TypeChecker.GetSymbolAtLocation(expressionForType); symbol != nil {
-					symbolType := checker.Checker_getTypeOfSymbol(ctx.TypeChecker, symbol)
-					if symbolType != nil && checker.Type_flags(symbolType)&checker.TypeFlagsConditional != 0 {
-						uncastType = symbolType
+				for {
+					previousCharPos := asKeywordRange.Pos() - 1
+					if previousCharPos < expression.End() {
+						break
 					}
+					previousChar := ctx.SourceFile.Text()[previousCharPos]
+					if !utils.IsStrWhiteSpace(rune(previousChar)) {
+						break
+					}
+					asKeywordRange = asKeywordRange.WithPos(previousCharPos)
+				}
+
+				typeNodePos := utils.TrimNodeTextRange(ctx.SourceFile, typeNode).Pos()
+				if asKeywordRange.End() > typeNodePos {
+					return []rule.RuleFix{
+						rule.RuleFixRemoveRange(core.NewTextRange(expression.End(), typeNode.Loc.End())),
+					}
+				}
+				betweenText := ctx.SourceFile.Text()[asKeywordRange.End():typeNodePos]
+				if !utils.IsStringWhiteSpace(betweenText) {
+					return []rule.RuleFix{
+						rule.RuleFixRemoveRange(asKeywordRange),
+						rule.RuleFixRemove(ctx.SourceFile, typeNode),
+					}
+				}
+
+				return []rule.RuleFix{
+					rule.RuleFixRemoveRange(core.NewTextRange(asKeywordRange.Pos(), typeNodeRange.End())),
 				}
 			}
 
-			typeIsUnchanged := isTypeUnchanged(uncastType, castType)
+			s := scanner.GetScannerForSourceFile(ctx.SourceFile, node.Pos())
+			openingAngleBracket := s.TokenRange()
+			s.ResetPos(typeNode.End())
+			s.Scan()
+			closingAngleBracket := s.TokenRange()
+			return []rule.RuleFix{rule.RuleFixRemoveRange(openingAngleBracket.WithEnd(closingAngleBracket.End()))}
+		}
 
-			var wouldSameTypeBeInferred bool
-			if castTypeIsLiteral {
-				wouldSameTypeBeInferred = isImplicitlyNarrowedLiteralDeclaration(node)
-			} else {
-				wouldSameTypeBeInferred = !typeAnnotationIsConstAssertion
-			}
-
-			if !typeIsUnchanged || !wouldSameTypeBeInferred {
-				return
-			}
+		reportUnnecessaryTypeAssertion := func(node *ast.Node, uncastType, castType *checker.Type) {
+			typeNode := node.Type()
+			expression := node.Expression()
+			expressionForType := ast.SkipParentheses(expression)
 
 			if typeNode.Pos() < expression.Pos() {
 				searchStart := node.Pos()
@@ -344,20 +555,8 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 
 			if node.Kind == ast.KindAsExpression {
 				s := scanner.GetScannerForSourceFile(ctx.SourceFile, expression.End())
-
-				// Get the text range of the `as` keyword token.
-				// Example: `const x = y as T;`
-				//                      ^^
 				asKeywordRange := s.TokenRange()
-
-				// Get the text range of the type node (includes any trailing trivia).
-				// Example: `const x = y as T;`
-				//                         ^
-				typeNodeRange := typeNode.Loc
-
-				// Report the `as T` part of `const x = y as T;` for the main diagnostic message
-				assertionRange := asKeywordRange.WithEnd(typeNodeRange.End())
-
+				assertionRange := asKeywordRange.WithEnd(typeNode.Loc.End())
 				ctx.ReportDiagnosticWithFixes(
 					buildUnnecessaryTypeAssertionDiagnostic(
 						assertionRange,
@@ -365,53 +564,12 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 						ctx.TypeChecker.TypeToString(uncastType),
 						ctx.TypeChecker.TypeToString(castType),
 					), func() []rule.RuleFix {
-						// Extend the `as` keyword range backwards to include any leading whitespace.
-						// Input:
-						// `x /* comment 1 */ as /* comment 2 */ SomeType`
-						//                   ^^ `asKeywordRange`
-						// Output:
-						// `x /* comment 1 */ as /* comment 2 */ SomeType`
-						//                   ^^^ `asKeywordRange`
-						// Input:
-						// `x  as /* comment 2 */ SomeType`
-						//     ^^ `asKeywordRange`
-						// Output:
-						// `x  as /* comment 2 */ SomeType`
-						//   ^^^^ `asKeywordRange`
-						//
-						for {
-							previousCharPos := asKeywordRange.Pos() - 1
-							// Don't extend past the end of the expression being asserted
-							if previousCharPos < expression.End() {
-								break
-							}
-							previousChar := ctx.SourceFile.Text()[previousCharPos]
-							// Stop when we hit a non-whitespace character (expression or comment)
-							if !utils.IsStrWhiteSpace(rune(previousChar)) {
-								break
-							}
-							asKeywordRange = asKeywordRange.WithPos(previousCharPos)
-						}
-
-						typeNodePos := utils.TrimNodeTextRange(ctx.SourceFile, typeNode).Pos()
-
-						// If the text between the `as` token and `SomeType` is only whitespace,
-						// the two fixes can be merged into one. This produces cleaner output.
-						// `x as /* comment 1 */ as /* comment 2 */ SomeType`
-						//                         ^^^^^^^^^^^^^^^^^
-						betweenText := ctx.SourceFile.Text()[asKeywordRange.End():typeNodePos]
-						if !utils.IsStringWhiteSpace(betweenText) {
-							return []rule.RuleFix{
-								rule.RuleFixRemoveRange(asKeywordRange),
-								rule.RuleFixRemove(ctx.SourceFile, typeNode),
-							}
-						}
-
-						return []rule.RuleFix{
-							rule.RuleFixRemoveRange(core.NewTextRange(asKeywordRange.Pos(), typeNodeRange.End())),
-						}
+						return buildAssertionFixes(node)
 					})
-			} else {
+				return
+			}
+
+			{
 				s := scanner.GetScannerForSourceFile(ctx.SourceFile, node.Pos())
 				openingAngleBracket := s.TokenRange()
 				s.ResetPos(typeNode.End())
@@ -429,7 +587,358 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 						return []rule.RuleFix{rule.RuleFixRemoveRange(assertionRange)}
 					})
 			}
-			// TODO - add contextually unnecessary check for this
+		}
+
+		getOriginalExpression := func(node *ast.Node) *ast.Node {
+			current := ast.SkipParentheses(node.Expression())
+			for ast.IsAsExpression(current) || ast.IsTypeAssertion(current) {
+				current = ast.SkipParentheses(current.Expression())
+			}
+			return current
+		}
+
+		isArgumentToParentCallOrNew := func(node *ast.Node) (bool, int) {
+			parent := parentThroughParens(node)
+			if parent == nil || (!ast.IsCallExpression(parent) && !ast.IsNewExpression(parent)) {
+				return false, -1
+			}
+			for i, argument := range parent.Arguments() {
+				if argument == node || ast.SkipParentheses(argument) == node {
+					return true, i
+				}
+			}
+			return false, -1
+		}
+
+		hasGenericCallSignature := func(t *checker.Type) bool {
+			return slices.ContainsFunc(utils.GetCallSignatures(ctx.TypeChecker, t), func(sig *checker.Signature) bool {
+				return len(sig.TypeParameters()) > 0
+			})
+		}
+
+		genericsMismatch := func(uncast, contextual *checker.Type) bool {
+			return slices.ContainsFunc(checker.Checker_getPropertiesOfType(ctx.TypeChecker, contextual), func(prop *ast.Symbol) bool {
+				contextualSigs := checker.Checker_getSignaturesOfType(
+					ctx.TypeChecker,
+					checker.Checker_getTypeOfSymbol(ctx.TypeChecker, prop),
+					checker.SignatureKindCall,
+				)
+				if !slices.ContainsFunc(contextualSigs, func(sig *checker.Signature) bool {
+					return len(sig.TypeParameters()) > 0
+				}) {
+					return false
+				}
+
+				uncastProp := checker.Checker_getPropertyOfType(ctx.TypeChecker, uncast, prop.Name)
+				if uncastProp == nil {
+					return true
+				}
+
+				uncastSigs := checker.Checker_getSignaturesOfType(
+					ctx.TypeChecker,
+					checker.Checker_getTypeOfSymbol(ctx.TypeChecker, uncastProp),
+					checker.SignatureKindCall,
+				)
+				return !slices.ContainsFunc(uncastSigs, func(sig *checker.Signature) bool {
+					return len(sig.TypeParameters()) > 0
+				})
+			})
+		}
+
+		isArgumentToOverloadedFunction := func(node *ast.Node) bool {
+			isArg, argIndex := isArgumentToParentCallOrNew(node)
+			if !isArg {
+				return false
+			}
+
+			parent := parentThroughParens(node)
+			calleeType := ctx.TypeChecker.GetTypeAtLocation(parent.Expression())
+			signatures := ctx.TypeChecker.GetCallSignatures(calleeType)
+			if len(signatures) <= 1 {
+				return false
+			}
+
+			paramTypes := make([]*checker.Type, 0, len(signatures))
+			for _, sig := range signatures {
+				params := sig.Parameters()
+				if argIndex >= len(params) {
+					return true
+				}
+				paramType := checker.Checker_getTypeOfSymbol(ctx.TypeChecker, params[argIndex])
+				if valueDeclaration := params[argIndex].ValueDeclaration; valueDeclaration != nil &&
+					valueDeclaration.Kind == ast.KindParameter &&
+					valueDeclaration.AsParameterDeclaration().DotDotDotToken != nil {
+					if typeArguments := getTypeArguments(paramType); len(typeArguments) > 0 {
+						paramType = typeArguments[0]
+					}
+				}
+				if paramType == nil {
+					return true
+				}
+				paramTypes = append(paramTypes, paramType)
+			}
+
+			firstParamType := paramTypes[0]
+			if slices.ContainsFunc(paramTypes, func(paramType *checker.Type) bool { return paramType != firstParamType }) {
+				uncastType := ctx.TypeChecker.GetTypeAtLocation(node.Expression())
+				return slices.ContainsFunc(paramTypes, func(paramType *checker.Type) bool {
+					return !checker.Checker_isTypeAssignableTo(ctx.TypeChecker, uncastType, paramType)
+				})
+			}
+			return false
+		}
+
+		isInDestructuringDeclaration := func(node *ast.Node) bool {
+			return ast.IsVariableDeclaration(node.Parent) &&
+				node.Parent.Initializer() == node &&
+				node.Parent.Name() != nil &&
+				ast.IsBindingPattern(node.Parent.Name())
+		}
+
+		isPropertyInProblematicContext := func(node *ast.Node) bool {
+			parent := node.Parent
+			if parent == nil || !ast.IsPropertyAssignment(parent) || parent.Initializer() != node {
+				return false
+			}
+			objectExpr := parent.Parent
+			if objectExpr == nil || !ast.IsObjectLiteralExpression(objectExpr) {
+				return false
+			}
+			if objectContextualType := checker.Checker_getContextualType(ctx.TypeChecker, objectExpr, checker.ContextFlagsNone); objectContextualType != nil && utils.IsUnionType(objectContextualType) {
+				propContextualType := checker.Checker_getContextualType(ctx.TypeChecker, node, checker.ContextFlagsNone)
+				if propContextualType == nil {
+					return true
+				}
+				nonNullableContextualType := checker.Checker_GetNonNullableType(ctx.TypeChecker, propContextualType)
+				if utils.IsUnionType(nonNullableContextualType) {
+					return true
+				}
+				uncastType := ctx.TypeChecker.GetTypeAtLocation(node.Expression())
+				return !checker.Checker_isTypeAssignableTo(ctx.TypeChecker, uncastType, nonNullableContextualType)
+			}
+			objectParent := objectExpr.Parent
+			return objectParent != nil &&
+				(ast.IsSatisfiesExpression(objectParent) ||
+					(ast.IsCallExpression(objectParent) && objectParent.Parent != nil && ast.IsSatisfiesExpression(objectParent.Parent)))
+		}
+
+		isAssignmentInNonStatementContext := func(node *ast.Node) bool {
+			parent := node.Parent
+			return parent != nil &&
+				ast.IsAssignmentExpression(parent, false) &&
+				parent.AsBinaryExpression().Right == node &&
+				(parent.Parent == nil || parent.Parent.Kind != ast.KindExpressionStatement)
+		}
+
+		isRightHandSideOfLogicalAssignment := func(node *ast.Node) bool {
+			parent := node.Parent
+			return parent != nil &&
+				ast.IsBinaryExpression(parent) &&
+				parent.AsBinaryExpression().Right == node &&
+				ast.IsLogicalOrCoalescingAssignmentOperator(parent.AsBinaryExpression().OperatorToken.Kind)
+		}
+
+		isInGenericContext := func(node *ast.Node) bool {
+			seenFunction := false
+			for current := node.Parent; current != nil; current = current.Parent {
+				if current.Kind == ast.KindFunctionDeclaration {
+					return false
+				}
+				if ast.IsFunctionExpression(current) || ast.IsArrowFunction(current) {
+					if current.Body() != nil && current.Body().Kind == ast.KindBlock {
+						return false
+					}
+					if seenFunction {
+						return false
+					}
+					seenFunction = true
+				}
+				if ast.IsCallExpression(current) || ast.IsNewExpression(current) {
+					if current.TypeArguments() != nil {
+						continue
+					}
+					if ast.IsCallExpression(current) && ast.IsAccessExpression(current.Expression()) {
+						if slices.Contains(current.Arguments(), node) {
+							continue
+						}
+					}
+					calleeType := ctx.TypeChecker.GetTypeAtLocation(current.Expression())
+					if hasGenericCallSignature(calleeType) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		skipParentTypeForContextualAny := func(node *ast.Node) bool {
+			parent := parentThroughParens(node)
+			return parent != nil &&
+				(ast.IsAsExpression(parent) ||
+					ast.IsTypeAssertion(parent) ||
+					parent.Kind == ast.KindSpreadElement ||
+					parent.Kind == ast.KindSpreadAssignment ||
+					ast.IsSatisfiesExpression(parent))
+		}
+
+		shouldSkipContextualTypeFallback := func(node *ast.Node, castIsAny bool) bool {
+			parent := parentThroughParens(node)
+			if castIsAny {
+				return (parent != nil && ast.IsLogicalExpression(parent)) || isInGenericContext(node)
+			}
+
+			if skipParentTypeForContextualAny(node) ||
+				ast.IsArrayLiteralExpression(node.Expression()) ||
+				isInDestructuringDeclaration(node) ||
+				isPropertyInProblematicContext(node) ||
+				isAssignmentInNonStatementContext(node) ||
+				isRightHandSideOfLogicalAssignment(node) ||
+				isArgumentToOverloadedFunction(node) {
+				return true
+			}
+
+			if isInGenericContext(node) {
+				originalExpr := getOriginalExpression(node)
+				return !isConceptuallyLiteral(originalExpr) &&
+					(parent == nil || !ast.IsPropertyAssignment(parent))
+			}
+
+			return false
+		}
+
+		hasPhantomTypeArgumentMismatch := func(node *ast.Node, uncastType, contextualType *checker.Type) bool {
+			return isInGenericContext(node) &&
+				(hasPhantomTypeArguments(uncastType) ||
+					hasPhantomTypeArguments(contextualType)) &&
+				!haveSameTypeArguments(uncastType, contextualType)
+		}
+
+		isNullishLiteralToUnion := func(node *ast.Node, castType *checker.Type) bool {
+			expression := ast.SkipParentheses(node.Expression())
+			return utils.IsUnionType(castType) &&
+				(expression.Kind == ast.KindNullKeyword ||
+					(ast.IsIdentifier(expression) && expression.Text() == "undefined"))
+		}
+
+		reportDoubleAssertionIfUnnecessary := func(node *ast.Node, contextualType *checker.Type) bool {
+			innerExpression := ast.SkipParentheses(node.Expression())
+			if !ast.IsAsExpression(innerExpression) && !ast.IsTypeAssertion(innerExpression) {
+				return false
+			}
+
+			originalExpr := getOriginalExpression(node)
+			originalType := ctx.TypeChecker.GetTypeAtLocation(originalExpr)
+			castType := ctx.TypeChecker.GetTypeAtLocation(node)
+
+			messageId := ""
+			if isTypeUnchanged(node, innerExpression, originalType, castType) && !isTypeAny(castType) {
+				messageId = "unnecessaryAssertion"
+			} else if contextualType != nil {
+				intermediateType := ctx.TypeChecker.GetTypeAtLocation(innerExpression)
+				if (isTypeAny(intermediateType) || isTypeUnknown(intermediateType)) &&
+					checker.Checker_isTypeAssignableTo(ctx.TypeChecker, originalType, contextualType) {
+					messageId = "contextuallyUnnecessary"
+				}
+			}
+			if messageId == "" {
+				return false
+			}
+
+			description := buildContextuallyUnnecessaryMessage(node.Loc).Message.Description
+			if messageId == "unnecessaryAssertion" {
+				description = buildUnnecessaryAssertionDiagnostic(node.Loc, originalExpr.Loc, ctx.TypeChecker.TypeToString(originalType)).Message.Description
+			}
+
+			ctx.ReportDiagnosticWithFixes(rule.RuleDiagnostic{
+				Range: node.Loc,
+				Message: rule.RuleMessage{
+					Id:          messageId,
+					Description: description,
+				},
+			}, func() []rule.RuleFix {
+				textRange := utils.TrimNodeTextRange(ctx.SourceFile, originalExpr)
+				text := ctx.SourceFile.Text()[textRange.Pos():textRange.End()]
+				if ast.IsObjectLiteralExpression(originalExpr) &&
+					node.Parent != nil &&
+					ast.IsArrowFunction(node.Parent) &&
+					node.Parent.Body() == node {
+					text = "(" + text + ")"
+				}
+				return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, text)}
+			})
+			return true
+		}
+
+		checkTypeAssertion := func(node *ast.Node) {
+			typeNode := node.Type()
+			if slices.Contains(opts.TypesToIgnore, strings.TrimSpace(ctx.SourceFile.Text()[typeNode.Pos():typeNode.End()])) {
+				return
+			}
+
+			castType := ctx.TypeChecker.GetTypeAtLocation(node)
+			castTypeIsLiteral := isTypeLiteral(castType)
+			typeAnnotationIsConstAssertion := isConstAssertion(typeNode)
+
+			if !opts.CheckLiteralConstAssertions && castTypeIsLiteral && typeAnnotationIsConstAssertion {
+				return
+			}
+
+			expression := node.Expression()
+			uncastType := getUncastType(node)
+
+			expressionForType := ast.SkipParentheses(expression)
+			if uncastType == castType && ast.IsIdentifier(expressionForType) {
+				if symbol := ctx.TypeChecker.GetSymbolAtLocation(expressionForType); symbol != nil {
+					symbolType := checker.Checker_getTypeOfSymbol(ctx.TypeChecker, symbol)
+					if symbolType != nil && checker.Type_flags(symbolType)&checker.TypeFlagsConditional != 0 {
+						uncastType = symbolType
+					}
+				}
+			}
+
+			typeIsUnchanged := isTypeUnchanged(node, expression, uncastType, castType)
+
+			var wouldSameTypeBeInferred bool
+			if castTypeIsLiteral {
+				wouldSameTypeBeInferred = isImplicitlyNarrowedLiteralDeclaration(node)
+			} else {
+				wouldSameTypeBeInferred = !typeAnnotationIsConstAssertion
+			}
+
+			if typeIsUnchanged && wouldSameTypeBeInferred {
+				reportUnnecessaryTypeAssertion(node, uncastType, castType)
+				return
+			}
+
+			castIsAny := isTypeAny(castType) && !skipParentTypeForContextualAny(node)
+			var contextualType *checker.Type
+			if !shouldSkipContextualTypeFallback(node, castIsAny) {
+				contextualType = checker.Checker_getContextualType(ctx.TypeChecker, node, checker.ContextFlagsNone)
+			}
+
+			if contextualType != nil {
+				contextualTypeIsAny := isTypeAny(contextualType)
+				isCallArgument, _ := isArgumentToParentCallOrNew(node)
+				anyInvolvedInContextualCheck := (!contextualTypeIsAny && !containsAny(contextualType)) ||
+					(contextualTypeIsAny && isCallArgument && !containsAny(castType))
+
+				isContextuallyUnnecessary := !typeAnnotationIsConstAssertion &&
+					!containsAny(uncastType) &&
+					anyInvolvedInContextualCheck &&
+					!hasPhantomTypeArgumentMismatch(node, uncastType, contextualType) &&
+					(castIsAny || !genericsMismatch(uncastType, contextualType)) &&
+					(contextualTypeIsAny || checker.Checker_isTypeAssignableTo(ctx.TypeChecker, uncastType, contextualType)) &&
+					!isNullishLiteralToUnion(node, castType)
+
+				if isContextuallyUnnecessary {
+					ctx.ReportDiagnosticWithFixes(buildContextuallyUnnecessaryMessage(node.Loc), func() []rule.RuleFix {
+						return buildAssertionFixes(node)
+					})
+					return
+				}
+			}
+
+			reportDoubleAssertionIfUnnecessary(node, contextualType)
 		}
 
 		return rule.RuleListeners{
@@ -460,17 +969,13 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 					return
 				}
 
-				t := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, expression)
+				constrainedType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, expression)
+				actualType := ctx.TypeChecker.GetTypeAtLocation(expression)
 
-				var tFlags checker.TypeFlags
-				for _, part := range utils.UnionTypeParts(t) {
-					tFlags |= checker.Type_flags(part)
-				}
+				constrainedTypeIsNullable := isNullableForNonNullAssertion(constrainedType)
+				actualTypeIsNullable := isNullableForNonNullAssertion(actualType)
 
-				if tFlags&(checker.TypeFlagsAny|checker.TypeFlagsUnknown|
-					checker.TypeFlagsNull|
-					checker.TypeFlagsUndefined|
-					checker.TypeFlagsVoid) == 0 {
+				if !constrainedTypeIsNullable && !actualTypeIsNullable {
 					if ast.IsIdentifier(expression) && isPossiblyUsedBeforeAssigned(expression) {
 						return
 					}
@@ -479,13 +984,22 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 						buildUnnecessaryAssertionDiagnostic(
 							exclamationRange,
 							expression.Loc,
-							ctx.TypeChecker.TypeToString(t),
+							ctx.TypeChecker.TypeToString(constrainedType),
 						),
 						func() []rule.RuleFix { return []rule.RuleFix{buildRemoveExclamationFix(exclamationRange)} },
 					)
 				} else {
 					// we know it's a nullable type
 					// so figure out if the variable is used in a place that accepts nullable types
+					if constrainedType != actualType {
+						return
+					}
+
+					var tFlags checker.TypeFlags
+					for _, part := range utils.UnionTypeParts(constrainedType) {
+						tFlags |= checker.Type_flags(part)
+					}
+
 					contextualType := utils.GetContextualType(ctx.TypeChecker, node)
 					if contextualType != nil {
 						var contextualFlags checker.TypeFlags

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
@@ -552,7 +552,6 @@ function processValue<T extends NumberValuePairType | NumberValueType>(
 		`},
 		{Code: `const cb = async (importOriginal: unknown) => { const actual = (await importOriginal()) as Record<string, unknown>; return { ...actual, useLocation: vi.fn() }; });`},
 		{
-			Skip: true,
 			Code: `
 type Data<T> = { value?: T };
 type ValueType<TData> = TData extends Data<infer T> ? T : never;
@@ -606,7 +605,6 @@ const b = a as const;
       `,
 		},
 		{
-			Skip: true,
 			Code: `
 (() => {})() as undefined;
       `,
@@ -618,7 +616,6 @@ f() as undefined;
       `,
 		},
 		{
-			Skip: true,
 			Code: `
 (function () {})() as undefined;
       `,
@@ -1084,6 +1081,17 @@ const test = inferred({
 });
 
 console.log(test.options.parameters.potato);
+    `,
+		},
+		{
+			Code: `
+declare function fn(value: string | null): void;
+fn((null) as string | null);
+    `,
+		},
+		{
+			Code: `
+const value: undefined = (() => {})() as undefined;
     `,
 		},
 	}, []rule_tester.InvalidTestCase{
@@ -2399,7 +2407,6 @@ interface Overloaded {
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 function doThing(a: number) {}
 doThing(5 as any);
@@ -2415,7 +2422,6 @@ doThing(5);
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 interface A {
   required: string;
@@ -2439,7 +2445,6 @@ doThing({ required: 'yes', alsoRequired: 1 });
 			},
 		},
 		{
-			Skip:   true,
 			Code:   "const x = 5 as any as 5;",
 			Output: []string{"const x = 5;"},
 			Errors: []rule_tester.InvalidTestCaseError{
@@ -2449,7 +2454,6 @@ doThing({ required: 'yes', alsoRequired: 1 });
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 const v: number = 5;
 const x = v as unknown as number;
@@ -2465,7 +2469,6 @@ const x = v;
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 const v: number = 5;
 const x = v as any as number;
@@ -2481,7 +2484,6 @@ const x = v;
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 const x = (1 + 1) as any as number;
       `,
@@ -2495,7 +2497,6 @@ const x = 1 + 1;
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 const x = 2 * ((1 + 1) as any as number);
       `,
@@ -2509,7 +2510,6 @@ const x = 2 * (1 + 1);
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 const v: number = 5;
 const x = <number>(<any>v);
@@ -2525,7 +2525,6 @@ const x = v;
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 const obj = { id: '' };
 const obj2 = obj as { id: string };
@@ -2541,7 +2540,6 @@ const obj2 = obj;
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 const obj = { id: '' };
 const obj2 = obj as any as { id: string };
@@ -2557,7 +2555,6 @@ const obj2 = obj;
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 const obj = { id: '' };
 const obj2 = obj as unknown as { id: string };
@@ -2573,7 +2570,6 @@ const obj2 = obj;
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 const array = ['a', 'b'];
 const array2 = array as any as string[];
@@ -2589,7 +2585,6 @@ const array2 = array;
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 const array = ['a', 'b'];
 const array2 = array as unknown as string[];
@@ -2605,7 +2600,6 @@ const array2 = array;
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 type A = 'a';
 type B = 'b';
@@ -2629,7 +2623,6 @@ fn(a);
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 interface Props {
   a: number;
@@ -2649,7 +2642,6 @@ const x = { a: 1 };
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 interface Props {
   a: number;
@@ -2669,7 +2661,6 @@ const x = { a: 1 };
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 interface Props {
   a: number;
@@ -2689,7 +2680,6 @@ const fn = (): Props => ({ a: 1 });
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 declare function fn(param: number): void;
 fn(42 as unknown as number);
@@ -2705,7 +2695,6 @@ fn(42);
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 declare function fn(param: number): void;
 fn(42 as any as number);
@@ -2721,7 +2710,6 @@ fn(42);
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 declare function fn(params: { param: number });
 fn({ param: 42 as number });
@@ -2737,7 +2725,6 @@ fn({ param: 42 });
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 declare function fn(params: { param: number });
 fn({ param: 42 as any });
@@ -2753,7 +2740,6 @@ fn({ param: 42 });
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 type StringOrNumber = string | number;
 declare function fn(param: StringOrNumber);
@@ -2771,7 +2757,6 @@ fn(42);
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 type NumbersRecord = { [key: string]: number };
 declare function fn(params: { data: NumbersRecord });
@@ -2791,7 +2776,6 @@ fn({ data: data });
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 type NumbersRecord = { [key: string]: number };
 declare function fn(params: { data: NumbersRecord });
@@ -2817,7 +2801,6 @@ fn({
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 type Json = string | number | boolean | null | { [key: string]: Json } | Json[];
 type Tables<T extends 'my_table'> = { my_table: { my_column: Json } }[T];
@@ -2837,7 +2820,6 @@ const result = updatedColumn;
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 interface T {
   a: string;
@@ -2859,7 +2841,6 @@ fn<T>({ a: '' });
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 declare function update<T extends string>(value: T): void;
 update('hi' as unknown as string);
@@ -2875,7 +2856,6 @@ update('hi');
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 declare function update<T extends string>(value: T): void;
 update('hi' as string);
@@ -2891,7 +2871,6 @@ update('hi');
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 declare function fn(x: string[]): void;
 fn(['hello'] as any);
@@ -2907,7 +2886,6 @@ fn(['hello']);
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 type ChatMessage = { message: string };
 type Json = string | { [key: string]: Json };
@@ -2929,7 +2907,6 @@ update({ chat: chat });
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 type ChatMessage = { message: string };
 type Json = string | { [key: string]: Json };
@@ -2951,7 +2928,6 @@ update({ chat: chat });
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 interface Node {
   parent: Node;
@@ -2977,7 +2953,6 @@ function fn2<T extends Node>(node: T): void {
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 interface A {
   a: string;
@@ -3009,7 +2984,6 @@ fn(a);
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 declare const a: string[];
 declare const b: readonly string[];
@@ -3027,7 +3001,6 @@ const fileNames: string[] = a.concat(b);
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 declare function fn(text: any): void;
 declare const value: string | number;
@@ -3045,7 +3018,6 @@ fn(value);
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 interface A {
   type: 'a';
@@ -3081,7 +3053,6 @@ const schema: A | B = {
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 interface A {
   type: 'a';
@@ -3117,7 +3088,6 @@ const schema: A | B = {
 			},
 		},
 		{
-			Skip: true,
 			Code: `
 declare function fn1<T>(fn: () => void): void;
 declare function fn2(text: string): void;
@@ -3132,6 +3102,121 @@ fn1(() => {
   fn2('hi');
 });
       `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+type Empty<T> = {};
+declare function fn(value: Empty<string>): void;
+fn({} as Empty<number>);
+      `,
+			Output: []string{`
+type Empty<T> = {};
+declare function fn(value: Empty<string>): void;
+fn({});
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+type Empty<T> = {};
+type Box<T> = { value: T };
+declare const box: Box<Empty<number>>;
+declare function identity<T>(value: T): T;
+const result: { item: Box<Empty<string>> } = identity({
+  item: box as Box<Empty<boolean>>,
+});
+      `,
+			Output: []string{`
+type Empty<T> = {};
+type Box<T> = { value: T };
+declare const box: Box<Empty<number>>;
+declare function identity<T>(value: T): T;
+const result: { item: Box<Empty<string>> } = identity({
+  item: box,
+});
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+declare const value: (text: string) => string;
+const callback: <T extends string>(value: T) => void =
+  value as (text: string) => void;`,
+			Output: []string{`
+declare const value: (text: string) => string;
+const callback: <T extends string>(value: T) => void =
+  value;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+function f<T extends string>(value: string) {
+  const target: string = value as T;
+}`,
+			Output: []string{`
+function f<T extends string>(value: string) {
+  const target: string = value;
+}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+declare function fn(value: {}): void;
+fn({} as string extends string ? {} : never);
+      `,
+			Output: []string{`
+declare function fn(value: {}): void;
+fn({});
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+declare function fn(value: void): void;
+fn((() => {})() as undefined);
+      `,
+			Output: []string{`
+declare function fn(value: void): void;
+fn((() => {})());
+      `},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+declare function fn(value: unknown): void;
+fn((() => {})() as undefined);`,
+			Output: []string{`
+declare function fn(value: unknown): void;
+fn((() => {})());`},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "contextuallyUnnecessary",


### PR DESCRIPTION
This follows up the upstream test sync by enabling the cases that were temporarily skipped.

The implementation now mirrors the upstream rule more closely for the cases those tests cover: same-type checks account for structural and generic edge cases, contextual fallback handles unnecessary assertions accepted by the receiver, double assertions can be removed when the original expression is already sufficient, and non-null assertions follow the newer constrained-vs-actual type behavior.

The goal is to keep the synced tests active without relaxing coverage, while preserving the existing false-negative choices around overloaded calls, generic inference, phantom type arguments, logical assignments, satisfies expressions, and implicit-void IIFEs.

fixes https://github.com/oxc-project/tsgolint/pull/1002