### PR TITLE
test(no-unnecessary-type-assertion): cover nullable literal assertion

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-type-assertion.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-type-assertion.snap
@@ -1630,3 +1630,11 @@ Message: This assertion is unnecessary since the receiver accepts the original t
    3 | fn((() => {})() as undefined);
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~
 ---
+
+[TestNoUnnecessaryTypeAssertion/invalid-120 - 1]
+Diagnostic 1: contextuallyUnnecessary (1:26 - 1:45)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   1 | const x: string | null = 'a' as string | null;
+     |                          ~~~~~~~~~~~~~~~~~~~~
+   2 | void x;
+---

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
@@ -3222,5 +3222,14 @@ fn((() => {})());`},
 					MessageId: "contextuallyUnnecessary",
 				},
 			},
+		},
+		{
+			Code:   "const x: string | null = 'a' as string | null;\nvoid x;",
+			Output: []string{"const x: string | null = 'a';\nvoid x;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
 		}})
 }


### PR DESCRIPTION
Adds regression coverage for #990, where a string literal asserted to a nullable wider type should be reported as contextually unnecessary when the receiver already accepts the original expression type.

This is intentionally test-only coverage on top of the existing no-unnecessary-type-assertion fix branch.

Closes #992
Fixes #990
