### PR TITLE
test(no-unnecessary-type-arguments): sync tests with typescript-eslint

### DIFF
--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
@@ -193,6 +193,15 @@ const button = <Button<string> />;
       `,
 			Tsx: true,
 		},
+		{Code: `
+function f<T = number>() {}
+const g = f<number>;
+    `},
+		{Code: `
+function f<T = number>() {}
+function takesFn(fn: () => void) {}
+takesFn(f<number>);
+    `},
 
 		// OXC-specific cases not present in upstream.
 		{Code: `


### PR DESCRIPTION
## Summary

Sync `no-unnecessary-type-arguments` tests with the latest upstream typescript-eslint test file.

Upstream test file: `packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts`

Changes from typescript-eslint are included in this change
  - typescript-eslint/typescript-eslint#12220

This rule's tests are up to date with typescript-eslint `ef1fd28c68b10da2e5b56823da8491f10f2c2b97`.

Note: the local helper did not find a previously recorded upstream hash in the latest local test-file commit, so this sync uses the current upstream head and the observed unmatched upstream test-file change.

## Validation

- `git diff --check -- internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go` passed
- `go test ./internal/rules/no_unnecessary_type_arguments/...` could not run in this worktree because `typescript-go/go.mod` is missing; the `typescript-go` submodule directory is empty.