### PR TITLE
fix(no-unnecessary-type-arguments): preserve constructor inference

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-type-arguments.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-type-arguments.snap
@@ -250,3 +250,12 @@ Message: This is the default value for this type parameter, so it can be omitted
      |   ~~~~~
    6 |       
 ---
+
+[TestNoUnnecessaryTypeArguments/invalid-28 - 1]
+Diagnostic 1: unnecessaryTypeParameter (5:15 - 5:21)
+Message: This is the default value for this type parameter, so it can be omitted.
+   4 | }
+   5 | new C<string, unknown>('value');
+     |               ~~~~~~~
+   6 |       
+---

--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
@@ -120,7 +120,67 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 			return nil
 		}
 
-		checkArgsAndParameters := func(arguments *ast.NodeList, parameters []*ast.Node) {
+		typeNodeReferencesTypeParameter := func(typeNode *ast.Node, typeParameterSymbols map[*ast.Symbol]struct{}) bool {
+			var visit func(node *ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if node == nil {
+					return false
+				}
+
+				if ast.IsIdentifier(node) {
+					if symbol := ctx.TypeChecker.GetSymbolAtLocation(node); symbol != nil {
+						if _, ok := typeParameterSymbols[symbol]; ok {
+							return true
+						}
+					}
+				}
+
+				return node.ForEachChild(func(child *ast.Node) bool {
+					return visit(child)
+				})
+			}
+
+			return visit(typeNode)
+		}
+
+		constructorArgumentsCanInferTypeParameters := func(node *ast.Node, parameters []*ast.Node) bool {
+			if !ast.IsNewExpression(node) || len(node.Arguments()) == 0 {
+				return false
+			}
+
+			typeParameterSymbols := make(map[*ast.Symbol]struct{}, len(parameters))
+			for _, parameter := range parameters {
+				name := parameter.Name()
+				if name == nil {
+					continue
+				}
+				if symbol := ctx.TypeChecker.GetSymbolAtLocation(name); symbol != nil {
+					typeParameterSymbols[symbol] = struct{}{}
+				}
+			}
+			if len(typeParameterSymbols) == 0 {
+				return false
+			}
+
+			signature := checker.Checker_getResolvedSignature(ctx.TypeChecker, node, nil, checker.CheckModeNormal)
+			if signature == nil {
+				return false
+			}
+			declaration := checker.Signature_declaration(signature)
+			if declaration == nil || declaration.FunctionLikeData() == nil {
+				return false
+			}
+
+			for _, parameter := range declaration.Parameters() {
+				if typeNode := parameter.Type(); typeNode != nil && typeNodeReferencesTypeParameter(typeNode, typeParameterSymbols) {
+					return true
+				}
+			}
+
+			return false
+		}
+
+		checkArgsAndParameters := func(node *ast.Node, arguments *ast.NodeList, parameters []*ast.Node) {
 			if arguments == nil || parameters == nil || len(arguments.Nodes) == 0 || len(parameters) == 0 {
 				return
 			}
@@ -171,6 +231,12 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 				return
 			}
 
+			// Removing the entire type argument list from a constructor can re-enable
+			// inference for all class type parameters used by constructor parameters.
+			if lastParamIndex == 0 && constructorArgumentsCanInferTypeParameters(node, parameters) {
+				return
+			}
+
 			ctx.ReportNodeWithFixes(typeArgument, buildUnnecessaryTypeParameterMessage(), func() []rule.RuleFix {
 				var removeRange core.TextRange
 				if lastParamIndex == 0 {
@@ -185,32 +251,32 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 		return rule.RuleListeners{
 			ast.KindExpressionWithTypeArguments: func(node *ast.Node) {
 				expr := node.AsExpressionWithTypeArguments()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromType(node, expr.Expression))
+				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromType(node, expr.Expression))
 			},
 			ast.KindTypeReference: func(node *ast.Node) {
 				expr := node.AsTypeReferenceNode()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromType(node, expr.TypeName))
+				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromType(node, expr.TypeName))
 			},
 
 			ast.KindCallExpression: func(node *ast.Node) {
 				expr := node.AsCallExpression()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node))
+				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindNewExpression: func(node *ast.Node) {
 				expr := node.AsNewExpression()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node))
+				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindTaggedTemplateExpression: func(node *ast.Node) {
 				expr := node.AsTaggedTemplateExpression()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node))
+				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindJsxOpeningElement: func(node *ast.Node) {
 				expr := node.AsJsxOpeningElement()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node))
+				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindJsxSelfClosingElement: func(node *ast.Node) {
 				expr := node.AsJsxSelfClosingElement()
-				checkArgsAndParameters(expr.TypeArguments, getTypeParametersFromCall(node))
+				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 		}
 	},

--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
@@ -439,6 +439,42 @@ async function useAppSession(event: H3Event) {
   return useSession<SessionData>(event, config);
 }
     `},
+		// https://github.com/oxc-project/oxc/issues/22915
+		{Code: `
+type RecordToTuple<T> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][];
+
+class RequestContext<
+  Values extends Record<string, unknown> | unknown = unknown,
+> {
+  constructor(
+    _iterable?: Values extends Record<string, unknown>
+      ? RecordToTuple<Partial<Values>>
+      : Iterable<readonly [string, unknown]>,
+  ) {}
+
+  set<K extends Values extends Record<string, unknown> ? keyof Values : string>(
+    _key: K,
+    _value: Values extends Record<string, unknown>
+      ? K extends keyof Values
+        ? Values[K]
+        : never
+      : unknown,
+  ): void {}
+}
+
+type UntypedRequestContext = RequestContext;
+
+function acceptsUntypedContext(_context: UntypedRequestContext): void {}
+
+const context = new RequestContext<unknown>([
+  ['instructions', 'Reply for the agent.'],
+  ['tools', {}],
+]);
+
+acceptsUntypedContext(context);
+    `},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `
@@ -967,6 +1003,27 @@ type Default = Record<string, any>;
 type Alias = Default;
 function f<T = Default>() {}
 f();
+      `,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					Line:      5,
+					MessageId: "unnecessaryTypeParameter",
+				},
+			},
+		},
+		{
+			Code: `
+class C<T, U = unknown> {
+  constructor(_value: U) {}
+}
+new C<string, unknown>('value');
+      `,
+			Output: []string{`
+class C<T, U = unknown> {
+  constructor(_value: U) {}
+}
+new C<string>('value');
       `,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{


### PR DESCRIPTION
`typescript/no-unnecessary-type-arguments` could remove an explicit default class type argument from `new` expressions even when constructor arguments would infer a different class type after the type argument list is removed. In the reported `RequestContext<unknown>(...)` case, the explicit `unknown` matches the default but is still semantically meaningful because omitting it narrows the constructed type from the iterable argument.

This change keeps reporting default type arguments for constructors when they are safe, but skips the fix when constructor parameter type annotations reference class type parameters that would become inferable from constructor arguments. A regression test covers the issue sample.

Fixes oxc-project/oxc#22915