### PR TITLE
refactor: remove `OXLINT_TSGOLINT_TIMINGS` env var

### DIFF
--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -401,9 +401,8 @@ func runHeadless(args []string) int {
 		}
 	})
 
-	requestTimings := opts.debugTimings || os.Getenv("OXLINT_TSGOLINT_TIMINGS") == "1"
 	var timingStore *linter.RuleTimingStore
-	if requestTimings {
+	if opts.debugTimings {
 		timingStore = linter.NewRuleTimingStore()
 	}
 
@@ -459,7 +458,7 @@ func runHeadless(args []string) int {
 
 	wg.Wait()
 
-	if requestTimings {
+	if opts.debugTimings {
 		if err := writeMessage(os.Stdout, headlessMessageTypeTiming, headlessTimingPayloadFromRecords(timingStore.Collect())); err != nil {
 			log.Printf("ERROR: failed to write timing output: %v", err)
 			return 1


### PR DESCRIPTION
The inclusion of `OXLINT_TSGOLINT_TIMINGS` muddies the water w.r.t. exactly what our API surface area.

Users that wish to get timings from type aware rules should use `--debug timings` via oxlint. This will supply the correct flags to tsgolint.

We can consider adding this back in future if we determine there is a need for it, but in the mean time, it's sensible to keep the API surface area small.