### PR TITLE
fix(prefer-optional-chain): optional chain type assertion handling

### DIFF
--- a/internal/rule_tester/__snapshots__/prefer-optional-chain.snap
+++ b/internal/rule_tester/__snapshots__/prefer-optional-chain.snap
@@ -5389,3 +5389,10 @@ Message: Prefer using an optional chain expression instead, as it's more concise
    4 | 
   Suggestion 1: [optionalChainSuggest] Change to an optional chain.
 ---
+
+[TestPreferOptionalChainRule/invalid-601 - 1]
+Diagnostic 1: preferOptionalChain (1:1 - 1:69)
+Message: Prefer using an optional chain expression instead, as it's more concise and easier to read.
+   1 | foo && foo[bar as string | number] && foo[bar as string | number].baz;
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---

--- a/internal/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -308,17 +308,13 @@ func unwrapForComparison(n *ast.Node) *ast.Node {
 			n = n.AsParenthesizedExpression().Expression
 		case ast.IsNonNullExpression(n):
 			n = n.AsNonNullExpression().Expression
-		case n.Kind == ast.KindAsExpression:
-			n = n.AsAsExpression().Expression
-		case n.Kind == ast.KindTypeAssertionExpression:
-			n = n.AsTypeAssertion().Expression
 		default:
 			return n
 		}
 	}
 }
 
-// Ignores parentheses, non-null assertions, type assertions.
+// Ignores parentheses and non-null assertions.
 func areNodesStructurallyEqual(a, b *ast.Node) bool {
 	a = unwrapForComparison(a)
 	b = unwrapForComparison(b)
@@ -388,6 +384,16 @@ func areNodesStructurallyEqual(a, b *ast.Node) bool {
 			}
 		}
 		return true
+
+	case ast.KindAsExpression:
+		aAs := a.AsAsExpression()
+		bAs := b.AsAsExpression()
+		return areNodesStructurallyEqual(aAs.Expression, bAs.Expression)
+
+	case ast.KindTypeAssertionExpression:
+		aAssertion := a.AsTypeAssertion()
+		bAssertion := b.AsTypeAssertion()
+		return areNodesStructurallyEqual(aAssertion.Expression, bAssertion.Expression)
 
 	case ast.KindStringLiteral, ast.KindNumericLiteral, ast.KindBigIntLiteral,
 		ast.KindNoSubstitutionTemplateLiteral:

--- a/internal/rules/prefer_optional_chain/prefer_optional_chain_test.go
+++ b/internal/rules/prefer_optional_chain/prefer_optional_chain_test.go
@@ -4219,6 +4219,12 @@ foo.bar?.() === undefined || foo.bar?.().baz;
               intervention.projectId.toString(),
         );
       `,
+	}, rule_tester.ValidTestCase{
+		Code: `
+        export function buggy_memberReceiver(e: { relatedTarget: EventTarget | null }): void {
+          if (!e.relatedTarget || !(e.relatedTarget as HTMLElement).closest('.c')) {}
+        }
+      `,
 	})
 
 	// --- Spacing sanity checks ---
@@ -4267,6 +4273,16 @@ item?.value === null;
 `,
 					},
 				},
+			},
+		},
+	})
+
+	invalidCases = append(invalidCases, rule_tester.InvalidTestCase{
+		Code:   `foo && foo[bar as string | number] && foo[bar as string | number].baz;`,
+		Output: []string{`foo?.[bar as string | number]?.baz;`},
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				MessageId: "preferOptionalChain",
 			},
 		},
 	})


### PR DESCRIPTION
This aligns `prefer-optional-chain` with upstream `typescript-eslint` behavior for type assertions in access chains. Type assertions are now kept opaque during chain comparison instead of being unwrapped, so patterns like `!e.relatedTarget || !(e.relatedTarget as HTMLElement).closest(...)` are not treated as safe optional-chain candidates.

A regression case was added for the reported member-expression receiver scenario. This avoids producing an unsafe autofix that moves `?.` onto the method call and drops the original null guard.

fixes https://github.com/oxc-project/tsgolint/issues/1008