### PR TITLE
fix(linter): cap checker pool and workers to 4, add panic recovery per-file

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -462,7 +462,8 @@ func RunLinterOnProgram(options RunLinterOnProgramOptions) error {
 	logLevel := options.LogLevel
 	program := options.Program
 	files := options.Files
-	workers := options.Workers
+	// Cap workers to prevent excessive goroutine count and GC pressure
+	workers := min(options.Workers, 4)
 	getRulesForFile := options.GetRulesForFile
 	onDiagnostic := options.OnDiagnostic
 	onInternalDiagnostic := options.OnInternalDiagnostic
@@ -501,38 +502,49 @@ func RunLinterOnProgram(options RunLinterOnProgramOptions) error {
 					ctx.TypeChecker = w.checker
 
 					for file := range w.queue {
-						if logLevel == utils.LogLevelDebug {
-							log.Print(file.FileName())
-						}
-						ctxBuilder.file = file
-						ctx.SourceFile = file
-
-						rules := getRulesForFile(file)
-						for _, r := range rules {
-							ctxBuilder.ruleName = r.Name
-							for kind, listener := range r.Run(ctx) {
-								listeners, ok := registeredListeners[kind]
-								if !ok {
-									listeners = make([]taggedListener, 0, len(rules))
+						func() {
+							defer func() {
+								if r := recover(); r != nil {
+									log.Printf("panic in rule %q while processing %s: %v", ctxBuilder.ruleName, file.FileName(), r)
+									for k := range registeredListeners {
+										registeredListeners[k] = registeredListeners[k][:0]
+									}
 								}
-								registeredListeners[kind] = append(listeners, taggedListener{ruleName: r.Name, fn: listener})
-							}
-						}
+							}()
 
-						runListeners := func(kind ast.Kind, node *ast.Node) {
-							if listeners, ok := registeredListeners[kind]; ok {
-								for _, listener := range listeners {
-									ctxBuilder.ruleName = listener.ruleName
-									listener.fn(node)
+							if logLevel == utils.LogLevelDebug {
+								log.Print(file.FileName())
+							}
+							ctxBuilder.file = file
+							ctx.SourceFile = file
+
+							rules := getRulesForFile(file)
+							for _, r := range rules {
+								ctxBuilder.ruleName = r.Name
+								for kind, listener := range r.Run(ctx) {
+									listeners, ok := registeredListeners[kind]
+									if !ok {
+										listeners = make([]taggedListener, 0, len(rules))
+									}
+									registeredListeners[kind] = append(listeners, taggedListener{ruleName: r.Name, fn: listener})
 								}
 							}
-						}
 
-						visitLintNodes(file, runListeners)
-						// Instead of clearing the map, we clear the slices in-place to avoid re-allocating memory for the listeners on each file.
-						for k := range registeredListeners {
-							registeredListeners[k] = registeredListeners[k][:0]
-						}
+							runListeners := func(kind ast.Kind, node *ast.Node) {
+								if listeners, ok := registeredListeners[kind]; ok {
+									for _, listener := range listeners {
+										ctxBuilder.ruleName = listener.ruleName
+										listener.fn(node)
+									}
+								}
+							}
+
+							visitLintNodes(file, runListeners)
+							// Instead of clearing the map, we clear the slices in-place to avoid re-allocating memory for the listeners on each file.
+							for k := range registeredListeners {
+								registeredListeners[k] = registeredListeners[k][:0]
+							}
+						}()
 					}
 				}
 
@@ -559,52 +571,63 @@ func RunLinterOnProgram(options RunLinterOnProgramOptions) error {
 				ctx.TypeChecker = w.checker
 
 				for file := range w.queue {
-					if logLevel == utils.LogLevelDebug {
-						log.Print(file.FileName())
-					}
-					ctxBuilder.file = file
-					ctx.SourceFile = file
-
-					rules := getRulesForFile(file)
-					timingStats := make([]RuleTimingStat, len(rules))
-					for ruleIdx, r := range rules {
-						ctxBuilder.ruleName = r.Name
-						start := time.Now()
-						listenersByKind := r.Run(ctx)
-						recordTiming(&timingStats[ruleIdx], time.Since(start))
-						for kind, listener := range listenersByKind {
-							listeners, ok := registeredListeners[kind]
-							if !ok {
-								listeners = make([]timedTaggedListener, 0, len(rules))
+					func() {
+						defer func() {
+							if r := recover(); r != nil {
+								log.Printf("panic in rule %q while processing %s: %v", ctxBuilder.ruleName, file.FileName(), r)
+								for k := range registeredListeners {
+									registeredListeners[k] = registeredListeners[k][:0]
+								}
 							}
-							registeredListeners[kind] = append(listeners, timedTaggedListener{ruleName: r.Name, ruleIdx: ruleIdx, fn: listener})
-						}
-					}
+						}()
 
-					runListeners := func(kind ast.Kind, node *ast.Node) {
-						if listeners, ok := registeredListeners[kind]; ok {
-							for _, listener := range listeners {
-								ctxBuilder.ruleName = listener.ruleName
-								start := time.Now()
-								listener.fn(node)
-								recordTiming(&timingStats[listener.ruleIdx], time.Since(start))
+						if logLevel == utils.LogLevelDebug {
+							log.Print(file.FileName())
+						}
+						ctxBuilder.file = file
+						ctx.SourceFile = file
+
+						rules := getRulesForFile(file)
+						timingStats := make([]RuleTimingStat, len(rules))
+						for ruleIdx, r := range rules {
+							ctxBuilder.ruleName = r.Name
+							start := time.Now()
+							listenersByKind := r.Run(ctx)
+							recordTiming(&timingStats[ruleIdx], time.Since(start))
+							for kind, listener := range listenersByKind {
+								listeners, ok := registeredListeners[kind]
+								if !ok {
+									listeners = make([]timedTaggedListener, 0, len(rules))
+								}
+								registeredListeners[kind] = append(listeners, timedTaggedListener{ruleName: r.Name, ruleIdx: ruleIdx, fn: listener})
 							}
 						}
-					}
 
-					visitLintNodes(file, runListeners)
-					for idx, stat := range timingStats {
-						if stat.Calls == 0 {
-							continue
+						runListeners := func(kind ast.Kind, node *ast.Node) {
+							if listeners, ok := registeredListeners[kind]; ok {
+								for _, listener := range listeners {
+									ctxBuilder.ruleName = listener.ruleName
+									start := time.Now()
+									listener.fn(node)
+									recordTiming(&timingStats[listener.ruleIdx], time.Since(start))
+								}
+							}
 						}
-						merged := localTimings[rules[idx].Name]
-						merged.add(stat)
-						localTimings[rules[idx].Name] = merged
-					}
-					// Instead of clearing the map, we clear the slices in-place to avoid re-allocating memory for the listeners on each file.
-					for k := range registeredListeners {
-						registeredListeners[k] = registeredListeners[k][:0]
-					}
+
+						visitLintNodes(file, runListeners)
+						for idx, stat := range timingStats {
+							if stat.Calls == 0 {
+								continue
+							}
+							merged := localTimings[rules[idx].Name]
+							merged.add(stat)
+							localTimings[rules[idx].Name] = merged
+						}
+						// Instead of clearing the map, we clear the slices in-place to avoid re-allocating memory for the listeners on each file.
+						for k := range registeredListeners {
+							registeredListeners[k] = registeredListeners[k][:0]
+						}
+					}()
 				}
 			}
 

--- a/patches/0001-Adapt-project-service-for-single-run-mode.patch
+++ b/patches/0001-Adapt-project-service-for-single-run-mode.patch
@@ -24,7 +24,7 @@ index 37abaff97..19dac4dfc 100644
  	// stored in the old program's options.
  	createCheckerPool := func(program *compiler.Program) compiler.CheckerPool {
 -		checkerPool = newCheckerPool(4, program, nil)
-+		checkerPool = newCheckerPool(runtime.GOMAXPROCS(0), program, p.log)
++		checkerPool = newCheckerPool(min(4, runtime.GOMAXPROCS(0)), program, p.log)
  		return checkerPool
  	}
  


### PR DESCRIPTION
Patch 0001 set the checker pool size to `runtime.GOMAXPROCS(0)`, creating excessive concurrent goroutines with deep TypeScript type-checking stacks. The Go GC stack walker can get stuck scanning these stacks, pinning a core at 100% CPU. This makes my laptop heat up significantly.

It caps the checker pool to `min(4, runtime.GOMAXPROCS(0))` and also the linter workers to `min(options.Workers, 4)`. Then it wraps per-file processing in `defer/recover` so a rule panic doesn't abort the entire lint run.

Related: https://github.com/oxc-project/oxc/pull/23618