### PR TITLE
perf(consistent-return): defer per-function type resolution

### DIFF
--- a/internal/rules/consistent_return/consistent_return.go
+++ b/internal/rules/consistent_return/consistent_return.go
@@ -25,14 +25,14 @@ func buildUnexpectedReturnValueMessage(functionNameWithKind string) rule.RuleMes
 }
 
 type functionState struct {
-	node                 *ast.Node
-	upper                *functionState
-	hasReturn            bool
-	hasReturnValue       bool
-	hasMismatch          bool
-	allowsVoidReturn     bool
-	functionNameWithKind string
-	messageId            string
+	node                     *ast.Node
+	upper                    *functionState
+	hasReturn                bool
+	hasReturnValue           bool
+	hasMismatch              bool
+	allowsVoidReturn         bool
+	allowsVoidReturnComputed bool
+	messageId                string
 }
 
 func getFunctionNameWithKind(sourceFile *ast.SourceFile, node *ast.Node) string {
@@ -132,9 +132,9 @@ func getHasReturnValue(ctx rule.RuleContext, node *ast.ReturnStatement, treatUnd
 func reportMismatchedReturnStatement(ctx rule.RuleContext, node *ast.Node, currentFunction *functionState) {
 	switch currentFunction.messageId {
 	case "missingReturnValue":
-		ctx.ReportNode(node, buildMissingReturnValueMessage(currentFunction.functionNameWithKind))
+		ctx.ReportNode(node, buildMissingReturnValueMessage(getFunctionNameWithKind(ctx.SourceFile, currentFunction.node)))
 	case "unexpectedReturnValue":
-		ctx.ReportNode(node, buildUnexpectedReturnValueMessage(currentFunction.functionNameWithKind))
+		ctx.ReportNode(node, buildUnexpectedReturnValueMessage(getFunctionNameWithKind(ctx.SourceFile, currentFunction.node)))
 	}
 }
 
@@ -145,12 +145,22 @@ var ConsistentReturnRule = rule.Rule{
 
 		var currentFunction *functionState
 
+		// allowsVoidReturn lazily computes (and memoizes) whether the function may
+		// legitimately return void/thenable-void. This requires a GetTypeAtLocation
+		// call, which we defer until a return statement or the exit check actually
+		// needs it — most functions never reach those branches.
+		allowsVoidReturn := func(fn *functionState) bool {
+			if !fn.allowsVoidReturnComputed {
+				fn.allowsVoidReturn = isReturnVoidOrThenableVoid(ctx, fn.node)
+				fn.allowsVoidReturnComputed = true
+			}
+			return fn.allowsVoidReturn
+		}
+
 		enterFunction := func(node *ast.Node) {
 			currentFunction = &functionState{
-				node:                 node,
-				upper:                currentFunction,
-				allowsVoidReturn:     isReturnVoidOrThenableVoid(ctx, node),
-				functionNameWithKind: getFunctionNameWithKind(ctx.SourceFile, node),
+				node:  node,
+				upper: currentFunction,
 			}
 		}
 
@@ -159,9 +169,9 @@ var ConsistentReturnRule = rule.Rule{
 				if !currentFunction.hasMismatch &&
 					currentFunction.hasReturn &&
 					currentFunction.hasReturnValue &&
-					!currentFunction.allowsVoidReturn &&
-					currentFunction.node.Flags&ast.NodeFlagsHasImplicitReturn != 0 {
-					ctx.ReportNode(currentFunction.node, buildMissingReturnValueMessage(currentFunction.functionNameWithKind))
+					currentFunction.node.Flags&ast.NodeFlagsHasImplicitReturn != 0 &&
+					!allowsVoidReturn(currentFunction) {
+					ctx.ReportNode(currentFunction.node, buildMissingReturnValueMessage(getFunctionNameWithKind(ctx.SourceFile, currentFunction.node)))
 				}
 				currentFunction = currentFunction.upper
 			}
@@ -173,7 +183,7 @@ var ConsistentReturnRule = rule.Rule{
 			}
 
 			returnStatement := node.AsReturnStatement()
-			if returnStatement.Expression == nil && currentFunction.allowsVoidReturn {
+			if returnStatement.Expression == nil && allowsVoidReturn(currentFunction) {
 				return
 			}
 


### PR DESCRIPTION
Generated with Claude Code, reviewed and tested by me.

`consistent-return` previously did eager, per-function work on **every** function it entered, even though most functions never trigger a diagnostic:

- `isReturnVoidOrThenableVoid(ctx, node)` — a `GetTypeAtLocation` call — was run for every function on `enterFunction`.
- `getFunctionNameWithKind(...)` was computed up front and stored on every `functionState`, even when no report is ever emitted.

This PR defers both:

- **`allowsVoidReturn` is now lazy + memoized.** The `GetTypeAtLocation` call only happens when a `return;` statement or the function-exit check actually needs it. Functions that never reach those branches pay nothing.
- **The function name is computed only at report time**, where it is actually used, instead of for every function entered.

The visitor logic is otherwise unchanged; the exit-check condition is just reordered so the cheap flag checks short-circuit before the (now lazy) `allowsVoidReturn` call.

## Performance

Benchmarked over the [VS Code](https://github.com/microsoft/vscode) repo — 11,674 files, 18 threads, **646,186 rule calls**, 12 runs per binary, per-rule timing via `oxlint --debug=timings`.

| Metric | before | after | improvement |
|---|---:|---:|---:|
| mean | 7315.8 ms | 854.9 ms | **8.56× faster** |
| median | 7192.0 ms | 843.7 ms | 8.52× faster |
| min | 6755.7 ms | 782.5 ms | 8.63× faster |
| max | 8649.8 ms | 981.6 ms | 8.81× faster |
| stddev | 508.7 ms | 55.5 ms | — |

## Correctness

Diagnostics are unchanged. Running the rule in isolation over the same repo produces byte-for-byte identical output before and after (34,596 lines incl. warnings, sorted & diffed): **2035 warnings + 48 errors**, identical.

## Methodology

```bash
OXLINT_TSGOLINT_PATH=<binary> oxlint \
  --type-aware --quiet -A all -W typescript/consistent-return \
  --debug=timings -f default
```