### PR TITLE
perf(no-unnecessary-qualifier): skip symbol resolution outside namespaces.

### DIFF
--- a/internal/rules/no_unnecessary_qualifier/no_unnecessary_qualifier.go
+++ b/internal/rules/no_unnecessary_qualifier/no_unnecessary_qualifier.go
@@ -89,6 +89,13 @@ var NoUnnecessaryQualifierRule = rule.Rule{
 			if currentFailedNamespaceExpression != nil {
 				return
 			}
+			// A qualifier can only ever be unnecessary when we are inside an enum or
+			// namespace declaration (the only places that populate namespacesInScope).
+			// The vast majority of property accesses occur outside any such scope, so
+			// bail out before doing any (expensive) symbol resolution.
+			if len(namespacesInScope) == 0 {
+				return
+			}
 			if !qualifierIsUnnecessary(qualifier, name) {
 				return
 			}


### PR DESCRIPTION
Generated with Claude Code, tested and reviewed by me.

## Summary

A qualifier can only ever be *unnecessary* when the access occurs **inside an enum or namespace declaration** — those are the only constructs that populate `namespacesInScope`. Yet the rule was running `qualifierIsUnnecessary(...)` (which does symbol resolution) on essentially every qualified property access in the program, including the overwhelming majority that live outside any namespace.

This PR adds an early bail-out: if `namespacesInScope` is empty, return before doing any symbol resolution.

```go
if len(namespacesInScope) == 0 {
    return
}
```

In real-world code almost all qualified accesses are outside a namespace, so the expensive path is now skipped for them.

## Performance

Benchmarked over the [VS Code](https://github.com/microsoft/vscode) repo — 11,674 files, 18 threads, **3,041,167 rule calls**, 12 runs per binary, per-rule timing via `oxlint --debug=timings`.

| Metric | before | after | improvement |
|---|---:|---:|---:|
| mean | 3209.2 ms | 91.5 ms | **35.1× faster** |
| median | 3204.7 ms | 90.4 ms | 35.4× faster |
| min | 2851.9 ms | 85.6 ms | 33.3× faster |
| max | 3837.0 ms | 104.5 ms | 36.7× faster |
| stddev | 255.5 ms | 5.0 ms | — |

## Correctness

Diagnostics are unchanged. Running the rule in isolation over the same repo produces byte-for-byte identical output before and after (1,375 lines incl. warnings, sorted & diffed): **114 warnings + 48 errors**, identical.

## Methodology

```bash
OXLINT_TSGOLINT_PATH=<binary> oxlint \
  --type-aware --quiet -A all -W typescript/no-unnecessary-qualifier \
  --debug=timings -f default
```