### PR TITLE
perf(no-unnecessary-type-parameters): reuse AST-walk visitor closure

### DIFF
--- a/internal/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -93,10 +93,6 @@ func collectTypeParameterReferenceNodes(ctx rule.RuleContext, node *ast.Node, sy
 	references := make([]*ast.Node, 0, 8)
 
 	var walk func(current *ast.Node)
-	// Allocate the ForEachChildAndJSDoc visitor once and reuse it for every
-	// node. Declaring the callback inline inside walk would heap-allocate a new
-	// closure on every recursive call (once per node in the subtree), which on
-	// large files dominated this rule's allocation churn (and thus GC time).
 	visitChild := func(child *ast.Node) bool {
 		walk(child)
 		return false

--- a/internal/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -93,6 +93,14 @@ func collectTypeParameterReferenceNodes(ctx rule.RuleContext, node *ast.Node, sy
 	references := make([]*ast.Node, 0, 8)
 
 	var walk func(current *ast.Node)
+	// Allocate the ForEachChildAndJSDoc visitor once and reuse it for every
+	// node. Declaring the callback inline inside walk would heap-allocate a new
+	// closure on every recursive call (once per node in the subtree), which on
+	// large files dominated this rule's allocation churn (and thus GC time).
+	visitChild := func(child *ast.Node) bool {
+		walk(child)
+		return false
+	}
 	walk = func(current *ast.Node) {
 		if current == nil {
 			return
@@ -108,10 +116,7 @@ func collectTypeParameterReferenceNodes(ctx rule.RuleContext, node *ast.Node, sy
 			}
 		}
 
-		ast.ForEachChildAndJSDoc(current, ctx.SourceFile, func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
+		ast.ForEachChildAndJSDoc(current, ctx.SourceFile, visitChild)
 	}
 
 	walk(node)


### PR DESCRIPTION
## Summary

`no-unnecessary-type-parameters` walks each generic node's subtree
(`collectTypeParameterReferenceNodes`) to find references to a type parameter.
The `ForEachChildAndJSDoc` callback was declared **inline inside the recursive
`walk`**, so Go heap-allocated a fresh closure on **every recursive call — once
per node in the subtree, per type parameter**.

Hoisting that callback to a single `visitChild` closure (allocated once and
reused for the whole walk) removes the per-node allocation. Behavior is
unchanged — the callback body is identical, it's just no longer re-created at
every node.

```go
var walk func(current *ast.Node)
// allocated once, reused for every node
visitChild := func(child *ast.Node) bool {
    walk(child)
    return false
}
walk = func(current *ast.Node) {
    ...
    ast.ForEachChildAndJSDoc(current, ctx.SourceFile, visitChild) // was: an inline closure here
}
```

## Benchmark

Exact `-benchmem` microbenchmark, **this rule only**, single-threaded, over VS
Code's `src/tsconfig.json` (**7,325 files**). Only the rule file was toggled
between baseline (`963aa60~1`) and optimized — so the entire delta is this
change. Allocation counts are exact and deterministic across re-runs (~14-alloc
jitter from map iteration order only).

| Metric        |  Baseline |  Optimized | Change                  |
| ------------- | --------: | ---------: | ----------------------- |
| **allocs/op** |   747,319 |    235,166 | **−68.5% (3.18× fewer)** |
| B/op          |  457.8 MB |   449.6 MB | −1.8%                   |
| ns/op         |   12.63 s |    12.69 s | ~unchanged              |
| diagnostics   |       223 |        223 | identical ✓             |

Hoisting the callback out of the recursive walk removes **~512k heap
allocations per pass** — a 68% drop in allocation count for this rule.

## Why bytes and single-thread wall-clock barely move

The eliminated closures escape analysis but are ~16 B each, so the byte
footprint moves little (−1.8%), and single-threaded wall-clock is flat (time is
dominated by type-checking). The payoff is **GC pressure / allocation churn**,
which surfaces under real multi-threaded, multi-rule runs rather than
single-rule latency. Cutting allocation *count* (which drives GC scan work) by
68% is the goal here.

## Notes

- Behavior is unchanged; existing tests pass and the diagnostic count over the
  VS Code corpus is identical (223).
- Same pattern (inline `ForEachChild*` callback inside a recursive walk) exists
  in a couple of other rules; this PR covers `no-unnecessary-type-parameters`
  only, the slowest type-aware rule in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
