### PR TITLE
perf(no-confusing-void-expression): check ancestor position before type query

### DIFF
--- a/internal/rules/no_confusing_void_expression/no_confusing_void_expression.go
+++ b/internal/rules/no_confusing_void_expression/no_confusing_void_expression.go
@@ -178,14 +178,20 @@ var NoConfusingVoidExpressionRule = rule.Rule{
 		}
 
 		checkExpression := func(node *ast.Node) {
-			t := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node)
-			if !utils.IsTypeFlagSet(t, checker.TypeFlagsVoidLike) {
-				return
-			}
-
+			// Cheap, pure-AST check first: most call/await expressions sit in a
+			// valid position (e.g. an expression statement), for which
+			// findInvalidAncestor returns nil immediately. Doing this before the
+			// (expensive) type query means those nodes never pay for it. The two
+			// guards are independent and side-effect free, so order does not
+			// affect which nodes report.
 			invalidAncestor := findInvalidAncestor(node)
 			if invalidAncestor == nil {
 				// void expression is in valid position
+				return
+			}
+
+			t := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node)
+			if !utils.IsTypeFlagSet(t, checker.TypeFlagsVoidLike) {
 				return
 			}
 

--- a/internal/rules/no_confusing_void_expression/no_confusing_void_expression.go
+++ b/internal/rules/no_confusing_void_expression/no_confusing_void_expression.go
@@ -178,12 +178,6 @@ var NoConfusingVoidExpressionRule = rule.Rule{
 		}
 
 		checkExpression := func(node *ast.Node) {
-			// Cheap, pure-AST check first: most call/await expressions sit in a
-			// valid position (e.g. an expression statement), for which
-			// findInvalidAncestor returns nil immediately. Doing this before the
-			// (expensive) type query means those nodes never pay for it. The two
-			// guards are independent and side-effect free, so order does not
-			// affect which nodes report.
 			invalidAncestor := findInvalidAncestor(node)
 			if invalidAncestor == nil {
 				// void expression is in valid position


### PR DESCRIPTION
Generated with Claude Code, tested and reviewed by me. Run against VS Code to ensure no diagnostic differences and to confirm the performance diff.

## Summary

`no-confusing-void-expression`'s `checkExpression` computed `GetConstrainedTypeAtLocation` (an expensive type-checker call) up front, then discarded the result whenever `findInvalidAncestor` returned `nil` — which is the common case, since most call/await expressions sit in a valid position (e.g. a plain expression statement).

This reorders the two guards so the cheap, pure-AST `findInvalidAncestor` runs **first** and returns early; the type query now only runs for the small fraction of expressions actually in an invalid position. The two guards are independent and side-effect free, so this does **not** change which nodes report.

```go
checkExpression := func(node *ast.Node) {
    // cheap pure-AST check first — most nodes return here
    invalidAncestor := findInvalidAncestor(node)
    if invalidAncestor == nil {
        return
    }
    // expensive type query only for the few nodes that reach it
    t := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node)
    if \!utils.IsTypeFlagSet(t, checker.TypeFlagsVoidLike) {
        return
    }
    ...
}
```

## Benchmark

Measured over the **VS Code** repo (988,418 rule calls for this rule), 12 runs each before-and-after on a cold run, to ensure the difference was real:

| | before | after | improvement |
| --- | ---: | ---: | --- |
| no-confusing-void-expression | 12877.2 ms | 10951.7 ms | **1.18× (−14.9%)** |

Note that a warmed benchmark will not display this result, as the perf difference is only really visible/useful when there hasn't been a prior run to grab/warm the type info (which is very useful for CI, for example).

## Notes

- Behavior is unchanged; the existing test suite passes. The two guards are both side-effect-free and were already AND-ed, so reordering them cannot change which nodes report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)