### PR TITLE
perf(no-unnecessary-type-conversion): hoist constant builtin-name slices

### DIFF
--- a/internal/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.go
+++ b/internal/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.go
@@ -13,6 +13,15 @@ import (
 	"github.com/typescript-eslint/tsgolint/internal/utils"
 )
 
+// Built-in symbol-name sets for each conversion function, hoisted to package
+// scope so they aren't reallocated on every matching call expression.
+var (
+	bigIntConversionBuiltins  = []string{"BigInt", "BigIntConstructor"}
+	booleanConversionBuiltins = []string{"Boolean", "BooleanConstructor"}
+	numberConversionBuiltins  = []string{"Number", "NumberConstructor"}
+	stringConversionBuiltins  = []string{"String", "StringConstructor"}
+)
+
 func buildUnnecessaryTypeConversionDiagnostic(conversion, expression core.TextRange, expressionType string) rule.RuleDiagnostic {
 	return rule.RuleDiagnostic{
 		Message: rule.RuleMessage{
@@ -280,19 +289,19 @@ var NoUnnecessaryTypeConversionRule = rule.Rule{
 			switch callee.AsIdentifier().Text {
 			case "BigInt":
 				typeFlag = checker.TypeFlagsBigIntLike
-				builtins = []string{"BigInt", "BigIntConstructor"}
+				builtins = bigIntConversionBuiltins
 				ok = true
 			case "Boolean":
 				typeFlag = checker.TypeFlagsBooleanLike
-				builtins = []string{"Boolean", "BooleanConstructor"}
+				builtins = booleanConversionBuiltins
 				ok = true
 			case "Number":
 				typeFlag = checker.TypeFlagsNumberLike
-				builtins = []string{"Number", "NumberConstructor"}
+				builtins = numberConversionBuiltins
 				ok = true
 			case "String":
 				typeFlag = checker.TypeFlagsStringLike
-				builtins = []string{"String", "StringConstructor"}
+				builtins = stringConversionBuiltins
 				ok = true
 			}
 


### PR DESCRIPTION
## What

The four `[]string{"X", "XConstructor"}` literals in `reportBuiltInConversionCall` were rebuilt on every matching `BigInt`/`Boolean`/`Number`/`String` call expression. Escape analysis (`go build -gcflags=-m`) confirms all four escape to the heap, since they're passed variadically into `IsBuiltinSymbolLike`.

They're compile-time constants used read-only (only compared downstream, never mutated), so this hoists them to package-level vars — one allocation for the whole program instead of one per matching call site.

## Benchmark

Per-rule microbenchmark running only this rule over a fixture with 1,600 builtin-conversion call expressions (`main` vs this branch, Apple M5 Pro):

| | allocs/op | B/op | ns/op |
|---|---|---|---|
| before | 4,859 | 109,305 | ~320µs |
| after | 3,259 | 58,105 | ~301µs |
| **delta** | **−1,600 (−33%)** | **−51,200 (−47%)** | ~flat |

That's exactly **−1 alloc / −32 B per matching conversion call** (the 2-string backing array). This is a GC-pressure reduction, not a latency change — wall-clock is flat.

## Safety

The slices flow only into `IsBuiltinSymbolLike(...builtins...)`, which compares elements; no mutation, no retention. Sharing a single backing array is semantically identical. Rule tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)