### PR TITLE
fix(no-unnecessary-condition): don't flag required `?.` on deferred conditional return types

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-condition.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-condition.snap
@@ -1961,3 +1961,19 @@ Message: Unnecessary conditional, value is always truthy.
      |     ~~~~
    3 |       
 ---
+
+[TestNoUnnecessaryConditionRule/invalid-142 - 1]
+Diagnostic 1: neverOptionalChain (6:11 - 6:35)
+Message: Unnecessary optional chain on a non-nullish value.
+   5 | declare const b: Box;
+   6 | const r = b.get('a')?.get('b')?.get('c');
+     |           ~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 | 
+
+Diagnostic 2: neverOptionalChain (6:11 - 6:25)
+Message: Unnecessary optional chain on a non-nullish value.
+   5 | declare const b: Box;
+   6 | const r = b.get('a')?.get('b')?.get('c');
+     |           ~~~~~~~~~~~~~~~
+   7 | 
+---

--- a/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -445,6 +445,34 @@ var NoUnnecessaryConditionRule = rule.Rule{
 			return constraintType, false
 		}
 
+		// constrainConditionalType returns the base constraint of a deferred
+		// conditional (the union of its branches). An unresolved conditional has no
+		// nullish flag, so isNullishType misreads it.
+		constrainConditionalType := func(t *checker.Type) *checker.Type {
+			if t == nil || checker.Type_flags(t)&checker.TypeFlagsConditional == 0 {
+				return t
+			}
+			if constraint := checker.Checker_getBaseConstraintOfType(ctx.TypeChecker, t); constraint != nil {
+				return constraint
+			}
+			return t
+		}
+
+		// isNullishType, but applies constrainConditionalType at every level,
+		// recursing into union members.
+		var isConstrainedNullishType func(t *checker.Type) bool
+		isConstrainedNullishType = func(t *checker.Type) bool {
+			if t == nil {
+				return false
+			}
+			t = constrainConditionalType(t)
+			if utils.IsUnionType(t) {
+				return slices.ContainsFunc(t.Types(), isConstrainedNullishType)
+			}
+			flags := checker.Type_flags(t)
+			return flags&(checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid) != 0
+		}
+
 		getPropertyNameFromLiteralType := func(t *checker.Type) (string, bool) {
 			if t == nil {
 				return "", false
@@ -717,8 +745,9 @@ var NoUnnecessaryConditionRule = rule.Rule{
 			for _, part := range prevType.Types() {
 				signatures := ctx.TypeChecker.GetCallSignatures(part)
 				for _, sig := range signatures {
+					// Constrain so a conditional nullish return isn't misread as non-nullable.
 					returnType := ctx.TypeChecker.GetReturnTypeOfSignature(sig)
-					if returnType != nil && isNullishType(returnType) {
+					if returnType != nil && isConstrainedNullishType(returnType) {
 						isOwnNullable = true
 						break
 					}
@@ -1293,7 +1322,7 @@ var NoUnnecessaryConditionRule = rule.Rule{
 				}
 			}
 
-			if !isNullishType(exprType) {
+			if !isConstrainedNullishType(exprType) {
 				ctx.ReportNode(node, buildNeverOptionalChainMessage())
 			}
 		}

--- a/internal/rules/no_unnecessary_condition/no_unnecessary_condition_test.go
+++ b/internal/rules/no_unnecessary_condition/no_unnecessary_condition_test.go
@@ -1391,6 +1391,57 @@ assertSecond(...[], true);
 	if (typeof value === 'object' && value !== null) { console.log('foo'); }
 }`,
 		},
+		// Deferred conditional with a nullish branch, left unresolved on chains of
+		// length >= 3. The `?.` links are required, so none of these is reported.
+		{Code: `
+interface Box {
+  get<H = never>(name: string): [H] extends [never] ? Box | null : Box;
+}
+declare const b: Box;
+const r = b.get('a')?.get('b')?.get('c');
+`},
+		{Code: `
+interface BoxUndef {
+  get<H = never>(name: string): [H] extends [never] ? BoxUndef | undefined : BoxUndef;
+}
+declare const b: BoxUndef;
+const r = b.get('a')?.get('b')?.get('c');
+`},
+		{Code: `
+interface BoxExplicit {
+  get<H>(name: string): [H] extends [never] ? BoxExplicit | null : BoxExplicit;
+}
+declare const b: BoxExplicit;
+const r = b.get<never>('a')?.get<never>('b')?.get<never>('c');
+`},
+		{Code: `
+type Ret<H> = [H] extends [never] ? BoxAlias | null : BoxAlias;
+interface BoxAlias {
+  get<H = never>(name: string): Ret<H>;
+}
+declare const b: BoxAlias;
+const r = b.get('a')?.get('b')?.get('c');
+`},
+		// Deferred conditional nested as a union member (`X | (cond)`). The
+		// nullish branch must still be seen through the union.
+		{Code: `
+interface BoxUnion {
+  get<H = never>(name: string): BoxUnion | ([H] extends [never] ? null : BoxUnion);
+}
+declare const b: BoxUnion;
+const r = b.get('a')?.get('b')?.get('c');
+`},
+		// Deferred conditional reached through property access in a generic scope,
+		// where the type parameter keeps it unresolved. Exercises the nullish check
+		// in checkOptionalChain rather than the call-expression path.
+		{Code: `
+interface BoxGeneric<H> {
+  next: [H] extends [never] ? BoxGeneric<H> | null : BoxGeneric<H>;
+}
+function foo<T>(b: BoxGeneric<T>): unknown {
+  return b.next?.next?.next;
+}
+`},
 	}, []rule_tester.InvalidTestCase{
 		// Basic always truthy/falsy cases
 		{
@@ -2851,6 +2902,22 @@ if (true || false) {}
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "alwaysFalsy"},
 				{MessageId: "alwaysTruthy"},
+			},
+		},
+		// Precision guard: both branches non-nullish, so the `?.` links are
+		// unnecessary and must be reported. Appended last to keep index-keyed
+		// snapshots aligned.
+		{
+			Code: `
+interface Box {
+  get<H = never>(name: string): [H] extends [never] ? Box : Box;
+}
+declare const b: Box;
+const r = b.get('a')?.get('b')?.get('c');
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "neverOptionalChain"},
+				{MessageId: "neverOptionalChain"},
 			},
 		},
 	})


### PR DESCRIPTION
Generated with Claude Code, reviewed and tested by me.

A generic method returning a deferred conditional makes the chain below report a false "Unnecessary optional chain on a non-nullish value", even though `b.get('a')` is `Box | null` (tsc reports TS2531 without the `?.`).

```ts
interface Box {
  get<H = never>(name: string): [H] extends [never] ? Box | null : Box;
}
declare const b: Box;
const r = b.get('a')?.get('b')?.get('c');
```

On a chain of 3+ links TypeScript leaves the inner conditional unresolved (`TypeFlagsConditional`), which carries no nullish flag, so `isNullishType` reads it as non-nullish. In `isCallExpressionNullableOriginFromCallee` that makes the callee return look non-nullable, the chain's `| undefined` is attributed to the optional-chain short-circuit, and `removeNullishFromType` drops the real `| null`. The same unresolved conditional also reaches the final nullish check in `checkOptionalChain` directly when the chain is property access whose type stays unresolved (a type parameter in scope).

A new `isConstrainedNullishType` replaces a conditional with its base constraint (the union of its branches) before the nullish test, recurses into union members, and is gated on `TypeFlagsConditional` so other types are unchanged. It is used at both nullishness checks the optional-chain path relies on: the callee-return check and the final check in `checkOptionalChain`. A deferred conditional whose branches are all non-nullish is still reported.

Adds 6 valid regression cases (`| null`/`| undefined` branch, explicit `<never>`, named alias, union-member conditional, property access in a generic scope) and an invalid precision case; the snapshot diff is additive.