### PR TITLE
fix(no-unnecessary-type-assertions): generic array false positive

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-type-assertion.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-type-assertion.snap
@@ -1653,3 +1653,35 @@ Message: This assertion is unnecessary since the receiver accepts the original t
    4 | const value: unknown = 42 as unknown;
      |                        ~~~~~~~~~~~~~
 ---
+
+[TestNoUnnecessaryTypeAssertion/invalid-122 - 1]
+Diagnostic 1: contextuallyUnnecessary (2:4 - 2:16)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   1 | declare function f<T>(xs: string[], tag: T): void;
+   2 | f(['x' as string], 1);
+     |    ~~~~~~~~~~~~~
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-123 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:4 - 3:16)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function f<T>(xs: StringsWithMeta<T>, tag: T): void;
+   3 | f(['x' as string], 1);
+     |    ~~~~~~~~~~~~~
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-124 - 1]
+Diagnostic 1: contextuallyUnnecessary (4:4 - 4:16)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   3 | declare function f<T>(value: T): void;
+   4 | f(['x' as string]);
+     |    ~~~~~~~~~~~~~
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-125 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:7 - 3:19)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function f<T>(pair: readonly [T, string], tag: T): void;
+   3 | f([1, 'x' as string], 1);
+     |       ~~~~~~~~~~~~~
+---

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -630,6 +630,59 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			})
 		}
 
+		hasGenericInferenceParameterAtArgument := func(callOrNew *ast.Node, argIndex int, elementPath []int) bool {
+			signature := checker.Checker_getResolvedSignature(ctx.TypeChecker, callOrNew, nil, checker.CheckModeNormal)
+			if signature == nil {
+				return false
+			}
+			for signature.Target() != nil {
+				signature = signature.Target()
+			}
+			if len(signature.TypeParameters()) == 0 {
+				return false
+			}
+
+			params := checker.Signature_parameters(signature)
+			if len(params) == 0 {
+				return false
+			}
+
+			paramIndex := argIndex
+			if paramIndex >= len(params) {
+				paramIndex = len(params) - 1
+			}
+			param := params[paramIndex]
+			paramType := checker.Checker_getTypeOfSymbol(ctx.TypeChecker, param)
+			if valueDeclaration := param.ValueDeclaration; valueDeclaration != nil &&
+				valueDeclaration.Kind == ast.KindParameter &&
+				valueDeclaration.AsParameterDeclaration().DotDotDotToken != nil {
+				if typeArguments := getTypeArguments(paramType); len(typeArguments) > 0 {
+					typeArgumentIndex := 0
+					if len(typeArguments) > 1 {
+						typeArgumentIndex = min(argIndex-paramIndex, len(typeArguments)-1)
+					}
+					paramType = typeArguments[typeArgumentIndex]
+				}
+			}
+			for _, elementIndex := range elementPath {
+				var elementType *checker.Type
+				if checker.IsTupleType(paramType) {
+					typeArguments := checker.Checker_getTypeArguments(ctx.TypeChecker, paramType)
+					if len(typeArguments) > 0 {
+						elementType = typeArguments[min(elementIndex, len(typeArguments)-1)]
+					}
+				} else {
+					elementType = utils.GetNumberIndexType(ctx.TypeChecker, paramType)
+				}
+				if elementType == nil {
+					break
+				}
+				paramType = elementType
+			}
+
+			return containsTypeVariable(paramType)
+		}
+
 		genericsMismatch := func(uncast, contextual *checker.Type) bool {
 			return slices.ContainsFunc(checker.Checker_getPropertiesOfType(ctx.TypeChecker, contextual), func(prop *ast.Symbol) bool {
 				contextualSigs := checker.Checker_getSignaturesOfType(
@@ -752,6 +805,54 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 				ast.IsLogicalOrCoalescingAssignmentOperator(parent.AsBinaryExpression().OperatorToken.Kind)
 		}
 
+		isNestedInArrayLiteralArgumentToGenericCall := func(node *ast.Node) bool {
+			elementPath := []int{}
+			for child, current := node, node.Parent; current != nil; child, current = current, current.Parent {
+				if ast.IsFunctionExpression(current) || ast.IsArrowFunction(current) {
+					return false
+				}
+				if !ast.IsArrayLiteralExpression(current) {
+					continue
+				}
+				elementIndex := slices.IndexFunc(current.AsArrayLiteralExpression().Elements.Nodes, func(element *ast.Node) bool {
+					return element == child || ast.SkipParentheses(element) == ast.SkipParentheses(child)
+				})
+				if elementIndex == -1 {
+					continue
+				}
+				elementPath = append([]int{elementIndex}, elementPath...)
+
+				callArgument := current
+				parent := parentThroughParens(callArgument)
+				spreadOffset := 0
+				if parent != nil && ast.IsSpreadElement(parent) {
+					spreadOffset = elementIndex
+					callArgument = parent
+					parent = parentThroughParens(callArgument)
+				}
+				if parent == nil || (!ast.IsCallExpression(parent) && !ast.IsNewExpression(parent)) {
+					continue
+				}
+				if parent.TypeArguments() != nil {
+					return false
+				}
+
+				argIndex := slices.IndexFunc(parent.Arguments(), func(candidate *ast.Node) bool {
+					return candidate == callArgument || ast.SkipParentheses(candidate) == callArgument
+				})
+				if argIndex == -1 {
+					continue
+				}
+
+				parameterElementPath := elementPath
+				if ast.IsSpreadElement(callArgument) {
+					parameterElementPath = parameterElementPath[1:]
+				}
+				return hasGenericInferenceParameterAtArgument(parent, argIndex+spreadOffset, parameterElementPath)
+			}
+			return false
+		}
+
 		isInGenericContext := func(node *ast.Node) bool {
 			seenFunction := false
 			for current := node.Parent; current != nil; current = current.Parent {
@@ -803,6 +904,7 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 
 			if skipParentTypeForContextualAny(node) ||
 				ast.IsArrayLiteralExpression(node.Expression()) ||
+				isNestedInArrayLiteralArgumentToGenericCall(node) ||
 				isInDestructuringDeclaration(node) ||
 				isPropertyInProblematicContext(node) ||
 				isAssignmentInNonStatementContext(node) ||

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
@@ -1113,6 +1113,74 @@ const contextualValue: unknown = callable as unknown;
 declare function consume(value: unknown): void;
 consume(callable as unknown);
     `},
+		{
+			// https://github.com/oxc-project/tsgolint/issues/1044
+			Code: `
+type Item = { id: string | number };
+
+declare function combine<T1, T2 extends T1>(a: readonly T1[], b: readonly T2[]): T1[];
+
+declare const items: Item[];
+
+const result = combine([{ id: 0 } as Item], items);
+    `,
+		},
+		{
+			Code: `
+type Item = { id: string | number };
+
+interface Combiner {
+  new <T1, T2 extends T1>(a: readonly T1[], b: readonly T2[]): unknown;
+}
+
+declare const Combiner: Combiner;
+declare const items: Item[];
+
+const result = new Combiner([{ id: 0 } as Item], items);
+    `,
+		},
+		{
+			Code: `
+type Item = { id: string | number };
+
+declare function combine<T1, T2 extends T1>(
+  ...args: [label: string, a: readonly T1[], b: readonly T2[]]
+): T1[];
+
+declare const items: Item[];
+
+const result = combine('items', [{ id: 0 } as Item], items);
+    `,
+		},
+		{
+			Code: `
+type Item = { id: string | number };
+
+declare function combine<T>(
+  enabled: boolean,
+  ...args: [a: readonly T[], b: readonly Item[]]
+): T[];
+
+declare const items: Item[];
+
+const result = combine(true, [{ id: 0 } as Item], items);
+result[0].id = 'x';
+    `,
+		},
+		{
+			Code: `
+type Item = { id: string | number };
+
+declare function combine<T1, T2 extends T1>(
+  ...args: [a: readonly T1[], b: readonly T2[]]
+): T1[];
+
+declare const items: Item[];
+
+const result = combine(...[[{ id: 0 } as Item], items]);
+result[0].id = 'x';
+    `,
+		},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code:   "const foo = <3>3;",
@@ -3265,5 +3333,50 @@ const value: unknown = 42;`},
 				{MessageId: "contextuallyUnnecessary"},
 			},
 		},
-	})
+		{
+			Code:   "declare function f<T>(xs: string[], tag: T): void;\nf(['x' as string], 1);",
+			Output: []string{"declare function f<T>(xs: string[], tag: T): void;\nf(['x'], 1);"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code:   "type StringsWithMeta<T> = string[] & { meta?: T };\ndeclare function f<T>(xs: StringsWithMeta<T>, tag: T): void;\nf(['x' as string], 1);",
+			Output: []string{"type StringsWithMeta<T> = string[] & { meta?: T };\ndeclare function f<T>(xs: StringsWithMeta<T>, tag: T): void;\nf(['x'], 1);"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+declare function f(xs: string[]): void;
+declare function f<T>(value: T): void;
+f(['x' as string]);`,
+			Output: []string{`
+declare function f(xs: string[]): void;
+declare function f<T>(value: T): void;
+f(['x']);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+declare function f<T>(pair: readonly [T, string], tag: T): void;
+f([1, 'x' as string], 1);`,
+			Output: []string{`
+declare function f<T>(pair: readonly [T, string], tag: T): void;
+f([1, 'x'], 1);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		}})
 }


### PR DESCRIPTION
## Summary

- skip contextual-type fallback for assertions nested inside array literals passed to generic calls/new expressions
- add a regression case for an assertion that is required to keep generic inference wide enough for a later argument

## Root Cause

The rule treated the assertion as contextually unnecessary because the asserted element was assignable to the contextual array element type. In generic calls like `combine([{ id: 0 } as Item], items)`, removing the assertion changes inference for `T1` from `Item` to `{ id: number }`, which then rejects the second argument.


Fixes #1044.