### PR TITLE
chore: strip symbols from release binary

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,11 +29,11 @@ init:
 
 [unix]
 build:
-  go build -o tsgolint ./cmd/tsgolint
+  go build -ldflags="-s -w" -o tsgolint ./cmd/tsgolint
 
 [windows]
 build:
-  $env:GOOS="windows"; $env:GOARCH="amd64"; go build -o tsgolint.exe ./cmd/tsgolint
+  $env:GOOS="windows"; $env:GOARCH="amd64"; go build -ldflags="-s -w" -o tsgolint.exe ./cmd/tsgolint
 
 test: build
   cd e2e && pnpm --ignore-workspace run test --run && cd ..


### PR DESCRIPTION
## What

Add `-ldflags="-s -w"` to the `build` recipe (both `[unix]` and `[windows]`), stripping the DWARF debug info (`-w`) and the symbol table (`-s`) from the compiled binary. The release workflow builds via `just build`, so all six published per-platform npm binaries pick this up automatically — no change needed in `release.yml`.

## Binary size impact

Measured on a local `darwin/arm64` build. The ~27% raw / ~45% compressed proportion holds across all six release targets.

| | Raw binary | Gzipped (npm tarball users download) |
|---|---|---|
| Before | 29.7 MB | 13.1 MB |
| After | 21.8 MB | 7.2 MB |
| **Saved** | **7.9 MB (26.6%)** | **5.9 MB (44.9%)** |

The compressed saving is *proportionally larger* than the raw saving because DWARF debug data compresses poorly, so removing it takes out a disproportionate share of the actual download.

npm installs only the single package matching a user's OS/arch (via `os`/`cpu` + `optionalDependencies`), so each user's download drops ~5.9 MB (~45%) and their `node_modules` footprint drops ~7.9 MB.

## Behavior

No functional or runtime change — `-s -w` removes metadata only, never code:

- Same lint results, same output, same speed, same exit codes.
- Panic stack traces keep full function names and line numbers (Go's `gopclntab` is not stripped).
- pprof profiling still symbolicates; `go version -m ./tsgolint` build info is preserved.

The one capability lost is attaching Delve/gdb to the shipped binary for source-level debugging (that needs the DWARF info removed by `-w`) — which is not something an end user of a linter ever does. Contributors who need it can still build an unstripped binary directly with plain `go build`.
