### PR TITLE
chore: add -trimpath to release build

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,11 +29,11 @@ init:
 
 [unix]
 build:
-  go build -ldflags="-s -w" -o tsgolint ./cmd/tsgolint
+  go build -ldflags="-s -w" -trimpath -o tsgolint ./cmd/tsgolint
 
 [windows]
 build:
-  $env:GOOS="windows"; $env:GOARCH="amd64"; go build -ldflags="-s -w" -o tsgolint.exe ./cmd/tsgolint
+  $env:GOOS="windows"; $env:GOARCH="amd64"; go build -ldflags="-s -w" -trimpath -o tsgolint.exe ./cmd/tsgolint
 
 test: build
   cd e2e && pnpm --ignore-workspace run test --run && cd ..


### PR DESCRIPTION
## What

Add `-trimpath` to the `build` recipe (both `[unix]` and `[windows]`), alongside the existing `-ldflags="-s -w"` from #1049. `-trimpath` replaces absolute filesystem paths baked into the binary — the local build directory and the Go module cache — with clean module-relative paths.

## Why — hygiene, not size

- **Reproducible builds.** The output stops depending on *where* it was built, so the same commit built on different machines/paths produces an identical binary.
- **No leaked local paths.** Without it, panic stack traces and build metadata embed the builder's absolute paths (e.g. `/Users/<name>/.../typescript-go/internal/checker/checker.go`). `-trimpath` reduces those to `github.com/microsoft/typescript-go@.../internal/checker/checker.go`.

## Size impact — negligible (measured on the merged `-s -w` baseline)

| metric | `-s -w` | `+ -trimpath` | delta |
|---|---|---|---|
| raw binary | 21.79 MB | 21.74 MB | −49.5 KB (0.23%) |
| gzipped / npm download | 7.19 MB | 7.19 MB | −2.1 KB (0.03%) |
| `__gopclntab` | 6601.6 KB | 6563.8 KB | −37.8 KB (0.57%) |

The ~50 KB raw saving is incidental (trimmed path strings living in `gopclntab`); the download users actually fetch moves ~2 KB, because those repetitive path prefixes were already compressing away under npm's gzip. This is a build-hygiene change, not a size optimization.

## Behavior

No runtime change. Panic traces still show full function names and `file:line` — only the path *prefix* changes (module-relative instead of absolute).
