### PR TITLE
fix(prefer-optional-chain): preserve negated optional guard

### DIFF
--- a/internal/rule_tester/__snapshots__/prefer-optional-chain.snap
+++ b/internal/rule_tester/__snapshots__/prefer-optional-chain.snap
@@ -5396,3 +5396,30 @@ Message: Prefer using an optional chain expression instead, as it's more concise
    1 | foo && foo[bar as string | number] && foo[bar as string | number].baz;
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ---
+
+[TestPreferOptionalChainRule/invalid-602 - 1]
+Diagnostic 1: preferOptionalChain (3:5 - 3:33)
+Message: Prefer using an optional chain expression instead, as it's more concise and easier to read.
+   2 | declare const item: { myField?: string } | undefined;
+   3 | if (item == null || !item.myField) {
+     |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |   throw new Error('missing');
+---
+
+[TestPreferOptionalChainRule/invalid-603 - 1]
+Diagnostic 1: preferOptionalChain (3:5 - 3:34)
+Message: Prefer using an optional chain expression instead, as it's more concise and easier to read.
+   2 | declare const item: { myField?: string } | null;
+   3 | if (item === null || !item.myField) {
+     |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |   throw new Error('missing');
+---
+
+[TestPreferOptionalChainRule/invalid-604 - 1]
+Diagnostic 1: preferOptionalChain (3:5 - 3:39)
+Message: Prefer using an optional chain expression instead, as it's more concise and easier to read.
+   2 | declare const item: { myField?: string } | undefined;
+   3 | if (item === undefined || !item.myField) {
+     |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |   throw new Error('missing');
+---

--- a/internal/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -3571,10 +3571,13 @@ func (processor *chainProcessor) generateOrChainFixAndReport(node *ast.Node, cha
 			newCode = optionalChainCode
 		}
 	} else {
-		firstOpIsNegated := chainForOptional[0].typ == OperandTypeNot
-		lastOpIsNegated := chainForOptional[len(chainForOptional)-1].typ == OperandTypeNot
-
-		if firstOpIsNegated && lastOpIsNegated {
+		// An OR chain that reduces to a plain optional-chain access (no trailing
+		// nullish/comparison) obeys De Morgan's law:
+		//   A || B || ... || Z == !(!A && !B && ... && !Z)
+		// If the deepest access operand is `!x.y.z`, the reduced expression is
+		// `!x?.y?.z`, even when earlier operands are nullish-equality guards
+		// like `x == null`.
+		if chainForOptional[len(chainForOptional)-1].typ == OperandTypeNot {
 			newCode = "!" + optionalChainCode
 		} else {
 			newCode = optionalChainCode

--- a/internal/rules/prefer_optional_chain/prefer_optional_chain_test.go
+++ b/internal/rules/prefer_optional_chain/prefer_optional_chain_test.go
@@ -4287,5 +4287,57 @@ item?.value === null;
 		},
 	})
 
+	// https://github.com/oxc-project/tsgolint/issues/1060
+	// `x == null || !x.y` collapses to `!x?.y`, not `x?.y`.
+	// Dropping the outer negation inverts runtime behaviour, so this fix must
+	// preserve it.
+	invalidCases = append(invalidCases, rule_tester.InvalidTestCase{
+		Code: `
+declare const item: { myField?: string } | undefined;
+if (item == null || !item.myField) {
+  throw new Error('missing');
+}
+`,
+		Output: []string{`
+declare const item: { myField?: string } | undefined;
+if (!item?.myField) {
+  throw new Error('missing');
+}
+`},
+		Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+	})
+
+	invalidCases = append(invalidCases, rule_tester.InvalidTestCase{
+		Code: `
+declare const item: { myField?: string } | null;
+if (item === null || !item.myField) {
+  throw new Error('missing');
+}
+`,
+		Output: []string{`
+declare const item: { myField?: string } | null;
+if (!item?.myField) {
+  throw new Error('missing');
+}
+`},
+		Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+	})
+
+	invalidCases = append(invalidCases, rule_tester.InvalidTestCase{
+		Code: `
+declare const item: { myField?: string } | undefined;
+if (item === undefined || !item.myField) {
+  throw new Error('missing');
+}
+`,
+		Output: []string{`
+declare const item: { myField?: string } | undefined;
+if (!item?.myField) {
+  throw new Error('missing');
+}
+`},
+		Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+	})
+
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferOptionalChainRule, validCases, invalidCases)
 }


### PR DESCRIPTION
## Summary
- preserve the outer negation when OR-chain optional-chain fixes end in a negated property access
- add regression coverage for nullish guards followed by negated member access
- update the prefer-optional-chain snapshot

Fixes #1060.
