### PR TITLE
ci(release): Authenticode-sign Windows binaries via SignPath

### DIFF
--- a/.github/actions/sign-windows-binary/action.yml
+++ b/.github/actions/sign-windows-binary/action.yml
@@ -1,0 +1,70 @@
+name: Sign Windows binary
+
+# Authenticode-sign a single cross-compiled Windows `tsgolint` binary.
+#
+# Company-managed Windows machines enforce Microsoft Defender's ASR rule
+# "Block executable files from running unless they meet a prevalence, age, or
+# trusted list criteria", which silently blocks the unsigned tsgolint.exe that
+# oxlint spawns for type-aware rules:
+#
+#   Error: spawnSync ...\@oxlint-tsgolint\win32-x64\tsgolint.exe EACCES
+#     errno: -4092, code: 'EACCES', syscall: 'spawnSync ...tsgolint.exe'
+#
+# It is a policy block (no user-facing "Unblock" prompt), so end users cannot
+# override it. A valid Authenticode signature satisfies the ASR "trusted"
+# criterion for all enterprise Windows users. See
+# https://github.com/oxc-project/tsgolint/issues/876.
+#
+# Signing uses SignPath Foundation (free Authenticode signing for OSS), which
+# signs a GitHub-uploaded artifact via their service and therefore works from
+# this all-Linux pipeline (no Windows runner / signtool required). The
+# cross-compiled binary is still named `tsgolint` (no extension) at this stage;
+# Authenticode signs the PE image regardless of file name, and the signed bytes
+# are copied to `tsgolint.exe` later by gen-npm-packages.mjs. The SignPath
+# artifact configuration must therefore target the extension-less `tsgolint`
+# file inside the uploaded zip.
+
+inputs:
+  goarch:
+    description: Go architecture of the Windows binary to sign (e.g. amd64, arm64)
+    required: true
+  api-token:
+    description: SignPath REST API access token
+    required: true
+  organization-id:
+    description: SignPath organization ID
+    required: true
+  project-slug:
+    description: SignPath project slug
+    required: true
+  signing-policy-slug:
+    description: SignPath signing policy slug
+    required: true
+  artifact-configuration-slug:
+    description: SignPath artifact configuration slug
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Upload unsigned binary for signing
+      id: upload
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: unsigned-tsgolint-windows-${{ inputs.goarch }}
+        path: build/tsgolint-windows-${{ inputs.goarch }}/tsgolint
+        if-no-files-found: error
+
+    - name: Submit signing request
+      uses: SignPath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+      with:
+        api-token: ${{ inputs.api-token }}
+        organization-id: ${{ inputs.organization-id }}
+        project-slug: ${{ inputs.project-slug }}
+        signing-policy-slug: ${{ inputs.signing-policy-slug }}
+        artifact-configuration-slug: ${{ inputs.artifact-configuration-slug }}
+        github-artifact-id: ${{ steps.upload.outputs.artifact-id }}
+        wait-for-completion: true
+        # Extracts the signed `tsgolint` back over the unsigned one so that
+        # gen-npm-packages.mjs packs the signed binary.
+        output-artifact-directory: build/tsgolint-windows-${{ inputs.goarch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,87 +66,31 @@ jobs:
       - name: chmod +x
         run: find build -type f -name tsgolint -exec chmod +x {} \;
 
-      # ---------------------------------------------------------------------
-      # Authenticode-sign the Windows binaries.
-      #
-      # Company-managed Windows machines enforce Microsoft Defender's ASR rule
-      # "Block executable files from running unless they meet a prevalence, age,
-      # or trusted list criteria", which silently blocks the unsigned
-      # tsgolint.exe that oxlint spawns for type-aware rules:
-      #
-      #   Error: spawnSync ...\@oxlint-tsgolint\win32-x64\tsgolint.exe EACCES
-      #     errno: -4092, code: 'EACCES', syscall: 'spawnSync ...tsgolint.exe'
-      #
-      # It is a policy block (no user-facing "Unblock" prompt), so end users
-      # cannot override it. Authenticode-signing gives the binary a publisher
-      # reputation that satisfies the ASR "trusted" criterion for all enterprise
-      # Windows users. See https://github.com/oxc-project/tsgolint/issues/876.
-      #
-      # Signing uses SignPath Foundation (free Authenticode signing for OSS),
-      # which signs a GitHub-uploaded artifact via their service and works from
-      # this all-Linux pipeline (no Windows runner / signtool required). The
-      # cross-compiled binaries are still named `tsgolint` (no extension) at this
-      # stage; Authenticode signs the PE image regardless of file name, and the
-      # signed bytes are copied to `tsgolint.exe` by gen-npm-packages.mjs.
-      #
-      # TODO(maintainers): provision a SignPath Foundation project for this repo
-      # and add the following repository configuration. Until SIGNPATH_API_TOKEN
-      # is set, the steps below are skipped and the release publishes unsigned
-      # binaries (i.e. current behaviour), so the pipeline never breaks.
-      #   secrets:
-      #     SIGNPATH_API_TOKEN                    # SignPath REST API access token
-      #   variables (repository "Variables", not secrets):
-      #     SIGNPATH_ORGANIZATION_ID
-      #     SIGNPATH_PROJECT_SLUG
-      #     SIGNPATH_SIGNING_POLICY_SLUG
-      #     SIGNPATH_ARTIFACT_CONFIGURATION_SLUG  # must sign the extension-less
-      #                                           # `tsgolint` PE inside the zip
-      # ---------------------------------------------------------------------
-      - name: Upload unsigned Windows amd64 binary for signing
-        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
-        id: upload-unsigned-windows-amd64
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: unsigned-tsgolint-windows-amd64
-          path: build/tsgolint-windows-amd64/tsgolint
-          if-no-files-found: error
-
+      # Authenticode-sign the Windows binaries so Microsoft Defender's ASR rule
+      # "Block executable files ... unless they meet a prevalence, age, or
+      # trusted list criteria" stops blocking tsgolint.exe on managed machines
+      # (#876). Skipped until the SIGNPATH_* secret/vars are provisioned (see PR).
       - name: Sign Windows amd64 binary
         if: ${{ env.SIGNPATH_API_TOKEN != '' }}
-        uses: SignPath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        uses: ./.github/actions/sign-windows-binary
         with:
+          goarch: amd64
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
           signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
           artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
-          github-artifact-id: ${{ steps.upload-unsigned-windows-amd64.outputs.artifact-id }}
-          wait-for-completion: true
-          # Extracts the signed `tsgolint` back over the unsigned one so that
-          # gen-npm-packages.mjs packs the signed binary.
-          output-artifact-directory: build/tsgolint-windows-amd64
-
-      - name: Upload unsigned Windows arm64 binary for signing
-        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
-        id: upload-unsigned-windows-arm64
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: unsigned-tsgolint-windows-arm64
-          path: build/tsgolint-windows-arm64/tsgolint
-          if-no-files-found: error
 
       - name: Sign Windows arm64 binary
         if: ${{ env.SIGNPATH_API_TOKEN != '' }}
-        uses: SignPath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        uses: ./.github/actions/sign-windows-binary
         with:
+          goarch: arm64
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
           signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
           artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
-          github-artifact-id: ${{ steps.upload-unsigned-windows-arm64.outputs.artifact-id }}
-          wait-for-completion: true
-          output-artifact-directory: build/tsgolint-windows-arm64
 
       - name: Generate npm packages
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,11 @@ jobs:
     permissions:
       contents: write # for softprops/action-gh-release
       id-token: write # for `pnpm publish --provenance`
+    env:
+      # Mapped here so the Authenticode signing steps below can be gated on the
+      # presence of the secret via the `env` context (the `secrets` context is
+      # not available in step `if:` conditions).
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -60,6 +65,88 @@ jobs:
 
       - name: chmod +x
         run: find build -type f -name tsgolint -exec chmod +x {} \;
+
+      # ---------------------------------------------------------------------
+      # Authenticode-sign the Windows binaries.
+      #
+      # Company-managed Windows machines enforce Microsoft Defender's ASR rule
+      # "Block executable files from running unless they meet a prevalence, age,
+      # or trusted list criteria", which silently blocks the unsigned
+      # tsgolint.exe that oxlint spawns for type-aware rules:
+      #
+      #   Error: spawnSync ...\@oxlint-tsgolint\win32-x64\tsgolint.exe EACCES
+      #     errno: -4092, code: 'EACCES', syscall: 'spawnSync ...tsgolint.exe'
+      #
+      # It is a policy block (no user-facing "Unblock" prompt), so end users
+      # cannot override it. Authenticode-signing gives the binary a publisher
+      # reputation that satisfies the ASR "trusted" criterion for all enterprise
+      # Windows users. See https://github.com/oxc-project/tsgolint/issues/876.
+      #
+      # Signing uses SignPath Foundation (free Authenticode signing for OSS),
+      # which signs a GitHub-uploaded artifact via their service and works from
+      # this all-Linux pipeline (no Windows runner / signtool required). The
+      # cross-compiled binaries are still named `tsgolint` (no extension) at this
+      # stage; Authenticode signs the PE image regardless of file name, and the
+      # signed bytes are copied to `tsgolint.exe` by gen-npm-packages.mjs.
+      #
+      # TODO(maintainers): provision a SignPath Foundation project for this repo
+      # and add the following repository configuration. Until SIGNPATH_API_TOKEN
+      # is set, the steps below are skipped and the release publishes unsigned
+      # binaries (i.e. current behaviour), so the pipeline never breaks.
+      #   secrets:
+      #     SIGNPATH_API_TOKEN                    # SignPath REST API access token
+      #   variables (repository "Variables", not secrets):
+      #     SIGNPATH_ORGANIZATION_ID
+      #     SIGNPATH_PROJECT_SLUG
+      #     SIGNPATH_SIGNING_POLICY_SLUG
+      #     SIGNPATH_ARTIFACT_CONFIGURATION_SLUG  # must sign the extension-less
+      #                                           # `tsgolint` PE inside the zip
+      # ---------------------------------------------------------------------
+      - name: Upload unsigned Windows amd64 binary for signing
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        id: upload-unsigned-windows-amd64
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unsigned-tsgolint-windows-amd64
+          path: build/tsgolint-windows-amd64/tsgolint
+          if-no-files-found: error
+
+      - name: Sign Windows amd64 binary
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        uses: SignPath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-windows-amd64.outputs.artifact-id }}
+          wait-for-completion: true
+          # Extracts the signed `tsgolint` back over the unsigned one so that
+          # gen-npm-packages.mjs packs the signed binary.
+          output-artifact-directory: build/tsgolint-windows-amd64
+
+      - name: Upload unsigned Windows arm64 binary for signing
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        id: upload-unsigned-windows-arm64
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unsigned-tsgolint-windows-arm64
+          path: build/tsgolint-windows-arm64/tsgolint
+          if-no-files-found: error
+
+      - name: Sign Windows arm64 binary
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        uses: SignPath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-windows-arm64.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: build/tsgolint-windows-arm64
 
       - name: Generate npm packages
         env:


### PR DESCRIPTION
## Problem

On company-managed Windows machines, Microsoft Defender's admin-enforced ASR rule **"Block executable files from running unless they meet a prevalence, age, or trusted list criteria"** silently blocks the unsigned `tsgolint.exe`. `oxlint` spawns it for type-aware rules and the spawn fails:

```
Error: spawnSync ...\@oxlint-tsgolint\win32-x64\tsgolint.exe EACCES
  errno: -4092, code: 'EACCES', syscall: 'spawnSync ...tsgolint.exe'
```

Unlike a SmartScreen warning, this is a **policy** block with no user-facing "Unblock", so end users cannot override it. This is the class of failure reported in #876.

## Fix

Authenticode-sign the Windows binaries in the `publish` job using **SignPath Foundation** (free Authenticode signing for OSS). A valid signature chains to a publicly-trusted CA root and satisfies the ASR "trusted" criterion for all enterprise users. SignPath signs a GitHub-uploaded artifact via its service, so it works from the existing **all-Linux** release pipeline — no Windows runner / `signtool` required.

- New composite action `./.github/actions/sign-windows-binary` (mirrors the existing `./.github/actions/setup` pattern): uploads the unsigned binary, submits the SignPath signing request, and writes the signed binary back over the unsigned one so `gen-npm-packages.mjs` packs it.
- `release.yml` calls it once per Windows arch (`amd64`, `arm64`).
- The binary is still named `tsgolint` (no extension) at signing time; Authenticode signs the PE image regardless of file name, and the signed bytes are copied to `tsgolint.exe` by `gen-npm-packages.mjs`.

## ⚠️ Maintainer provisioning required

The signing steps are **gated on `SIGNPATH_API_TOKEN`** and are **skipped until it is set** — so this PR is safe to merge and the release keeps publishing unsigned binaries (current behaviour) until SignPath is configured. To enable signing, provision a SignPath Foundation project for the repo and add:

**Secret**
- `SIGNPATH_API_TOKEN` — SignPath REST API access token

**Variables** (repo → Settings → Secrets and variables → Actions → *Variables*, not Secrets)
- `SIGNPATH_ORGANIZATION_ID`
- `SIGNPATH_PROJECT_SLUG`
- `SIGNPATH_SIGNING_POLICY_SLUG`
- `SIGNPATH_ARTIFACT_CONFIGURATION_SLUG` — the artifact configuration must sign the extension-less `tsgolint` PE inside the uploaded zip

VoidZero may prefer a different signer (an existing code-signing vendor, or **Azure Trusted Signing** as Deno adopted in denoland/deno#28963). This PR is intentionally a minimal, working **SignPath** wiring to anchor that decision; switching signers only changes the composite action's internals, not the surrounding pipeline.

## Notes

- Third-party action pinned to a full commit SHA per repo convention: `SignPath/github-action-submit-signing-request@b9d91ea` (v2).
- Not executed against the real release workflow (it publishes to npm); validated by parsing the workflow YAML and verifying the action inputs against its `action.yml`.

Refs #876

## AI usage disclosure

Per [Oxc's AI Usage Policy](https://github.com/oxc-project/oxc/blob/main/CONTRIBUTING.md#ai-usage-policy): AI tooling (GitHub Copilot) was used to help draft this change. I have reviewed, understood, and validated all of it, and I take responsibility for the contribution. Happy to adjust the approach (signer choice, structure, etc.) based on maintainer preference.