### PR TITLE
perf(no-unnecessary-type-arguments): skip signature resolution when node has no type arguments

### DIFF
--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
@@ -248,60 +248,47 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 			})
 		}
 
-		hasTypeArguments := func(arguments *ast.NodeList) bool {
-			return arguments != nil && len(arguments.Nodes) != 0
+		// Resolving type parameters is expensive, so only do it once we know the
+		// node has explicit type arguments — the overwhelmingly common case is
+		// that it doesn't.
+		checkTypeArgsAndParameters := func(node *ast.Node, arguments *ast.NodeList, nameNode *ast.Node) {
+			if arguments == nil || len(arguments.Nodes) == 0 {
+				return
+			}
+			checkArgsAndParameters(node, arguments, getTypeParametersFromType(node, nameNode))
+		}
+
+		checkCallArgsAndParameters := func(node *ast.Node, arguments *ast.NodeList) {
+			if arguments == nil || len(arguments.Nodes) == 0 {
+				return
+			}
+			checkArgsAndParameters(node, arguments, getTypeParametersFromCall(node))
 		}
 
 		return rule.RuleListeners{
 			ast.KindExpressionWithTypeArguments: func(node *ast.Node) {
 				expr := node.AsExpressionWithTypeArguments()
-				if !hasTypeArguments(expr.TypeArguments) {
-					return
-				}
-				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromType(node, expr.Expression))
+				checkTypeArgsAndParameters(node, expr.TypeArguments, expr.Expression)
 			},
 			ast.KindTypeReference: func(node *ast.Node) {
 				expr := node.AsTypeReferenceNode()
-				if !hasTypeArguments(expr.TypeArguments) {
-					return
-				}
-				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromType(node, expr.TypeName))
+				checkTypeArgsAndParameters(node, expr.TypeArguments, expr.TypeName)
 			},
 
 			ast.KindCallExpression: func(node *ast.Node) {
-				expr := node.AsCallExpression()
-				if !hasTypeArguments(expr.TypeArguments) {
-					return
-				}
-				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
+				checkCallArgsAndParameters(node, node.AsCallExpression().TypeArguments)
 			},
 			ast.KindNewExpression: func(node *ast.Node) {
-				expr := node.AsNewExpression()
-				if !hasTypeArguments(expr.TypeArguments) {
-					return
-				}
-				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
+				checkCallArgsAndParameters(node, node.AsNewExpression().TypeArguments)
 			},
 			ast.KindTaggedTemplateExpression: func(node *ast.Node) {
-				expr := node.AsTaggedTemplateExpression()
-				if !hasTypeArguments(expr.TypeArguments) {
-					return
-				}
-				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
+				checkCallArgsAndParameters(node, node.AsTaggedTemplateExpression().TypeArguments)
 			},
 			ast.KindJsxOpeningElement: func(node *ast.Node) {
-				expr := node.AsJsxOpeningElement()
-				if !hasTypeArguments(expr.TypeArguments) {
-					return
-				}
-				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
+				checkCallArgsAndParameters(node, node.AsJsxOpeningElement().TypeArguments)
 			},
 			ast.KindJsxSelfClosingElement: func(node *ast.Node) {
-				expr := node.AsJsxSelfClosingElement()
-				if !hasTypeArguments(expr.TypeArguments) {
-					return
-				}
-				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
+				checkCallArgsAndParameters(node, node.AsJsxSelfClosingElement().TypeArguments)
 			},
 		}
 	},

--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
@@ -248,34 +248,59 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 			})
 		}
 
+		hasTypeArguments := func(arguments *ast.NodeList) bool {
+			return arguments != nil && len(arguments.Nodes) != 0
+		}
+
 		return rule.RuleListeners{
 			ast.KindExpressionWithTypeArguments: func(node *ast.Node) {
 				expr := node.AsExpressionWithTypeArguments()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromType(node, expr.Expression))
 			},
 			ast.KindTypeReference: func(node *ast.Node) {
 				expr := node.AsTypeReferenceNode()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromType(node, expr.TypeName))
 			},
 
 			ast.KindCallExpression: func(node *ast.Node) {
 				expr := node.AsCallExpression()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindNewExpression: func(node *ast.Node) {
 				expr := node.AsNewExpression()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindTaggedTemplateExpression: func(node *ast.Node) {
 				expr := node.AsTaggedTemplateExpression()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindJsxOpeningElement: func(node *ast.Node) {
 				expr := node.AsJsxOpeningElement()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindJsxSelfClosingElement: func(node *ast.Node) {
 				expr := node.AsJsxSelfClosingElement()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 		}

--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
@@ -248,9 +248,6 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 			})
 		}
 
-		// Resolving type parameters is expensive, so only do it once we know the
-		// node has explicit type arguments — the overwhelmingly common case is
-		// that it doesn't.
 		checkTypeArgsAndParameters := func(node *ast.Node, arguments *ast.NodeList, nameNode *ast.Node) {
 			if arguments == nil || len(arguments.Nodes) == 0 {
 				return


### PR DESCRIPTION
## Summary

All six listeners evaluated `getTypeParametersFromCall` / `getTypeParametersFromType` — which resolve the call signature (`Checker_getResolvedSignature`) or symbol — as an argument to `checkArgsAndParameters`, so the resolution ran for **every** call expression, `new` expression, tagged template, JSX element, and type reference in the file. `checkArgsAndParameters` then immediately discarded the result for any node without explicit type arguments, which is the overwhelmingly common case.

This adds a `TypeArguments`-first guard to each listener so signature/symbol resolution only runs on nodes that actually carry explicit type arguments. Same shape as the reorder in #1038.

## Measurement

VS Code corpus (`src/tsconfig.json`, 7,327 files), macOS/arm64.

**Rule solo** (headless, only this rule enabled — no other type-aware rule warming the checker's caches first), `hyperfine --warmup 1 --runs 6`:

| | wall clock |
|---|---|
| before | 3.021 s ± 0.078 s |
| after | **820.5 ms ± 30.2 ms** |

**3.68× ± 0.17 faster.** This is the number that matters for subset configs (e.g. oxlint enabling a handful of rules), where the avoided `getResolvedSignature` calls are paid in full.

**All rules enabled**, `--debug timings`:

| | rule time | calls |
|---|---|---|
| before | 210.8 / 217.7 ms | 947,345 |
| after | **50.1 / 49.4 ms** | 947,345 |

~4.3× less rule time. End-to-end wall clock for the full 58-rule run is unchanged (9.55 s vs 9.62 s, within noise) — the effect is masked because other type-aware rules force-check the same call nodes first and warm the checker's caches.

Diagnostics identical before/after: 247 in both, byte-for-byte equal after sorting.

Rule test suite, e2e suite, and `golangci-lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
