### PR TITLE
perf(no-misused-promises): skip type queries for never-callable expressions

### DIFF
--- a/internal/rule_tester/__snapshots__/no-misused-promises.snap
+++ b/internal/rule_tester/__snapshots__/no-misused-promises.snap
@@ -1007,3 +1007,21 @@ Message: Promise-returning function provided to property where a void return was
      |                ~~~~~~~~~~~~~~~
    5 | };
 ---
+
+[TestNoMisusedPromisesRule/invalid-90 - 1]
+Diagnostic 1: voidReturnArgument (4:11 - 4:18)
+Message: Promise returned in function argument where a void return was expected.
+   3 | function f<T extends () => Promise<void>>(t: T) {
+   4 |   takesCb({ ...t });
+     |           ~~~~~~~~
+   5 | }
+---
+
+[TestNoMisusedPromisesRule/invalid-91 - 1]
+Diagnostic 1: voidReturnVariable (3:26 - 3:33)
+Message: Promise-returning function provided to variable where a void return was expected.
+   2 | function f<T extends () => Promise<void>>(t: T) {
+   3 |   const cb: () => void = { ...t };
+     |                          ~~~~~~~~
+   4 | }
+---

--- a/internal/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/rules/no_misused_promises/no_misused_promises.go
@@ -117,6 +117,30 @@ var NoMisusedPromisesRule = rule.Rule{
 			checksVoidReturnOpts = defaultChecksVoidReturnOpts()
 		}
 
+		// A syntactic check for whether an expression could possibly evaluate to a
+		// value with call signatures. Literals, templates, and array/object literals
+		// can never be callable, so `returnsThenable` is always false for them and
+		// the type queries guarding it can be skipped entirely.
+		// This is a perf optimization to help avoid requesting types where possible.
+		couldBeFunctionLikeValue := func(node *ast.Node) bool {
+			switch node.Kind {
+			case ast.KindStringLiteral,
+				ast.KindNoSubstitutionTemplateLiteral,
+				ast.KindTemplateExpression,
+				ast.KindNumericLiteral,
+				ast.KindBigIntLiteral,
+				ast.KindTrueKeyword,
+				ast.KindFalseKeyword,
+				ast.KindNullKeyword,
+				ast.KindRegularExpressionLiteral,
+				ast.KindArrayLiteralExpression,
+				ast.KindObjectLiteralExpression:
+				return false
+			default:
+				return true
+			}
+		}
+
 		anySignatureIsThenableType := func(
 			node *ast.Node,
 			t *checker.Type,
@@ -414,17 +438,36 @@ var NoMisusedPromisesRule = rule.Rule{
 				for _, signature := range signatures {
 					for index, parameter := range checker.Signature_parameters(signature) {
 						decl := parameter.ValueDeclaration
+						isRestParameter := decl != nil && utils.IsRestParameterDeclaration(decl)
+
+						// A parameter position can only produce a report if there is an
+						// argument at that position that could be a thenable-returning
+						// function, so skip resolving the parameter type otherwise.
+						if index >= len(node.Arguments()) {
+							continue
+						}
+						if isRestParameter {
+							if !slices.ContainsFunc(node.Arguments()[index:], couldBeFunctionLikeValue) {
+								continue
+							}
+						} else if !couldBeFunctionLikeValue(node.Arguments()[index]) {
+							continue
+						}
+
 						t := ctx.TypeChecker.GetTypeOfSymbolAtLocation(parameter, node.Expression())
 
 						// If this is a array 'rest' parameter, check all of the argument indices
 						// from the current argument to the end.
-						if decl != nil && utils.IsRestParameterDeclaration(decl) {
+						if isRestParameter {
 							if checker.Checker_isArrayType(ctx.TypeChecker, t) {
 								// Unwrap 'Array<MaybeVoidFunction>' to 'MaybeVoidFunction',
 								// so that we'll handle it in the same way as a non-rest
 								// 'param: MaybeVoidFunction'
 								t = checker.Checker_getTypeArguments(ctx.TypeChecker, t)[0]
 								for i := index; i < len(node.Arguments()); i++ {
+									if !couldBeFunctionLikeValue(node.Arguments()[i]) {
+										continue
+									}
 									checkThenableOrVoidArgument(
 										node,
 										t,
@@ -438,6 +481,9 @@ var NoMisusedPromisesRule = rule.Rule{
 								// add the index of the second tuple parameter to 'voidReturnIndices'
 								typeArgs := checker.Checker_getTypeArguments(ctx.TypeChecker, t)
 								for i := index; i < len(node.Arguments()) && i-index < len(typeArgs); i++ {
+									if !couldBeFunctionLikeValue(node.Arguments()[i]) {
+										continue
+									}
 									checkThenableOrVoidArgument(
 										node,
 										typeArgs[i-index],
@@ -473,6 +519,13 @@ var NoMisusedPromisesRule = rule.Rule{
 		checkArguments := func(
 			node *ast.Expression,
 		) {
+			// A report requires an argument that could be a thenable-returning
+			// function; skip the callee/parameter type queries when no argument
+			// qualifies (e.g. zero arguments, or all-literal arguments).
+			if !slices.ContainsFunc(node.Arguments(), couldBeFunctionLikeValue) {
+				return
+			}
+
 			voidArgs := voidFunctionArguments(node)
 			if len(voidArgs) == 0 {
 				return
@@ -533,6 +586,9 @@ var NoMisusedPromisesRule = rule.Rule{
 		checkProperty := func(node *ast.Node) {
 			if ast.IsPropertyAssignment(node) {
 				property := node.AsPropertyAssignment()
+				if !couldBeFunctionLikeValue(property.Initializer) {
+					return
+				}
 				contextualType := checker.Checker_getContextualType(ctx.TypeChecker, property.Initializer, checker.ContextFlagsNone)
 
 				if contextualType != nil && isVoidReturningFunctionType(
@@ -674,7 +730,7 @@ var NoMisusedPromisesRule = rule.Rule{
 		}
 
 		checkReturnStatement := func(node *ast.ReturnStatement) {
-			if node.Expression == nil {
+			if node.Expression == nil || !couldBeFunctionLikeValue(node.Expression) {
 				return
 			}
 
@@ -702,6 +758,9 @@ var NoMisusedPromisesRule = rule.Rule{
 		}
 
 		checkAssignment := func(node *ast.BinaryExpression) {
+			if !couldBeFunctionLikeValue(node.Right) {
+				return
+			}
 			varType := ctx.TypeChecker.GetTypeAtLocation(node.Left)
 			if !isVoidReturningFunctionType(node.Left, varType) {
 				return
@@ -714,7 +773,8 @@ var NoMisusedPromisesRule = rule.Rule{
 
 		checkVariableDeclaration := func(node *ast.VariableDeclaration) {
 			if node.Initializer == nil ||
-				node.Type == nil {
+				node.Type == nil ||
+				!couldBeFunctionLikeValue(node.Initializer) {
 				return
 			}
 

--- a/internal/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/rules/no_misused_promises/no_misused_promises.go
@@ -118,7 +118,7 @@ var NoMisusedPromisesRule = rule.Rule{
 		}
 
 		// A syntactic check for whether an expression could possibly evaluate to a
-		// value with call signatures. Literals, templates, and array/object literals
+		// value with call signatures. Literals, templates, and array literals
 		// can never be callable, so `returnsThenable` is always false for them and
 		// the type queries guarding it can be skipped entirely.
 		// This is a perf optimization to help avoid requesting types where possible.
@@ -133,9 +133,16 @@ var NoMisusedPromisesRule = rule.Rule{
 				ast.KindFalseKeyword,
 				ast.KindNullKeyword,
 				ast.KindRegularExpressionLiteral,
-				ast.KindArrayLiteralExpression,
-				ast.KindObjectLiteralExpression:
+				ast.KindArrayLiteralExpression:
 				return false
+			case ast.KindObjectLiteralExpression:
+				// Spreading a generic value keeps its type (e.g. `{ ...t }` where
+				// `T extends () => Promise<void>` has type `T`), which can be
+				// callable, so only spread-free object literals are known to be
+				// never-callable.
+				return slices.ContainsFunc(node.AsObjectLiteralExpression().Properties.Nodes, func(property *ast.Node) bool {
+					return property.Kind == ast.KindSpreadAssignment
+				})
 			default:
 				return true
 			}

--- a/internal/rules/no_misused_promises/no_misused_promises_test.go
+++ b/internal/rules/no_misused_promises/no_misused_promises_test.go
@@ -2681,5 +2681,32 @@ const obj: O = {
 				},
 			},
 		},
+		{
+			Code: `
+declare function takesCb(cb: () => void): void;
+function f<T extends () => Promise<void>>(t: T) {
+  takesCb({ ...t });
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "voidReturnArgument",
+					Line:      4,
+				},
+			},
+		},
+		{
+			Code: `
+function f<T extends () => Promise<void>>(t: T) {
+  const cb: () => void = { ...t };
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "voidReturnVariable",
+					Line:      3,
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
## Summary

Every `voidReturn` report ultimately requires `returnsThenable(expr)` — the expression's apparent type must have a call signature returning a thenable. Literals, template strings, array literals, and spread-free object literals can never have call signatures, so the type queries gating those reports can be skipped syntactically.

Object literals **with spreads** are still checked: spreading a generic value keeps its type (`{ ...t }` where `T extends () => Promise<void>` has type `T`), whose apparent type can have call signatures. `{ ...anyValue }` remains safe in principle (`any` has no call signatures), but the guard conservatively checks any literal containing a spread. This was a real false negative found in adversarial review (same latent bug as strict-void-return, fixed there in #1068) — regression tests cover both guarded paths (call argument and contextually typed variable initializer).

This adds a `couldBeFunctionLikeValue` kind check in front of the checker calls in:

- `voidFunctionArguments` — per-argument guard before `GetTypeOfSymbolAtLocation` on the parameter (positional, rest, and both rest array/tuple unwrap loops)
- `checkArguments` — pre-scan of all arguments before the callee signature resolution (also skips zero-arg calls, which previously paid the full callee + params walk)
- `checkProperty` — before `Checker_getContextualType` on property assignments
- `checkReturnStatement` / `checkAssignment` / `checkVariableDeclaration` — before the contextual/declared type queries

## Measurement

VS Code corpus (`src/tsconfig.json`, 7.1k files), `--debug timings`, all rules enabled, mean of 3 runs (at the head including the spread fix):

| | rule time (mean of 3) | calls |
|---|---|---|
| before | 4658 ms (4758 / 4553 / 4663) | 2,815,527 |
| after | 3804 ms (4025 / 3730 / 3656) | 2,815,527 |

Diagnostic parity is exact: 207,794 diagnostics compared as `(rule, file, pos, end, messageId)` keys, 0 differing keys. As with #1064, the win is partially masked in an all-rules run because other type-aware rules warm the checker's caches on the same nodes; in subset configs the avoided queries are paid in full.

Known theoretical limitation (shared with #1068): global-interface augmentation (e.g. `interface String { (): Promise<void> }`) can give literal types call signatures, which the guard would skip. This is pathological declaration merging and considered acceptable.

Rule test suite passes, including two new regression tests for the spread case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
