### PR TITLE
perf(no-unsafe-argument): skip type queries for never-unsafe arguments

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unsafe-argument.snap
+++ b/internal/rule_tester/__snapshots__/no-unsafe-argument.snap
@@ -213,3 +213,12 @@ Message: Unsafe argument of type any assigned to a parameter of type T.
      |       ~~~
    6 |       
 ---
+
+[TestNoUnsafeArgumentRule/invalid-20 - 1]
+Diagnostic 1: unsafeArgument (4:5 - 4:19)
+Message: Unsafe argument of type any assigned to a parameter of type { x: number; }.
+   3 | declare const anyValue: any;
+   4 | foo({ ...anyValue });
+     |     ~~~~~~~~~~~~~~~
+   5 |       
+---

--- a/internal/rules/no_unsafe_argument/no_unsafe_argument.go
+++ b/internal/rules/no_unsafe_argument/no_unsafe_argument.go
@@ -2,6 +2,7 @@ package no_unsafe_argument
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -58,47 +59,26 @@ func newFunctionSignature(
 		return nil
 	}
 
-	paramTypes := []*checker.Type{}
-	var restT restType
-
 	parameters := checker.Signature_parameters(signature)
+	var restParam *ast.Symbol
 
 	for i, param := range parameters {
-		t := typeChecker.GetTypeOfSymbolAtLocation(param, node)
-
 		if param.Declarations != nil && len(param.Declarations) != 0 {
-			decl := param.Declarations[0]
-			if utils.IsRestParameterDeclaration(decl) {
+			if utils.IsRestParameterDeclaration(param.Declarations[0]) {
 				// is a rest param
-				if checker.Checker_isArrayType(typeChecker, t) {
-					restT = restType{
-						Type:  checker.Checker_getTypeArguments(typeChecker, t)[0],
-						Index: i,
-						Kind:  restTypeKindArray,
-					}
-				} else if checker.IsTupleType(t) {
-					restT = restType{
-						Index:         i,
-						Kind:          restTypeKindTuple,
-						TypeArguments: checker.Checker_getTypeArguments(typeChecker, t),
-					}
-				} else {
-					restT = restType{
-						Type:  t,
-						Index: i,
-						Kind:  restTypeKindOther,
-					}
-				}
+				restParam = param
+				parameters = parameters[:i]
 				break
 			}
 		}
-
-		paramTypes = append(paramTypes, t)
 	}
 
 	return &functionSignature{
-		paramTypes: paramTypes,
-		restType:   &restT,
+		typeChecker: typeChecker,
+		node:        node,
+		parameters:  parameters,
+		paramTypes:  make([]*checker.Type, len(parameters)),
+		restParam:   restParam,
 	}
 }
 
@@ -106,7 +86,13 @@ type functionSignature struct {
 	hasConsumedArguments bool
 	parameterTypeIndex   int
 
+	typeChecker *checker.Checker
+	node        *ast.Node
+	// parameters holds the non-rest parameters; paramTypes caches their types,
+	// resolved lazily so that skipped argument positions never request them.
+	parameters []*ast.Symbol
 	paramTypes []*checker.Type
+	restParam  *ast.Symbol
 	restType   *restType
 }
 
@@ -114,18 +100,43 @@ func (s *functionSignature) consumeRemainingArguments() {
 	s.hasConsumedArguments = true
 }
 
+// skipParameter advances past the parameter position of an argument that
+// doesn't need checking, without resolving the parameter's type.
+func (s *functionSignature) skipParameter() {
+	s.parameterTypeIndex += 1
+}
+
+func (s *functionSignature) getRestType() *restType {
+	if s.restType != nil {
+		return s.restType
+	}
+	restT := restType{Index: len(s.parameters), Kind: restTypeKindOther}
+	if s.restParam != nil {
+		t := s.typeChecker.GetTypeOfSymbolAtLocation(s.restParam, s.node)
+		if checker.Checker_isArrayType(s.typeChecker, t) {
+			restT.Kind = restTypeKindArray
+			restT.Type = checker.Checker_getTypeArguments(s.typeChecker, t)[0]
+		} else if checker.IsTupleType(t) {
+			restT.Kind = restTypeKindTuple
+			restT.TypeArguments = checker.Checker_getTypeArguments(s.typeChecker, t)
+		} else {
+			restT.Type = t
+		}
+	}
+	s.restType = &restT
+	return s.restType
+}
+
 func (s *functionSignature) getNextParameterType() *checker.Type {
 	index := s.parameterTypeIndex
 	s.parameterTypeIndex += 1
 
 	if index >= len(s.paramTypes) || s.hasConsumedArguments {
-		if s.restType == nil {
-			return nil
-		}
+		restType := s.getRestType()
 
-		switch s.restType.Kind {
+		switch restType.Kind {
 		case restTypeKindTuple:
-			typeArguments := s.restType.TypeArguments
+			typeArguments := restType.TypeArguments
 			if len(typeArguments) == 0 {
 				return nil
 			}
@@ -137,17 +148,52 @@ func (s *functionSignature) getNextParameterType() *checker.Type {
 				return typeArguments[len(typeArguments)-1]
 			}
 
-			typeIndex := index - s.restType.Index
+			typeIndex := index - restType.Index
 			if typeIndex >= len(typeArguments) {
 				return typeArguments[len(typeArguments)-1]
 			}
 
 			return typeArguments[typeIndex]
 		case restTypeKindArray, restTypeKindOther:
-			return s.restType.Type
+			return restType.Type
 		}
 	}
+	if s.paramTypes[index] == nil {
+		s.paramTypes[index] = s.typeChecker.GetTypeOfSymbolAtLocation(s.parameters[index], s.node)
+	}
 	return s.paramTypes[index]
+}
+
+// argumentCanBeUnsafe reports whether an argument expression could have a type
+// that IsUnsafeAssignment flags: `any`, or a generic type reference with unsafe
+// type arguments. Literals and template strings have literal/primitive types,
+// and function/object-literal expressions have anonymous object types — never
+// `any` and never a type reference — so resolving their type can be skipped.
+// Array literals CAN be unsafe (their type is the generic Array<T> reference,
+// e.g. `foo([anyValue])`), so they are not skipped.
+func argumentCanBeUnsafe(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindStringLiteral,
+		ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindTemplateExpression,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword,
+		ast.KindRegularExpressionLiteral,
+		ast.KindArrowFunction,
+		ast.KindFunctionExpression:
+		return false
+	case ast.KindObjectLiteralExpression:
+		// Spreading an `any` value makes the whole object literal `any`
+		// (e.g. `foo({ ...anyValue })`), so only spread-free literals are safe.
+		return slices.ContainsFunc(node.AsObjectLiteralExpression().Properties.Nodes, func(property *ast.Node) bool {
+			return property.Kind == ast.KindSpreadAssignment
+		})
+	default:
+		return true
+	}
 }
 
 var NoUnsafeArgumentRule = rule.Rule{
@@ -182,7 +228,9 @@ var NoUnsafeArgumentRule = rule.Rule{
 			callee *ast.Expression,
 			node *ast.Node,
 		) {
-			if len(args) == 0 {
+			// A report requires at least one argument whose type could be unsafe;
+			// skip the callee/signature type queries when none qualifies.
+			if !slices.ContainsFunc(args, argumentCanBeUnsafe) {
 				return
 			}
 
@@ -198,7 +246,7 @@ var NoUnsafeArgumentRule = rule.Rule{
 
 			if ast.IsTaggedTemplateExpression(node) {
 				// Consumes the first parameter (TemplateStringsArray) of the function called with TaggedTemplateExpression.
-				signature.getNextParameterType()
+				signature.skipParameter()
 			}
 
 			for _, argument := range args {
@@ -247,6 +295,11 @@ var NoUnsafeArgumentRule = rule.Rule{
 					}
 
 				default:
+					if !argumentCanBeUnsafe(argument) {
+						signature.skipParameter()
+						continue
+					}
+
 					parameterType := signature.getNextParameterType()
 					if parameterType == nil {
 						continue

--- a/internal/rules/no_unsafe_argument/no_unsafe_argument_test.go
+++ b/internal/rules/no_unsafe_argument/no_unsafe_argument_test.go
@@ -445,5 +445,20 @@ foo` + "`" + `${arg}` + "`" + `;
 				},
 			},
 		},
+		{
+			Code: `
+declare function foo(arg: { x: number }): void;
+declare const anyValue: any;
+foo({ ...anyValue });
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unsafeArgument",
+					Line:      4,
+					Column:    5,
+					EndColumn: 20,
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
## Summary

An argument can only be reported when `IsUnsafeAssignment` flags its type: `any` (including error types), or a generic type reference with unsafe type arguments. Two classes of expression can be proven safe syntactically:

- **Literals, templates, and function expressions** — literal/primitive or anonymous function types; never `any`, never a type reference.
- **Spread-free object literals** — anonymous object types. Object literals *containing* a spread are **not** skipped: spreading an `any` value makes the whole literal's type `any` (`foo({ ...anyValue })` must still report). Array literals are also not skipped, since their type is the generic `Array<T>` reference (`foo([anyValue])` reports).

Changes:

- `checkUnsafeArguments` pre-scans the arguments and returns before the callee `GetTypeAtLocation` + `getResolvedSignature` when no argument could be unsafe (also covers zero-arg calls).
- Skippable arguments advance the parameter cursor via a new `skipParameter()` instead of resolving the parameter type.
- `newFunctionSignature` no longer eagerly resolves every parameter type up front; parameter types are resolved lazily and memoized, and the rest-parameter type is resolved on first use. Skipped positions never pay for `GetTypeOfSymbolAtLocation`.

## Measurement

VS Code corpus (`src/tsconfig.json`, 7.3k files), `--debug timings`, all rules enabled:

| | rule time | calls |
|---|---|---|
| before | 1171.9 ms | 696,820 |
| after | 766.6 ms | 696,820 |

Diagnostics identical before/after (210,029 keys compared at `rule file:line:col` granularity). The key-level diff is what caught the object-literal-spread case during development: an unconditional object-literal skip lost 14 real diagnostics on VS Code, all `{ ...someAny }` arguments. That case now also has an explicit regression test (`foo({ ...anyValue })` with `declare const anyValue: any`), verified to fail if the guard is widened back to an unconditional skip. As with #1064, the win is partially masked in all-rules runs by checker cache warming from other rules.

Rule test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
