### PR TITLE
perf(linter): gate reportNodeWithSuggestions on FixSuggestions

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -289,7 +289,10 @@ func (b *ruleContextBuilder) reportNodeWithFixes(node *ast.Node, msg rule.RuleMe
 }
 
 func (b *ruleContextBuilder) reportNodeWithSuggestions(node *ast.Node, msg rule.RuleMessage, suggestionsFn func() []rule.RuleSuggestion) {
-	suggestions := suggestionsFn()
+	var suggestions []rule.RuleSuggestion
+	if b.fixState.FixSuggestions {
+		suggestions = suggestionsFn()
+	}
 	b.emitDiagnostic(rule.RuleDiagnostic{
 		Range:       utils.TrimNodeTextRange(b.file, node),
 		Message:     msg,


### PR DESCRIPTION
## Summary

`reportNodeWithSuggestions` built its suggestions eagerly, unlike its siblings `reportDiagnosticWithSuggestions` and `reportRangeWithSuggestions`, which only invoke the suggestion builder when `Fixes.FixSuggestions` is set. This adds the same gate.

In headless mode without fix suggestions requested, the serializer already drops suggestions (`opts.fixSuggestions` check in `headless.go`), so every diagnostic reported through `ReportNodeWithSuggestions` paid for building suggestion fixes that were never emitted. On the VS Code corpus that's ~25k diagnostics across the 11 rules using this entry point (promise-function-async 7.3k, no-confusing-void-expression 6.9k, no-floating-promises 5.5k, prefer-nullish-coalescing 3.9k, prefer-optional-chain 1.2k, …).

Output is unchanged in all modes: the CLI and rule tester set `FixSuggestions: true`, and headless only serializes suggestions when the client requests them.

## Benchmarks

Headless mode on the VS Code corpus (7,131 files × 58 rules, `fix_suggestions` off — the mode this change affects), 3 interleaved runs per binary, `--debug timings`:

- **Correctness:** output is byte-equivalent — all 208,056 diagnostics identical between base and gated binaries (rule, file, range, message ID, fixes), `with_suggestions=0` in both.
- **Wall clock:** unchanged (~9.5s both; the gated work is a small fraction of total lint time).
- **Per-rule timings:** `switch-exhaustiveness-check` is the clear beneficiary — its suggestion builder does checker work (enumerating missing union/enum members and stringifying their types) per diagnostic: **39.7ms → 25.4ms mean (−36%)**, cleanly separated across runs (base 38.6/39.8/40.8 vs gated 25.0/25.8/25.5). The other suggestion-reporting rules build suggestions from purely syntactic text edits, so their individual deltas stay within noise; the sum over all 13 affected rules moved −31.5ms (~−0.9%).
- **Alloc profile:** confirms the mechanism. In the base binary, `reportNodeWithSuggestions`'s callees include the `switch_exhaustiveness_check` and `no_floating_promises` suggestion-builder closures (cum 37,961 sampled objects); in the gated binary only `emitDiagnostic`/`TrimNodeTextRange` remain (cum 7,373) — the eager builder frames are gone.

Net: invisible end-to-end, but it removes real, provably-dead per-diagnostic work, with the win concentrated in rules whose suggestion builders touch the checker. The main motivation remains consistency with the sibling report paths.

Linter and rule tester test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)