### PR TITLE
perf(strict-void-return): skip type queries for never-callable expressions

### DIFF
--- a/internal/rule_tester/__snapshots__/strict-void-return.snap
+++ b/internal/rule_tester/__snapshots__/strict-void-return.snap
@@ -1215,3 +1215,21 @@ Message: Value returned in a context where a void return is expected.
      |                    ~~~~~~
    5 |       
 ---
+
+[TestStrictVoidReturnRule/invalid-110 - 1]
+Diagnostic 1: nonVoidFunc (4:7 - 4:14)
+Message: Value-returning function used in a context where a void function is expected.
+   3 | function bar<T extends () => number>(t: T) {
+   4 |   foo({ ...t });
+     |       ~~~~~~~~
+   5 | }
+---
+
+[TestStrictVoidReturnRule/invalid-111 - 1]
+Diagnostic 1: nonVoidFunc (3:26 - 3:33)
+Message: Value-returning function used in a context where a void function is expected.
+   2 | function bar<T extends () => number>(t: T) {
+   3 |   const cb: () => void = { ...t };
+     |                          ~~~~~~~~
+   4 | }
+---

--- a/internal/rules/strict_void_return/strict_void_return.go
+++ b/internal/rules/strict_void_return/strict_void_return.go
@@ -75,6 +75,30 @@ var StrictVoidReturnRule = rule.Rule{
 			return utils.IsTypeFlagSet(t, checker.TypeFlagsVoid)
 		}
 
+		// A syntactic check for whether an expression could possibly evaluate to a
+		// value with call signatures. Literals, templates, and array/object literals
+		// can never be callable, so `reportIfNonVoidFunction` can never report them
+		// and the type queries leading up to it can be skipped entirely.
+		// This is a perf optimization to help avoid requesting types where possible.
+		couldBeFunctionLikeValue := func(node *ast.Node) bool {
+			switch node.Kind {
+			case ast.KindStringLiteral,
+				ast.KindNoSubstitutionTemplateLiteral,
+				ast.KindTemplateExpression,
+				ast.KindNumericLiteral,
+				ast.KindBigIntLiteral,
+				ast.KindTrueKeyword,
+				ast.KindFalseKeyword,
+				ast.KindNullKeyword,
+				ast.KindRegularExpressionLiteral,
+				ast.KindArrayLiteralExpression,
+				ast.KindObjectLiteralExpression:
+				return false
+			default:
+				return true
+			}
+		}
+
 		var reportIfNonVoidFunction func(funcNode *ast.Node)
 		reportIfNonVoidFunction = func(funcNode *ast.Node) {
 			actualType := checker.Checker_getApparentType(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(funcNode))
@@ -139,6 +163,9 @@ var StrictVoidReturnRule = rule.Rule{
 		}
 
 		checkExpressionNode := func(node *ast.Node) bool {
+			if !couldBeFunctionLikeValue(node) {
+				return false
+			}
 			expectedType := checker.Checker_getContextualType(ctx.TypeChecker, node, checker.ContextFlagsNone)
 			if expectedType != nil && isVoidReturningFunctionType(expectedType) {
 				reportIfNonVoidFunction(node)
@@ -148,6 +175,13 @@ var StrictVoidReturnRule = rule.Rule{
 		}
 
 		checkFunctionCallNode := func(callNode *ast.Expression) {
+			args := callNode.Arguments()
+			// Only function-valued arguments can ever be reported, so skip the
+			// callee/parameter type resolution when no argument could be one.
+			if !slices.ContainsFunc(args, couldBeFunctionLikeValue) {
+				return
+			}
+
 			funcType := ctx.TypeChecker.GetTypeAtLocation(callNode.Expression())
 			signatures := utils.Flatten(utils.Map(utils.UnionTypeParts(funcType), func(typePart *checker.Type) []*checker.Signature {
 				if ast.IsCallExpression(callNode) {
@@ -156,8 +190,8 @@ var StrictVoidReturnRule = rule.Rule{
 				return utils.GetConstructSignatures(ctx.TypeChecker, typePart)
 			}))
 
-			for argIdx, argNode := range callNode.Arguments() {
-				if argNode.Kind == ast.KindSpreadElement {
+			for argIdx, argNode := range args {
+				if argNode.Kind == ast.KindSpreadElement || !couldBeFunctionLikeValue(argNode) {
 					continue
 				}
 

--- a/internal/rules/strict_void_return/strict_void_return.go
+++ b/internal/rules/strict_void_return/strict_void_return.go
@@ -76,8 +76,8 @@ var StrictVoidReturnRule = rule.Rule{
 		}
 
 		// A syntactic check for whether an expression could possibly evaluate to a
-		// value with call signatures. Literals, templates, and array/object literals
-		// can never be callable, so `reportIfNonVoidFunction` can never report them
+		// value with call signatures. Literals, templates, and array literals can
+		// never be callable, so `reportIfNonVoidFunction` can never report them
 		// and the type queries leading up to it can be skipped entirely.
 		// This is a perf optimization to help avoid requesting types where possible.
 		couldBeFunctionLikeValue := func(node *ast.Node) bool {
@@ -91,9 +91,15 @@ var StrictVoidReturnRule = rule.Rule{
 				ast.KindFalseKeyword,
 				ast.KindNullKeyword,
 				ast.KindRegularExpressionLiteral,
-				ast.KindArrayLiteralExpression,
-				ast.KindObjectLiteralExpression:
+				ast.KindArrayLiteralExpression:
 				return false
+			case ast.KindObjectLiteralExpression:
+				// Spreading a generic value keeps its type (e.g. `{ ...t }` where
+				// `T extends () => void` has type `T`), which can be callable, so
+				// only spread-free object literals are known to be never-callable.
+				return slices.ContainsFunc(node.AsObjectLiteralExpression().Properties.Nodes, func(property *ast.Node) bool {
+					return property.Kind == ast.KindSpreadAssignment
+				})
 			default:
 				return true
 			}

--- a/internal/rules/strict_void_return/strict_void_return_test.go
+++ b/internal/rules/strict_void_return/strict_void_return_test.go
@@ -2364,6 +2364,27 @@ f(undefined, () => 'test');
 				{MessageId: "nonVoidReturn", Line: 4},
 			},
 		},
+		{
+			Code: `
+declare function foo(cb: () => void): void;
+function bar<T extends () => number>(t: T) {
+  foo({ ...t });
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nonVoidFunc", Line: 4},
+			},
+		},
+		{
+			Code: `
+function bar<T extends () => number>(t: T) {
+  const cb: () => void = { ...t };
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nonVoidFunc", Line: 3},
+			},
+		},
 	}
 
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &StrictVoidReturnRule, validCases, invalidCases)


### PR DESCRIPTION
## Summary

Applies the same syntactic guard pattern as #1065 to `strict-void-return`, the rule with the highest unmasked cost found so far (~10s solo on the VS Code corpus — its ~570ms in all-rules runs is ~17× masked by checker-cache warming from other rules).

The rule can only ever report a node whose type has call signatures (`reportIfNonVoidFunction` early-returns when `GetCallSignatures` is empty). Literals, templates, array literals, and spread-free object literals can never be callable, so:

- `checkExpressionNode` now skips the `Checker_getContextualType` query for such nodes (fires on every variable initializer, return expression, assignment RHS, property assignment, array element, and JSX attribute).
- `checkFunctionCallNode` (fires on **every** call/new expression) now skips callee type + signature resolution entirely when no argument could be function-valued — including all zero-argument calls, which previously resolved the callee's type and full signature list for nothing — and skips the per-argument parameter-type walk for never-callable arguments.

**Object literals containing a spread are NOT skipped:** spreading a generic value keeps its type (`{ ...t }` where `T extends () => void` has type `T`), whose apparent type can have call signatures. An earlier revision skipped all object literals; adversarial review caught the false negative and regression tests now cover both guarded paths.

Known theoretical deviation (shared with #1065): global-interface augmentation like `interface String { (): void }` can make literal types callable; the guard would skip them. Considered pathological and acceptable.

## Benchmarks

VS Code corpus (src/tsconfig.json, 7,131 files), headless, 3 interleaved runs per binary, measured at the final revision (86f9396):

- **Solo run (rule alone):** 10330/10210/10238ms → 9832/9650/9610ms (mean 10259 → 9697, **−5.5%**), cleanly separated. Remaining cost is the rule's semantic core: `getContextualTypeForArgument` on function-valued call arguments.
- **Full 58-rule run:** rule time 573ms → 410ms (**−28%**).
- **Parity:** solo diagnostics key-level identical (3,140); full-run diagnostics key-level identical across all 58 rules (208k keys, zero diff).

Rule test suite passes, including two new regression tests for the spread-of-generic case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)