### PR TITLE
Revert "perf(strict-void-return): skip type queries for never-callable expressions"

### DIFF
--- a/internal/rule_tester/__snapshots__/strict-void-return.snap
+++ b/internal/rule_tester/__snapshots__/strict-void-return.snap
@@ -1215,21 +1215,3 @@ Message: Value returned in a context where a void return is expected.
      |                    ~~~~~~
    5 |       
 ---
-
-[TestStrictVoidReturnRule/invalid-110 - 1]
-Diagnostic 1: nonVoidFunc (4:7 - 4:14)
-Message: Value-returning function used in a context where a void function is expected.
-   3 | function bar<T extends () => number>(t: T) {
-   4 |   foo({ ...t });
-     |       ~~~~~~~~
-   5 | }
----
-
-[TestStrictVoidReturnRule/invalid-111 - 1]
-Diagnostic 1: nonVoidFunc (3:26 - 3:33)
-Message: Value-returning function used in a context where a void function is expected.
-   2 | function bar<T extends () => number>(t: T) {
-   3 |   const cb: () => void = { ...t };
-     |                          ~~~~~~~~
-   4 | }
----

--- a/internal/rules/strict_void_return/strict_void_return.go
+++ b/internal/rules/strict_void_return/strict_void_return.go
@@ -75,36 +75,6 @@ var StrictVoidReturnRule = rule.Rule{
 			return utils.IsTypeFlagSet(t, checker.TypeFlagsVoid)
 		}
 
-		// A syntactic check for whether an expression could possibly evaluate to a
-		// value with call signatures. Literals, templates, and array literals can
-		// never be callable, so `reportIfNonVoidFunction` can never report them
-		// and the type queries leading up to it can be skipped entirely.
-		// This is a perf optimization to help avoid requesting types where possible.
-		couldBeFunctionLikeValue := func(node *ast.Node) bool {
-			switch node.Kind {
-			case ast.KindStringLiteral,
-				ast.KindNoSubstitutionTemplateLiteral,
-				ast.KindTemplateExpression,
-				ast.KindNumericLiteral,
-				ast.KindBigIntLiteral,
-				ast.KindTrueKeyword,
-				ast.KindFalseKeyword,
-				ast.KindNullKeyword,
-				ast.KindRegularExpressionLiteral,
-				ast.KindArrayLiteralExpression:
-				return false
-			case ast.KindObjectLiteralExpression:
-				// Spreading a generic value keeps its type (e.g. `{ ...t }` where
-				// `T extends () => void` has type `T`), which can be callable, so
-				// only spread-free object literals are known to be never-callable.
-				return slices.ContainsFunc(node.AsObjectLiteralExpression().Properties.Nodes, func(property *ast.Node) bool {
-					return property.Kind == ast.KindSpreadAssignment
-				})
-			default:
-				return true
-			}
-		}
-
 		var reportIfNonVoidFunction func(funcNode *ast.Node)
 		reportIfNonVoidFunction = func(funcNode *ast.Node) {
 			actualType := checker.Checker_getApparentType(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(funcNode))
@@ -169,9 +139,6 @@ var StrictVoidReturnRule = rule.Rule{
 		}
 
 		checkExpressionNode := func(node *ast.Node) bool {
-			if !couldBeFunctionLikeValue(node) {
-				return false
-			}
 			expectedType := checker.Checker_getContextualType(ctx.TypeChecker, node, checker.ContextFlagsNone)
 			if expectedType != nil && isVoidReturningFunctionType(expectedType) {
 				reportIfNonVoidFunction(node)
@@ -181,13 +148,6 @@ var StrictVoidReturnRule = rule.Rule{
 		}
 
 		checkFunctionCallNode := func(callNode *ast.Expression) {
-			args := callNode.Arguments()
-			// Only function-valued arguments can ever be reported, so skip the
-			// callee/parameter type resolution when no argument could be one.
-			if !slices.ContainsFunc(args, couldBeFunctionLikeValue) {
-				return
-			}
-
 			funcType := ctx.TypeChecker.GetTypeAtLocation(callNode.Expression())
 			signatures := utils.Flatten(utils.Map(utils.UnionTypeParts(funcType), func(typePart *checker.Type) []*checker.Signature {
 				if ast.IsCallExpression(callNode) {
@@ -196,8 +156,8 @@ var StrictVoidReturnRule = rule.Rule{
 				return utils.GetConstructSignatures(ctx.TypeChecker, typePart)
 			}))
 
-			for argIdx, argNode := range args {
-				if argNode.Kind == ast.KindSpreadElement || !couldBeFunctionLikeValue(argNode) {
+			for argIdx, argNode := range callNode.Arguments() {
+				if argNode.Kind == ast.KindSpreadElement {
 					continue
 				}
 

--- a/internal/rules/strict_void_return/strict_void_return_test.go
+++ b/internal/rules/strict_void_return/strict_void_return_test.go
@@ -2364,27 +2364,6 @@ f(undefined, () => 'test');
 				{MessageId: "nonVoidReturn", Line: 4},
 			},
 		},
-		{
-			Code: `
-declare function foo(cb: () => void): void;
-function bar<T extends () => number>(t: T) {
-  foo({ ...t });
-}
-      `,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "nonVoidFunc", Line: 4},
-			},
-		},
-		{
-			Code: `
-function bar<T extends () => number>(t: T) {
-  const cb: () => void = { ...t };
-}
-      `,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "nonVoidFunc", Line: 3},
-			},
-		},
 	}
 
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.minimal.json", t, &StrictVoidReturnRule, validCases, invalidCases)


### PR DESCRIPTION
Reverts oxc-project/tsgolint#1068

> Known theoretical deviation (shared with https://github.com/oxc-project/tsgolint/pull/1065): global-interface augmentation like interface String { (): void } can make literal types callable; the guard would skip them. Considered pathological and acceptable.

As mentioned [here](https://github.com/oxc-project/tsgolint/pull/1065#issuecomment-4934415570), we should be targeting correctness over performance (we want users to trust the results of these tools, and prioritising perf can erode that trust. The TS type system is incredibly flexilble, and user can (and will) do wierd and strange things.