### PR TITLE
perf(no-unnecessary-type-arguments): gate type queries behind cheap checks

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-type-arguments.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-type-arguments.snap
@@ -259,3 +259,12 @@ Message: This is the default value for this type parameter, so it can be omitted
      |               ~~~~~~~
    6 |       
 ---
+
+[TestNoUnnecessaryTypeArguments/invalid-29 - 1]
+Diagnostic 1: unnecessaryTypeParameter (4:6 - 4:11)
+Message: This is the default value for this type parameter, so it can be omitted.
+   3 | declare function make(): void;
+   4 | make<number>(1);
+     |      ~~~~~~
+   5 |       
+---

--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
@@ -105,7 +105,98 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 			return nil
 		}
 
+		// declarationHasDefaultedTypeParameter reports whether a function-like
+		// declaration has at least one type parameter with a default.
+		declarationHasDefaultedTypeParameter := func(decl *ast.Node) bool {
+			for _, typeParameter := range decl.TypeParameters() {
+				if typeParameter.AsTypeParameterDeclaration().DefaultType != nil {
+					return true
+				}
+			}
+			return false
+		}
+
+		// declarationCannotAcceptArgCount reports whether a function-like
+		// declaration definitely cannot be the overload resolved for a call with
+		// argCount value arguments. It only returns true when certain: the
+		// declaration has fewer parameter slots than the call has arguments and
+		// no rest parameter to absorb the extras. Conservative (returns false)
+		// whenever argCount is unknown (<0) or a rest parameter is present.
+		declarationCannotAcceptArgCount := func(decl *ast.Node, argCount int) bool {
+			if argCount < 0 {
+				return false
+			}
+			parameters := decl.Parameters()
+			if len(parameters) >= argCount {
+				return false
+			}
+			for _, parameter := range parameters {
+				if parameter.AsParameterDeclaration().DotDotDotToken != nil {
+					return false
+				}
+			}
+			return true
+		}
+
+		// callCanReportUnnecessaryTypeArgument is a cheap gate before the
+		// expensive signature resolution below. The rule can only report when the
+		// resolved overload's type parameter (at the position of the last type
+		// argument) has a default. Resolving the callee symbol and scanning its
+		// overload declarations is far cheaper than full overload resolution, so
+		// when no overload that could match this call's argument count carries a
+		// defaulted type parameter, the resolution is skipped entirely. Any
+		// uncertainty falls back to resolving (returns true) to preserve behavior.
+		callCanReportUnnecessaryTypeArgument := func(node *ast.Node) bool {
+			var callee *ast.Node
+			argCount := -1
+			switch node.Kind {
+			case ast.KindCallExpression, ast.KindNewExpression:
+				callee = node.Expression()
+				argCount = len(node.Arguments())
+			case ast.KindTaggedTemplateExpression:
+				callee = node.AsTaggedTemplateExpression().Tag
+			default:
+				// JSX and anything else: argument count is ambiguous, so don't
+				// attempt to gate; resolve as before.
+				return true
+			}
+			if callee == nil {
+				return true
+			}
+
+			symbol := ctx.TypeChecker.GetSymbolAtLocation(callee)
+			if symbol == nil {
+				return true
+			}
+			if symbol.Flags&ast.SymbolFlagsAlias != 0 {
+				var found bool
+				symbol, found = ctx.TypeChecker.ResolveAlias(symbol)
+				if !found {
+					return true
+				}
+			}
+			if symbol.Declarations == nil {
+				return true
+			}
+
+			for _, decl := range symbol.Declarations {
+				// Only plain function/method overloads have a syntactic parameter
+				// list we can reason about. For classes, variables holding
+				// call/construct signatures, etc., fall back to resolving.
+				if decl.FunctionLikeData() == nil {
+					return true
+				}
+				if declarationHasDefaultedTypeParameter(decl) && !declarationCannotAcceptArgCount(decl, argCount) {
+					return true
+				}
+			}
+			return false
+		}
+
 		getTypeParametersFromCall := func(node *ast.Node) []*ast.Node {
+			if !callCanReportUnnecessaryTypeArgument(node) {
+				return nil
+			}
 			signature := checker.Checker_getResolvedSignature(ctx.TypeChecker, node, nil, checker.CheckModeNormal)
 			if signature != nil {
 				if declaration := checker.Signature_declaration(signature); declaration != nil {
@@ -248,34 +339,63 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 			})
 		}
 
+		// A node can only be reported when it has an explicit type argument list.
+		// Most call/new/type-reference nodes have none, so gate the expensive
+		// type-parameter queries (getResolvedSignature / symbol resolution) behind
+		// this cheap syntactic check before they run.
+		hasTypeArguments := func(typeArguments *ast.NodeList) bool {
+			return typeArguments != nil && len(typeArguments.Nodes) != 0
+		}
+
 		return rule.RuleListeners{
 			ast.KindExpressionWithTypeArguments: func(node *ast.Node) {
 				expr := node.AsExpressionWithTypeArguments()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromType(node, expr.Expression))
 			},
 			ast.KindTypeReference: func(node *ast.Node) {
 				expr := node.AsTypeReferenceNode()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromType(node, expr.TypeName))
 			},
 
 			ast.KindCallExpression: func(node *ast.Node) {
 				expr := node.AsCallExpression()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindNewExpression: func(node *ast.Node) {
 				expr := node.AsNewExpression()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindTaggedTemplateExpression: func(node *ast.Node) {
 				expr := node.AsTaggedTemplateExpression()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindJsxOpeningElement: func(node *ast.Node) {
 				expr := node.AsJsxOpeningElement()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 			ast.KindJsxSelfClosingElement: func(node *ast.Node) {
 				expr := node.AsJsxSelfClosingElement()
+				if !hasTypeArguments(expr.TypeArguments) {
+					return
+				}
 				checkArgsAndParameters(node, expr.TypeArguments, getTypeParametersFromCall(node))
 			},
 		}

--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
@@ -65,24 +65,30 @@ var NoUnnecessaryTypeArgumentsRule = rule.Rule{
 				return nil
 			}
 
-			declarations := slices.Clone(symbol.Declarations)
+			// Only a symbol with merged declarations needs reordering so the
+			// type-context declaration is consulted first. The common case is a
+			// single declaration, where cloning and sorting would just allocate.
+			declarations := symbol.Declarations
+			if len(declarations) > 1 {
+				declarations = slices.Clone(declarations)
 
-			nodeInTypeContext := isInTypeContext(node)
-			slices.SortFunc(declarations, func(a *ast.Node, b *ast.Node) int {
-				if !nodeInTypeContext {
-					a, b = b, a
-				}
-				res := 0
+				nodeInTypeContext := isInTypeContext(node)
+				slices.SortFunc(declarations, func(a *ast.Node, b *ast.Node) int {
+					if !nodeInTypeContext {
+						a, b = b, a
+					}
+					res := 0
 
-				if isTypeContextDeclaration(a) {
-					res -= 1
-				}
-				if isTypeContextDeclaration(b) {
-					res += 1
-				}
+					if isTypeContextDeclaration(a) {
+						res -= 1
+					}
+					if isTypeContextDeclaration(b) {
+						res += 1
+					}
 
-				return res
-			})
+					return res
+				})
+			}
 
 			for _, decl := range declarations {
 				if ast.IsTypeAliasDeclaration(decl) || ast.IsInterfaceDeclaration(decl) || ast.IsClassLike(decl) {

--- a/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
+++ b/internal/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
@@ -197,6 +197,14 @@ const button = <Button<string> />;
 function f<T = number>() {}
 const g = f<number>;
     `},
+		// A defaulted type parameter only lives on the zero-argument overload, so
+		// a call that passes an argument resolves to the non-defaulted overload
+		// and must not be reported (mirrors React's useState<string>('')).
+		{Code: `
+declare function useThing<S>(initial: S): S;
+declare function useThing<S = undefined>(): S | undefined;
+useThing<string>('');
+    `},
 		{Code: `
 function f<T = number>() {}
 function takesFn(fn: () => void) {}
@@ -1029,6 +1037,28 @@ new C<string>('value');
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					Line:      5,
+					MessageId: "unnecessaryTypeParameter",
+				},
+			},
+		},
+		// The argument-taking overload itself carries the default, so a call that
+		// passes an argument still resolves to a defaulted type parameter. The
+		// gate must resolve (not skip) and report the redundant type argument.
+		{
+			Code: `
+declare function make<T = number>(x: T): void;
+declare function make(): void;
+make<number>(1);
+      `,
+			Output: []string{`
+declare function make<T = number>(x: T): void;
+declare function make(): void;
+make(1);
+      `,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					Line:      4,
 					MessageId: "unnecessaryTypeParameter",
 				},
 			},


### PR DESCRIPTION
## Summary

`no-unnecessary-type-arguments` ran its expensive type-parameter queries unconditionally. On a real React codebase this made it the **single most expensive rule** — ~15–18% of total lint time — because React's deeply-generic hook overloads (`useState`, `useRef`, …) are pathological for signature resolution. Three complementary short-circuits, all producing **identical diagnostics**:

1. **Skip the query for nodes with no explicit type argument list** (all 7 listeners). A node can only be reported if it has a `<…>` list, so this moves `checkArgsAndParameters`'s existing empty-arguments early-return *ahead* of the eagerly-evaluated query argument.

2. **A cheap symbol-based gate for the call/new/tagged path.** The rule can only report when the *matched* overload's last type parameter has a **default**. Instead of always paying `getResolvedSignature` (full overload resolution + inference), resolve the callee **symbol** (a cheap name lookup) and skip resolution when no overload that could accept this call's *argument count* carries a defaulted type parameter. React's `useState<S = undefined>()` default lives on the **zero-argument** overload, so `useState<string>("")` is inapplicable to it by arity and resolution selects the argument-taking overload, which has no default. (Verified with `tsc`: with the zero-arg defaulted overload declared *first*, `f<string>("")` still resolves to the arg-taking overload.) Any uncertainty (unresolved symbol, class/variable declaration, tagged-template/JSX where arg count is ambiguous) falls back to resolving. **False-negative-free**: the overload that would report always accepted the call's arguments, so it is never excluded and always forces resolution.

3. **Skip cloning + sorting `symbol.Declarations` for single-declaration symbols** in the type-reference path. The clone+sort only matters for merged symbols (multiple declarations); the common case is one declaration, where it just allocates.

## Measurement — real React codebase (excalidraw)

`--debug timings`, all rules enabled, `packages/excalidraw/tsconfig.json` (with `@types/react` installed). The row is this rule's own listener time:

| | rule time (3 runs) | % of total | calls |
|---|---|---|---|
| **before** | 1571 / 1336 / 1156 ms | 15–18% | 20,277 |
| **after** | 11 / 15 / 21 ms | 0.1–0.3% | 20,277 |

**~99% reduction** (~1.3 s → ~15 ms), identical call count. Diagnostics **byte-identical** — this rule's 4 findings match exactly, and all 7,458 diagnostics across every rule are unchanged (zero collateral).

### Microbenchmarks (single-rule isolation, AMD Ryzen 9 9950X)

| Scenario | Before | After | Δ |
|---|---|---|---|
| typeorm `src` (507 files), warm (benchstat n=6) | 30.39ms | 19.23ms | **−36.7%** (p=0.002) |
| allocations (after clone-skip) | 20.14k | 9.7k | **−52%** |
| React `useState/useRef/useMemo<T>` cold, 6000 calls | 47ms | 20ms | **−57%** (near the no-op floor) |

## Reproduce on excalidraw

```sh
# 1. Corpus with real @types/react (the generic hook overloads)
git clone --depth 1 https://github.com/excalidraw/excalidraw
( cd excalidraw && yarn install --frozen-lockfile )

# 2. Build the "after" binary from this branch
go build -o /tmp/tsgolint-after ./cmd/tsgolint
# ...and a "before" binary from the base commit (stash this rule's changes or check out main)

# 3. Compare this rule's own time (all rules, --debug timings)
cd excalidraw
/tmp/tsgolint-before --tsconfig packages/excalidraw/tsconfig.json --debug timings | grep no-unnecessary-type-arguments
/tmp/tsgolint-after  --tsconfig packages/excalidraw/tsconfig.json --debug timings | grep no-unnecessary-type-arguments

# 4. Verify diagnostics are unchanged
diff \
  <(/tmp/tsgolint-before --tsconfig packages/excalidraw/tsconfig.json 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g') \
  <(/tmp/tsgolint-after  --tsconfig packages/excalidraw/tsconfig.json 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')
```

## Tests

Rule suite passes. Adds two regression tests:
- **valid** `useThing<string>('')` — defaulted type parameter only on the zero-arg overload, must not false-report (the `useState` shape).
- **invalid** `make<number>(1)` — the argument-taking overload itself carries the default, so the gate must resolve and still report the redundant type argument (snapshot `invalid-29`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)