### PR TITLE
perf(no-misused-promises): skip type queries for never-callable expressions

### DIFF
--- a/internal/rule_tester/__snapshots__/no-misused-promises.snap
+++ b/internal/rule_tester/__snapshots__/no-misused-promises.snap
@@ -1025,3 +1025,51 @@ Message: Promise-returning function provided to variable where a void return was
      |                          ~~~~~~~~
    4 | }
 ---
+
+[TestNoMisusedPromisesRule/invalid-92 - 1]
+Diagnostic 1: voidReturnArgument (6:9 - 6:17)
+Message: Promise returned in function argument where a void return was expected.
+   5 | declare function takesCb(cb: () => void): void;
+   6 | takesCb('literal');
+     |         ~~~~~~~~~
+   7 | takesCb(`template`);
+
+Diagnostic 2: voidReturnArgument (7:9 - 7:18)
+Message: Promise returned in function argument where a void return was expected.
+   6 | takesCb('literal');
+   7 | takesCb(`template`);
+     |         ~~~~~~~~~~
+   8 | const cb: () => void = 'literal';
+
+Diagnostic 3: voidReturnVariable (8:24 - 8:32)
+Message: Promise-returning function provided to variable where a void return was expected.
+   7 | takesCb(`template`);
+   8 | const cb: () => void = 'literal';
+     |                        ~~~~~~~~~
+   9 |       
+---
+
+[TestNoMisusedPromisesRule/invalid-93 - 1]
+Diagnostic 1: voidReturnArgument (6:9 - 6:11)
+Message: Promise returned in function argument where a void return was expected.
+   5 | declare function takesCb(cb: () => void): void;
+   6 | takesCb(123);
+     |         ~~~
+   7 |       
+---
+
+[TestNoMisusedPromisesRule/invalid-94 - 1]
+Diagnostic 1: voidReturnArgument (6:9 - 6:14)
+Message: Promise returned in function argument where a void return was expected.
+   5 | declare function takesCb(cb: () => void): void;
+   6 | takesCb([1, 2]);
+     |         ~~~~~~
+   7 | const cb: () => void = [1, 2];
+
+Diagnostic 2: voidReturnVariable (7:24 - 7:29)
+Message: Promise-returning function provided to variable where a void return was expected.
+   6 | takesCb([1, 2]);
+   7 | const cb: () => void = [1, 2];
+     |                        ~~~~~~
+   8 |       
+---

--- a/internal/rule_tester/__snapshots__/no-misused-promises.snap
+++ b/internal/rule_tester/__snapshots__/no-misused-promises.snap
@@ -1007,3 +1007,21 @@ Message: Promise-returning function provided to property where a void return was
      |                ~~~~~~~~~~~~~~~
    5 | };
 ---
+
+[TestNoMisusedPromisesRule/invalid-90 - 1]
+Diagnostic 1: voidReturnArgument (4:11 - 4:18)
+Message: Promise returned in function argument where a void return was expected.
+   3 | function f<T extends () => Promise<void>>(t: T) {
+   4 |   takesCb({ ...t });
+     |           ~~~~~~~~
+   5 | }
+---
+
+[TestNoMisusedPromisesRule/invalid-91 - 1]
+Diagnostic 1: voidReturnVariable (3:26 - 3:33)
+Message: Promise-returning function provided to variable where a void return was expected.
+   2 | function f<T extends () => Promise<void>>(t: T) {
+   3 |   const cb: () => void = { ...t };
+     |                          ~~~~~~~~
+   4 | }
+---

--- a/internal/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/rules/no_misused_promises/no_misused_promises.go
@@ -117,6 +117,30 @@ var NoMisusedPromisesRule = rule.Rule{
 			checksVoidReturnOpts = defaultChecksVoidReturnOpts()
 		}
 
+		// A syntactic check for whether an expression could possibly evaluate to a
+		// value with call signatures. Literals, templates, and array/object literals
+		// can never be callable, so `returnsThenable` is always false for them and
+		// the type queries guarding it can be skipped entirely.
+		// This is a perf optimization to help avoid requesting types where possible.
+		couldBeFunctionLikeValue := func(node *ast.Node) bool {
+			switch node.Kind {
+			case ast.KindStringLiteral,
+				ast.KindNoSubstitutionTemplateLiteral,
+				ast.KindTemplateExpression,
+				ast.KindNumericLiteral,
+				ast.KindBigIntLiteral,
+				ast.KindTrueKeyword,
+				ast.KindFalseKeyword,
+				ast.KindNullKeyword,
+				ast.KindRegularExpressionLiteral,
+				ast.KindArrayLiteralExpression,
+				ast.KindObjectLiteralExpression:
+				return false
+			default:
+				return true
+			}
+		}
+
 		anySignatureIsThenableType := func(
 			node *ast.Node,
 			t *checker.Type,
@@ -414,17 +438,36 @@ var NoMisusedPromisesRule = rule.Rule{
 				for _, signature := range signatures {
 					for index, parameter := range checker.Signature_parameters(signature) {
 						decl := parameter.ValueDeclaration
+						isRestParameter := decl != nil && utils.IsRestParameterDeclaration(decl)
+
+						// A parameter position can only produce a report if there is an
+						// argument at that position that could be a thenable-returning
+						// function, so skip resolving the parameter type otherwise.
+						if index >= len(node.Arguments()) {
+							continue
+						}
+						if isRestParameter {
+							if !slices.ContainsFunc(node.Arguments()[index:], couldBeFunctionLikeValue) {
+								continue
+							}
+						} else if !couldBeFunctionLikeValue(node.Arguments()[index]) {
+							continue
+						}
+
 						t := ctx.TypeChecker.GetTypeOfSymbolAtLocation(parameter, node.Expression())
 
 						// If this is a array 'rest' parameter, check all of the argument indices
 						// from the current argument to the end.
-						if decl != nil && utils.IsRestParameterDeclaration(decl) {
+						if isRestParameter {
 							if checker.Checker_isArrayType(ctx.TypeChecker, t) {
 								// Unwrap 'Array<MaybeVoidFunction>' to 'MaybeVoidFunction',
 								// so that we'll handle it in the same way as a non-rest
 								// 'param: MaybeVoidFunction'
 								t = checker.Checker_getTypeArguments(ctx.TypeChecker, t)[0]
 								for i := index; i < len(node.Arguments()); i++ {
+									if !couldBeFunctionLikeValue(node.Arguments()[i]) {
+										continue
+									}
 									checkThenableOrVoidArgument(
 										node,
 										t,
@@ -438,6 +481,9 @@ var NoMisusedPromisesRule = rule.Rule{
 								// add the index of the second tuple parameter to 'voidReturnIndices'
 								typeArgs := checker.Checker_getTypeArguments(ctx.TypeChecker, t)
 								for i := index; i < len(node.Arguments()) && i-index < len(typeArgs); i++ {
+									if !couldBeFunctionLikeValue(node.Arguments()[i]) {
+										continue
+									}
 									checkThenableOrVoidArgument(
 										node,
 										typeArgs[i-index],
@@ -473,6 +519,13 @@ var NoMisusedPromisesRule = rule.Rule{
 		checkArguments := func(
 			node *ast.Expression,
 		) {
+			// A report requires an argument that could be a thenable-returning
+			// function; skip the callee/parameter type queries when no argument
+			// qualifies (e.g. zero arguments, or all-literal arguments).
+			if !slices.ContainsFunc(node.Arguments(), couldBeFunctionLikeValue) {
+				return
+			}
+
 			voidArgs := voidFunctionArguments(node)
 			if len(voidArgs) == 0 {
 				return
@@ -533,6 +586,9 @@ var NoMisusedPromisesRule = rule.Rule{
 		checkProperty := func(node *ast.Node) {
 			if ast.IsPropertyAssignment(node) {
 				property := node.AsPropertyAssignment()
+				if !couldBeFunctionLikeValue(property.Initializer) {
+					return
+				}
 				contextualType := checker.Checker_getContextualType(ctx.TypeChecker, property.Initializer, checker.ContextFlagsNone)
 
 				if contextualType != nil && isVoidReturningFunctionType(
@@ -674,7 +730,7 @@ var NoMisusedPromisesRule = rule.Rule{
 		}
 
 		checkReturnStatement := func(node *ast.ReturnStatement) {
-			if node.Expression == nil {
+			if node.Expression == nil || !couldBeFunctionLikeValue(node.Expression) {
 				return
 			}
 
@@ -702,6 +758,9 @@ var NoMisusedPromisesRule = rule.Rule{
 		}
 
 		checkAssignment := func(node *ast.BinaryExpression) {
+			if !couldBeFunctionLikeValue(node.Right) {
+				return
+			}
 			varType := ctx.TypeChecker.GetTypeAtLocation(node.Left)
 			if !isVoidReturningFunctionType(node.Left, varType) {
 				return
@@ -714,7 +773,8 @@ var NoMisusedPromisesRule = rule.Rule{
 
 		checkVariableDeclaration := func(node *ast.VariableDeclaration) {
 			if node.Initializer == nil ||
-				node.Type == nil {
+				node.Type == nil ||
+				!couldBeFunctionLikeValue(node.Initializer) {
 				return
 			}
 

--- a/internal/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/rules/no_misused_promises/no_misused_promises.go
@@ -117,11 +117,35 @@ var NoMisusedPromisesRule = rule.Rule{
 			checksVoidReturnOpts = defaultChecksVoidReturnOpts()
 		}
 
-		// A syntactic check for whether an expression could possibly evaluate to a
-		// value with call signatures. Literals, templates, and array literals
-		// can never be callable, so `returnsThenable` is always false for them and
-		// the type queries guarding it can be skipped entirely.
-		// This is a perf optimization to help avoid requesting types where possible.
+		hasCallSignatures := func(node *ast.Node) bool {
+			t := checker.Checker_getApparentType(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(node))
+			return utils.Some(utils.UnionTypeParts(t), func(t *checker.Type) bool {
+				return len(utils.GetCallSignatures(ctx.TypeChecker, t)) != 0
+			})
+		}
+
+		// Every `voidReturn` report requires the reported expression to have call
+		// signatures, so expressions that can't have any are skipped before the type
+		// queries that gate the report are ever made.
+		//
+		// Whether a literal has call signatures is a property of its kind rather than
+		// of the node: the apparent type of every string literal is the global
+		// `String`, of every array literal an `Array<T>`, and so on. Those globals
+		// normally have no call signatures, but interface augmentation (e.g.
+		// `interface String { (): Promise<void> }`) can give them some, so the answer
+		// is sampled from the checker on first use and cached per kind instead of
+		// being assumed. That costs at most one type query per literal kind per file,
+		// in exchange for skipping the queries on every literal that follows.
+		callableByLiteralKind := make(map[ast.Kind]bool, 8)
+		isCallableLiteralKind := func(node *ast.Node) bool {
+			callable, cached := callableByLiteralKind[node.Kind]
+			if !cached {
+				callable = hasCallSignatures(node)
+				callableByLiteralKind[node.Kind] = callable
+			}
+			return callable
+		}
+
 		couldBeFunctionLikeValue := func(node *ast.Node) bool {
 			switch node.Kind {
 			case ast.KindStringLiteral,
@@ -134,15 +158,19 @@ var NoMisusedPromisesRule = rule.Rule{
 				ast.KindNullKeyword,
 				ast.KindRegularExpressionLiteral,
 				ast.KindArrayLiteralExpression:
-				return false
+				return isCallableLiteralKind(node)
 			case ast.KindObjectLiteralExpression:
 				// Spreading a generic value keeps its type (e.g. `{ ...t }` where
-				// `T extends () => Promise<void>` has type `T`), which can be
-				// callable, so only spread-free object literals are known to be
-				// never-callable.
-				return slices.ContainsFunc(node.AsObjectLiteralExpression().Properties.Nodes, func(property *ast.Node) bool {
+				// `T extends () => Promise<void>` has type `T`), which can be callable.
+				// A spread-free object literal can't declare a call signature, so the
+				// only ones it can have are inherited from the global `Object`, which
+				// the per-kind sample covers.
+				if slices.ContainsFunc(node.AsObjectLiteralExpression().Properties.Nodes, func(property *ast.Node) bool {
 					return property.Kind == ast.KindSpreadAssignment
-				})
+				}) {
+					return true
+				}
+				return isCallableLiteralKind(node)
 			default:
 				return true
 			}

--- a/internal/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/rules/no_misused_promises/no_misused_promises.go
@@ -117,8 +117,7 @@ var NoMisusedPromisesRule = rule.Rule{
 			checksVoidReturnOpts = defaultChecksVoidReturnOpts()
 		}
 
-		hasCallSignatures := func(node *ast.Node) bool {
-			t := checker.Checker_getApparentType(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(node))
+		typeHasCallSignatures := func(t *checker.Type) bool {
 			return utils.Some(utils.UnionTypeParts(t), func(t *checker.Type) bool {
 				return len(utils.GetCallSignatures(ctx.TypeChecker, t)) != 0
 			})
@@ -126,26 +125,15 @@ var NoMisusedPromisesRule = rule.Rule{
 
 		// Every `voidReturn` report requires the reported expression to have call
 		// signatures, so expressions that can't have any are skipped before the type
-		// queries that gate the report are ever made.
+		// queries gating the report are ever made.
 		//
-		// Whether a literal has call signatures is a property of its kind rather than
+		// For a literal, having call signatures is a property of its kind rather than
 		// of the node: the apparent type of every string literal is the global
 		// `String`, of every array literal an `Array<T>`, and so on. Those globals
-		// normally have no call signatures, but interface augmentation (e.g.
-		// `interface String { (): Promise<void> }`) can give them some, so the answer
-		// is sampled from the checker on first use and cached per kind instead of
-		// being assumed. That costs at most one type query per literal kind per file,
-		// in exchange for skipping the queries on every literal that follows.
+		// normally have none, but interface augmentation
+		// (`interface String { (): Promise<void> }`) can give them some, so the answer
+		// is sampled from the checker once per kind rather than assumed.
 		callableByLiteralKind := make(map[ast.Kind]bool, 8)
-		isCallableLiteralKind := func(node *ast.Node) bool {
-			callable, cached := callableByLiteralKind[node.Kind]
-			if !cached {
-				callable = hasCallSignatures(node)
-				callableByLiteralKind[node.Kind] = callable
-			}
-			return callable
-		}
-
 		couldBeFunctionLikeValue := func(node *ast.Node) bool {
 			switch node.Kind {
 			case ast.KindStringLiteral,
@@ -158,22 +146,26 @@ var NoMisusedPromisesRule = rule.Rule{
 				ast.KindNullKeyword,
 				ast.KindRegularExpressionLiteral,
 				ast.KindArrayLiteralExpression:
-				return isCallableLiteralKind(node)
 			case ast.KindObjectLiteralExpression:
 				// Spreading a generic value keeps its type (e.g. `{ ...t }` where
 				// `T extends () => Promise<void>` has type `T`), which can be callable.
-				// A spread-free object literal can't declare a call signature, so the
-				// only ones it can have are inherited from the global `Object`, which
-				// the per-kind sample covers.
-				if slices.ContainsFunc(node.AsObjectLiteralExpression().Properties.Nodes, func(property *ast.Node) bool {
-					return property.Kind == ast.KindSpreadAssignment
-				}) {
+				// A spread-free object literal declares no call signatures of its own,
+				// so the only ones it can have come from the global `Object`, which the
+				// per-kind sample below covers.
+				if utils.Some(node.AsObjectLiteralExpression().Properties.Nodes, ast.IsSpreadAssignment) {
 					return true
 				}
-				return isCallableLiteralKind(node)
 			default:
 				return true
 			}
+
+			callable, sampled := callableByLiteralKind[node.Kind]
+			if !sampled {
+				t := checker.Checker_getApparentType(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(node))
+				callable = typeHasCallSignatures(t)
+				callableByLiteralKind[node.Kind] = callable
+			}
+			return callable
 		}
 
 		anySignatureIsThenableType := func(
@@ -220,9 +212,7 @@ var NoMisusedPromisesRule = rule.Rule{
 			if t == nil {
 				return false
 			}
-			return utils.Some(utils.UnionTypeParts(t), func(t *checker.Type) bool {
-				return len(utils.GetCallSignatures(ctx.TypeChecker, t)) != 0
-			})
+			return typeHasCallSignatures(t)
 		}
 
 		// Variation on the thenable check which requires all forms of the type (read:
@@ -450,11 +440,7 @@ var NoMisusedPromisesRule = rule.Rule{
 		voidFunctionArguments := func(
 			node *ast.Expression,
 		) []int {
-			// 'new' can be used without any arguments, as in 'let b = new Object;'
-			// In this case, there are no argument positions to check, so return early.
-			if node.Arguments() == nil {
-				return []int{}
-			}
+			args := node.Arguments()
 			thenableReturnIndices := []int{}
 			voidReturnIndices := []int{}
 			t := ctx.TypeChecker.GetTypeAtLocation(node.Expression())
@@ -472,20 +458,24 @@ var NoMisusedPromisesRule = rule.Rule{
 				}
 				for _, signature := range signatures {
 					for index, parameter := range checker.Signature_parameters(signature) {
+						// Parameters are in declaration order, so once one has no argument
+						// at its position, neither does any that follows.
+						if index >= len(args) {
+							break
+						}
+
 						decl := parameter.ValueDeclaration
 						isRestParameter := decl != nil && utils.IsRestParameterDeclaration(decl)
 
-						// A parameter position can only produce a report if there is an
-						// argument at that position that could be a thenable-returning
-						// function, so skip resolving the parameter type otherwise.
-						if index >= len(node.Arguments()) {
-							continue
-						}
+						// A parameter position can only produce a report if an argument it
+						// covers could be a thenable-returning function, so skip resolving
+						// the parameter type otherwise. A rest parameter covers every
+						// remaining argument.
+						covered := args[index : index+1]
 						if isRestParameter {
-							if !slices.ContainsFunc(node.Arguments()[index:], couldBeFunctionLikeValue) {
-								continue
-							}
-						} else if !couldBeFunctionLikeValue(node.Arguments()[index]) {
+							covered = args[index:]
+						}
+						if !slices.ContainsFunc(covered, couldBeFunctionLikeValue) {
 							continue
 						}
 
@@ -499,8 +489,8 @@ var NoMisusedPromisesRule = rule.Rule{
 								// so that we'll handle it in the same way as a non-rest
 								// 'param: MaybeVoidFunction'
 								t = checker.Checker_getTypeArguments(ctx.TypeChecker, t)[0]
-								for i := index; i < len(node.Arguments()); i++ {
-									if !couldBeFunctionLikeValue(node.Arguments()[i]) {
+								for i := index; i < len(args); i++ {
+									if !couldBeFunctionLikeValue(args[i]) {
 										continue
 									}
 									checkThenableOrVoidArgument(
@@ -515,8 +505,8 @@ var NoMisusedPromisesRule = rule.Rule{
 								// Check each type in the tuple - for example, [boolean, () => void] would
 								// add the index of the second tuple parameter to 'voidReturnIndices'
 								typeArgs := checker.Checker_getTypeArguments(ctx.TypeChecker, t)
-								for i := index; i < len(node.Arguments()) && i-index < len(typeArgs); i++ {
-									if !couldBeFunctionLikeValue(node.Arguments()[i]) {
+								for i := index; i < len(args) && i-index < len(typeArgs); i++ {
+									if !couldBeFunctionLikeValue(args[i]) {
 										continue
 									}
 									checkThenableOrVoidArgument(

--- a/internal/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/rules/no_misused_promises/no_misused_promises.go
@@ -118,7 +118,7 @@ var NoMisusedPromisesRule = rule.Rule{
 		}
 
 		// A syntactic check for whether an expression could possibly evaluate to a
-		// value with call signatures. Literals, templates, and array/object literals
+		// value with call signatures. Literals, templates, and array literals
 		// can never be callable, so `returnsThenable` is always false for them and
 		// the type queries guarding it can be skipped entirely.
 		// This is a perf optimization to help avoid requesting types where possible.
@@ -133,9 +133,16 @@ var NoMisusedPromisesRule = rule.Rule{
 				ast.KindFalseKeyword,
 				ast.KindNullKeyword,
 				ast.KindRegularExpressionLiteral,
-				ast.KindArrayLiteralExpression,
-				ast.KindObjectLiteralExpression:
+				ast.KindArrayLiteralExpression:
 				return false
+			case ast.KindObjectLiteralExpression:
+				// Spreading a generic value keeps its type (e.g. `{ ...t }` where
+				// `T extends () => Promise<void>` has type `T`), which can be
+				// callable, so only spread-free object literals are known to be
+				// never-callable.
+				return slices.ContainsFunc(node.AsObjectLiteralExpression().Properties.Nodes, func(property *ast.Node) bool {
+					return property.Kind == ast.KindSpreadAssignment
+				})
 			default:
 				return true
 			}

--- a/internal/rules/no_misused_promises/no_misused_promises_test.go
+++ b/internal/rules/no_misused_promises/no_misused_promises_test.go
@@ -2708,5 +2708,67 @@ function f<T extends () => Promise<void>>(t: T) {
 				},
 			},
 		},
+		// Augmenting a global interface with a call signature makes literals of that
+		// kind callable, so they must still be checked.
+		{
+			Code: `
+interface String {
+  (): Promise<void>;
+}
+declare function takesCb(cb: () => void): void;
+takesCb('literal');
+takesCb(` + "`template`" + `);
+const cb: () => void = 'literal';
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "voidReturnArgument",
+					Line:      6,
+				},
+				{
+					MessageId: "voidReturnArgument",
+					Line:      7,
+				},
+				{
+					MessageId: "voidReturnVariable",
+					Line:      8,
+				},
+			},
+		},
+		{
+			Code: `
+interface Number {
+  (): Promise<void>;
+}
+declare function takesCb(cb: () => void): void;
+takesCb(123);
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "voidReturnArgument",
+					Line:      6,
+				},
+			},
+		},
+		{
+			Code: `
+interface Array<T> {
+  (): Promise<void>;
+}
+declare function takesCb(cb: () => void): void;
+takesCb([1, 2]);
+const cb: () => void = [1, 2];
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "voidReturnArgument",
+					Line:      6,
+				},
+				{
+					MessageId: "voidReturnVariable",
+					Line:      7,
+				},
+			},
+		},
 	})
 }

--- a/internal/rules/no_misused_promises/no_misused_promises_test.go
+++ b/internal/rules/no_misused_promises/no_misused_promises_test.go
@@ -2681,5 +2681,32 @@ const obj: O = {
 				},
 			},
 		},
+		{
+			Code: `
+declare function takesCb(cb: () => void): void;
+function f<T extends () => Promise<void>>(t: T) {
+  takesCb({ ...t });
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "voidReturnArgument",
+					Line:      4,
+				},
+			},
+		},
+		{
+			Code: `
+function f<T extends () => Promise<void>>(t: T) {
+  const cb: () => void = { ...t };
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "voidReturnVariable",
+					Line:      3,
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
Revives #1065, which was closed because the syntactic guard traded correctness for speed. This version keeps the speed without the false negatives.

## The problem with the original

The guard assumed literals can never be callable, so `returnsThenable` must be false for them and the type queries gating a `voidReturn` report could be skipped. That is true right up until a global interface is augmented with a call signature:

```ts
interface String {
  (): Promise<void>;
}
declare function takesCb(cb: () => void): void;
takesCb('literal'); // apparent type is String, which now has a thenable-returning call signature
```

As [noted on the original PR](https://github.com/oxc-project/tsgolint/pull/1065#issuecomment-4934415570), missing diagnostics is the wrong side to err on, and #1068 was reverted for the same reason.

## The fix

Whether a literal has call signatures is a property of its *kind*, not of the node: the apparent type of every string literal is the global `String`, of every array literal an `Array<T>`, of every numeric literal `Number`, and so on. So instead of assuming those globals have no call signatures, the rule asks the checker once per literal kind and caches the answer for the rest of the file. If a program augments `String`, every string literal in it is checked as before.

That costs at most one type query per literal kind per file (~7 in the worst case), in exchange for skipping the queries on every literal that follows. Object literals with spreads are still treated as possibly-callable, as in the original PR (`{ ...t }` where `T extends () => Promise<void>` has type `T`).

## Correctness

On a fixture that augments `String`, `Number`, `Boolean`, `Array`, `Object`, and `RegExp` with `(): Promise<void>`:

| | no-misused-promises diagnostics |
|---|---|
| `main` (no guard) | 9 |
| #1065 as merged | **1** (8 missed) |
| this PR | 9 |

Regression tests cover the augmented `String`, `Number`, and `Array` cases, alongside the existing spread tests.

Full-corpus parity on VS Code: 234,462 diagnostics compared as `(rule, file, line, col)` keys, **0 differing keys** against `main`, and the rule's call count is unchanged at 1,774,662.

## Measurement

VS Code 1.99.0 (`src/tsconfig.json`, 4,550 files, `--debug timings`). No `node_modules` in this environment, so `types`/`plugins` were emptied in that tsconfig; every binary lints the identical program, so the A/B holds. `main` here is the current `main` with no guard at all.

All rules enabled — `no-misused-promises` rule time, mean of 6 runs:

| | rule time | vs main |
|---|---|---|
| `main` | 3109 ms | — |
| **this PR** | **2556 ms** | **−17.8%** |
| #1065 as merged (incorrect) | 2592 ms | −16.6% |

Single-rule config (headless, only `no-misused-promises`), mean of 3 runs:

| | rule time | vs main |
|---|---|---|
| `main` | 6816 ms | — |
| **this PR** | **6326 ms** | **−7.2%** |
| #1065 as merged (incorrect) | 6463 ms | −5.2% |

The per-kind sampling costs nothing measurable against the queries it avoids, so this lands slightly ahead of the original (incorrect) version on both configurations — the guard also now stops walking parameters once they run past the last argument, which the original kept doing.

If this approach looks right, #1068 (`strict-void-return`, reverted in #1071) can be revived the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
