### PR TITLE
refactor: drop dead isFunction guards built on a bitwise ast.Kind mask

### DIFF
--- a/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -1955,12 +1955,10 @@ func normalizeAllowConstantLoopConditions(value any) string {
 // Used for array methods like:
 // - [1, 2, 3].filter(() => true) // always truthy, returns all elements
 // - [1, 2, 3].find(() => false)  // always falsy, returns undefined
+//
+// funcNode is the predicate argument, which need not be an inline function: a
+// reference to one (`[1, 2].filter(pred)`) is analyzed through its call signatures.
 func checkPredicateFunction(ctx rule.RuleContext, funcNode *ast.Node, checkTypeGuards bool) {
-	isFunction := funcNode.Kind&(ast.KindArrowFunction|ast.KindFunctionExpression|ast.KindFunctionDeclaration) != 0
-	if !isFunction {
-		return
-	}
-
 	funcType := ctx.TypeChecker.GetTypeAtLocation(funcNode)
 	signatures := ctx.TypeChecker.GetCallSignatures(funcType)
 

--- a/internal/rules/strict_boolean_expressions/strict_boolean_expressions.go
+++ b/internal/rules/strict_boolean_expressions/strict_boolean_expressions.go
@@ -157,8 +157,7 @@ var StrictBooleanExpressionsRule = rule.Rule{
 						if arg == nil {
 							return
 						}
-						isFunction := arg.Kind&(ast.KindArrowFunction|ast.KindFunctionExpression|ast.KindFunctionDeclaration) != 0
-						if isFunction && ast.GetFunctionFlags(arg)&ast.FunctionFlagsAsync != 0 {
+						if ast.GetFunctionFlags(arg)&ast.FunctionFlagsAsync != 0 {
 							ctx.ReportNode(arg, buildPredicateCannotBeAsyncMessage())
 							return
 						}


### PR DESCRIPTION
## Summary

`no-unnecessary-condition` and `strict-boolean-expressions` each gated a predicate argument with the same expression:

```go
arg.Kind&(ast.KindArrowFunction|ast.KindFunctionExpression|ast.KindFunctionDeclaration) != 0
```

`ast.Kind` is a sequential enum, not a bit set. The three kinds are `220`, `219` and `263`, so the OR-mask is `479`, and `kind & 479 != 0` holds for **346 of the 351** kinds. The only kinds the guards actually rejected were `KindUnknown` and `KindLessThanEqualsToken`, neither of which can reach these call sites — so in practice both guards were dead code that always fell through.

## Why remove rather than fix

Rewriting them as real kind tests (`ast.IsArrowFunction(n) || ...`) looks like the obvious fix, but it changes behavior and fails an existing test:

```ts
declare const test: <T extends true>() => T;

[1, null].filter(test);
//               ~~~~ This callback should return a conditional, but return is always truthy.
```

`no-unnecessary-condition` is *expected* to report a predicate passed by reference, not just an inline function literal. The rule analyzes the argument through its call signatures, so a reference to a predicate is handled exactly like an inline one, and a non-callable argument simply has no call signatures and reports nothing. A real kind check would silently drop these true positives.

`strict-boolean-expressions` only used the flag to guard `ast.GetFunctionFlags`, which already returns `FunctionFlagsInvalid` for any node without body data — so the async-predicate check is unchanged for every kind.

## Test plan

No behavior change; the existing tests pass unmodified.

- [x] `go test ./internal/rules/no_unnecessary_condition/`
- [x] `go test ./internal/rules/strict_boolean_expressions/`
- [x] `go test ./...`
- [x] `gofmt` clean
### Differential check on real codebases

Built the linter from `main` and from this branch, ran all rules over the corpora below, and compared every diagnostic — rule, file, line/column, exact source range, and the full autofix/suggestion text (not just counts, so a changed fixer would surface). Output is **byte-for-byte identical** on both binaries:

| Corpus | Files | Diagnostics | `main` vs this branch |
| --- | --- | --- | --- |
| `microsoft/vscode` (`src/`) | 7,325 | 201,348 | identical |
| `actualbudget/actual` (`desktop-client`, TSX) | 742 | 16,602 | identical |
| `actualbudget/actual` (`component-library`, TSX) | 427 | 545 | identical |

The vscode count excludes `no-unsafe-type-assertion`, which is nondeterministic across runs independently of this change. Every other rule matched exactly.


🤖 Generated with [Claude Code](https://claude.com/claude-code)