### PR TITLE
refactor: remove dead code from rules

### DIFF
--- a/internal/rules/consistent_type_exports/consistent_type_exports.go
+++ b/internal/rules/consistent_type_exports/consistent_type_exports.go
@@ -166,9 +166,6 @@ var ConsistentTypeExportsRule = rule.Rule{
 			if exportDecl.IsTypeOnly || exportDecl.ModuleSpecifier == nil {
 				return
 			}
-			if exportDecl.ExportClause != nil && !ast.IsNamespaceExport(exportDecl.ExportClause.AsNode()) {
-				return
-			}
 
 			moduleSymbol := ctx.TypeChecker.GetSymbolAtLocation(exportDecl.ModuleSpecifier.AsNode())
 			if moduleSymbol == nil {
@@ -215,9 +212,6 @@ var ConsistentTypeExportsRule = rule.Rule{
 
 		analyzeNamedExport := func(node *ast.Node) *analyzedNamedExport {
 			exportDecl := node.AsExportDeclaration()
-			if exportDecl.ExportClause == nil || !ast.IsNamedExports(exportDecl.ExportClause.AsNode()) {
-				return nil
-			}
 			if exportDecl.IsTypeOnly {
 				return nil
 			}

--- a/internal/rules/no_array_delete/no_array_delete.go
+++ b/internal/rules/no_array_delete/no_array_delete.go
@@ -48,9 +48,6 @@ var NoArrayDeleteRule = rule.Rule{
 
 		return rule.RuleListeners{
 			ast.KindDeleteExpression: func(node *ast.Node) {
-				if node.Kind != ast.KindDeleteExpression {
-					return
-				}
 				deleteExpression := ast.SkipParentheses(node.AsDeleteExpression().Expression)
 
 				if !ast.IsElementAccessExpression(deleteExpression) {

--- a/internal/rules/no_deprecated/no_deprecated.go
+++ b/internal/rules/no_deprecated/no_deprecated.go
@@ -164,10 +164,6 @@ var NoDeprecatedRule = rule.Rule{
 					return true, reason
 				}
 
-				if symbol.Flags&ast.SymbolFlagsAlias == 0 {
-					break
-				}
-
 				if checker.Checker_getDeclarationOfAliasSymbol(ctx.TypeChecker, symbol) == nil {
 					break
 				}

--- a/internal/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/rules/no_misused_promises/no_misused_promises.go
@@ -595,9 +595,6 @@ var NoMisusedPromisesRule = rule.Rule{
 				)
 
 				if isVoidReturningFunctionType(node.Name(), contextualType) {
-					if ast.IsMethodDeclaration(node) {
-					}
-
 					if node.Type() != nil {
 						ctx.ReportNode(node.Type(), buildVoidReturnPropertyMessage())
 					} else {

--- a/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -1183,25 +1183,6 @@ var NoUnnecessaryConditionRule = rule.Rule{
 							return
 						}
 					}
-				} else if isPropertyAccess(expression) || isElementAccess(expression) {
-					// Handle property/element access on call expression result
-					// e.g., foo?.().bar?.baz or foo?.bar?.().baz
-					var innerExpr *ast.Node
-					if isPropertyAccess(expression) {
-						innerExpr = expression.AsPropertyAccessExpression().Expression
-					} else {
-						innerExpr = expression.AsElementAccessExpression().Expression
-					}
-
-					// Check if the inner expression is a call expression
-					if innerExpr != nil && isCallExpr(innerExpr) {
-						exprType = getTypeFromCallProperty(innerExpr, expression)
-						if exprType == nil {
-							return
-						}
-					} else {
-						exprType = getResolvedType(expression)
-					}
 				} else {
 					exprType = getResolvedType(expression)
 				}

--- a/internal/rules/no_unsafe_enum_comparison/suggestion.go
+++ b/internal/rules/no_unsafe_enum_comparison/suggestion.go
@@ -63,9 +63,6 @@ func enumMemberSuffixText(sourceFile *ast.SourceFile, member *ast.Node) string {
 
 func isQualifiedIdentifierText(value string) bool {
 	parts := strings.Split(value, ".")
-	if len(parts) == 0 {
-		return false
-	}
 	for _, part := range parts {
 		if !scanner.IsIdentifierText(part, core.LanguageVariantStandard) {
 			return false

--- a/internal/rules/only_throw_error/only_throw_error.go
+++ b/internal/rules/only_throw_error/only_throw_error.go
@@ -89,18 +89,16 @@ func isRethrownError(ctx rule.RuleContext, node *ast.Node) bool {
 
 	if methodName == "catch" {
 		// .catch(onRejected)
-		// First argument must be our arrow function and not preceded by spread
-		if len(args) >= 1 && args[0] == funcNode && !ast.IsSpreadElement(args[0]) {
+		// First argument must be our arrow function
+		if len(args) >= 1 && args[0] == funcNode {
 			isRejectionHandler = true
 		}
 	} else if methodName == "then" {
 		// .then(onFulfilled, onRejected)
-		// Second argument must be our arrow function
-		// Also check that neither first nor second argument is a spread element
-		if len(args) >= 2 && args[1] == funcNode {
-			if !ast.IsSpreadElement(args[0]) && !ast.IsSpreadElement(args[1]) {
-				isRejectionHandler = true
-			}
+		// Second argument must be our arrow function, and onFulfilled must not be
+		// a spread element (which would shift the argument positions).
+		if len(args) >= 2 && args[1] == funcNode && !ast.IsSpreadElement(args[0]) {
+			isRejectionHandler = true
 		}
 	}
 

--- a/internal/rules/prefer_includes/prefer_includes.go
+++ b/internal/rules/prefer_includes/prefer_includes.go
@@ -228,7 +228,7 @@ var PreferIncludesRule = rule.Rule{
 		// Verifies that for every indexOf declaration, there exists an includes
 		// declaration on the same type with matching parameters
 		indexOfHasCompatibleIncludes := func(indexOfSymbol *ast.Symbol) bool {
-			if indexOfSymbol == nil || indexOfSymbol.Declarations == nil || len(indexOfSymbol.Declarations) == 0 {
+			if indexOfSymbol == nil || len(indexOfSymbol.Declarations) == 0 {
 				return false
 			}
 
@@ -324,10 +324,6 @@ var PreferIncludesRule = rule.Rule{
 		return rule.RuleListeners{
 			// Handle: /regex/.test(str) -> str.includes('literal')
 			ast.KindCallExpression: func(node *ast.Node) {
-				if node.Kind != ast.KindCallExpression {
-					return
-				}
-
 				callExpr := node.AsCallExpression()
 
 				// Check if it's a member access (e.g., /regex/.test or pattern.test)
@@ -375,14 +371,12 @@ var PreferIncludesRule = rule.Rule{
 				// Member access (.) has high precedence, so we only need parens for expressions
 				// that would parse incorrectly, like: a + b.includes() vs (a + b).includes()
 				// Safe types: literals, identifiers, member/element access, calls, already-parenthesized
-				needsParens := false
+				needsParens := true
 				switch argument.Kind {
 				case ast.KindIdentifier, ast.KindStringLiteral, ast.KindNumericLiteral,
 					ast.KindNoSubstitutionTemplateLiteral, ast.KindPropertyAccessExpression,
 					ast.KindCallExpression, ast.KindElementAccessExpression, ast.KindParenthesizedExpression:
 					needsParens = false
-				default:
-					needsParens = true
 				}
 
 				// Use TrimNodeTextRange to preserve leading whitespace
@@ -417,10 +411,6 @@ var PreferIncludesRule = rule.Rule{
 			},
 			// Handle: array.indexOf(item) !== -1 -> array.includes(item)
 			ast.KindBinaryExpression: func(node *ast.Node) {
-				if node.Kind != ast.KindBinaryExpression {
-					return
-				}
-
 				binaryExpr := node.AsBinaryExpression()
 				left := binaryExpr.Left
 

--- a/internal/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.go
+++ b/internal/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.go
@@ -103,16 +103,6 @@ func isNodeEqual(a, b *ast.Node) bool {
 	case ast.KindElementAccessExpression:
 		aElem := a.AsElementAccessExpression()
 		bElem := b.AsElementAccessExpression()
-		if aElem.ArgumentExpression == nil || bElem.ArgumentExpression == nil {
-			if aElem.ArgumentExpression != bElem.ArgumentExpression {
-				return false
-			}
-		}
-		if aElem.Expression == nil || bElem.Expression == nil {
-			if aElem.Expression != bElem.Expression {
-				return false
-			}
-		}
 		return isNodeEqual(aElem.ArgumentExpression, bElem.ArgumentExpression) && isNodeEqual(aElem.Expression, bElem.Expression)
 	case ast.KindNullKeyword:
 		return true

--- a/internal/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -840,19 +840,6 @@ func (processor *chainProcessor) extractCallSignatures(node *ast.Node) map[strin
 	return signatures
 }
 
-func (processor *chainProcessor) validateChainRoot(node *ast.Node, operatorKind ast.Kind) (*ast.BinaryExpression, bool) {
-	binExpr := node.AsBinaryExpression()
-	if binExpr.OperatorToken.Kind != operatorKind {
-		return nil, false
-	}
-
-	if isInsideJSX(node) {
-		return nil, false
-	}
-
-	return binExpr, true
-}
-
 func (processor *chainProcessor) isChainAlreadySeen(node *ast.Node) bool {
 	r := processor.getNodeRange(node)
 	return processor.seenRanges[textRange{start: r.Pos(), end: r.End()}]
@@ -1583,12 +1570,11 @@ outer3:
 		}
 	}
 
-	if isAndChain && ast.IsBinaryExpression(unwrapped) {
+	if ast.IsBinaryExpression(unwrapped) {
 		binExpr := unwrapped.AsBinaryExpression()
-		op := binExpr.OperatorToken.Kind
 
 		// Relational operators (<, >, <=, >=, in, instanceof) should not participate in optional chaining.
-		switch op {
+		switch binExpr.OperatorToken.Kind {
 		case ast.KindLessThanToken,
 			ast.KindGreaterThanToken,
 			ast.KindLessThanEqualsToken,
@@ -1618,74 +1604,14 @@ outer3:
 			hasPropertyAccess = true
 		}
 
-		if !hasPropertyAccess {
-			return Operand{typ: OperandTypeInvalid, node: node}
-		}
-
-		return Operand{typ: OperandTypeComparison, node: node, comparedExpr: comparedExpr}
-	}
-
-	if !isAndChain && ast.IsBinaryExpression(unwrapped) {
-		binExpr := unwrapped.AsBinaryExpression()
-		op := binExpr.OperatorToken.Kind
-
-		// Relational operators (<, >, <=, >=, in, instanceof) should not participate in optional chaining.
-		switch op {
-		case ast.KindLessThanToken,
-			ast.KindGreaterThanToken,
-			ast.KindLessThanEqualsToken,
-			ast.KindGreaterThanEqualsToken,
-			ast.KindInKeyword,
-			ast.KindInstanceOfKeyword:
-			return Operand{typ: OperandTypeInvalid, node: node}
-		}
-
-		left := ast.SkipParentheses(binExpr.Left)
-		right := ast.SkipParentheses(binExpr.Right)
-		leftIsAccess := utils.IsAccessExpression(left)
-		rightIsAccess := utils.IsAccessExpression(right)
-
-		// If both sides are access expressions, we can't convert to optional
-		// chaining without changing when the other side is evaluated.
-		if leftIsAccess && rightIsAccess {
-			return Operand{typ: OperandTypeInvalid, node: node}
-		}
-
-		comparedExpr := left
-		hasPropertyAccess := leftIsAccess
-		if rightIsAccess {
-			comparedExpr = right
-			hasPropertyAccess = true
-		}
-		// OR chains can only safely extend through comparisons that actually inspect
+		// Chains can only safely extend through comparisons that actually inspect
 		// an access expression. Non-nullish identifier comparisons like `b === a`
 		// should not seed an optional-chain candidate such as `b === a || b.foo()`.
 		if !hasPropertyAccess {
 			return Operand{typ: OperandTypeInvalid, node: node}
 		}
+
 		return Operand{typ: OperandTypeComparison, node: node, comparedExpr: comparedExpr}
-	}
-
-	if isAndChain {
-		if ast.IsBinaryExpression(unwrapped) {
-			binExpr := unwrapped.AsBinaryExpression()
-			op := binExpr.OperatorToken.Kind
-
-			isComparison := op == ast.KindEqualsEqualsToken ||
-				op == ast.KindExclamationEqualsToken ||
-				op == ast.KindEqualsEqualsEqualsToken ||
-				op == ast.KindExclamationEqualsEqualsToken ||
-				op == ast.KindLessThanToken ||
-				op == ast.KindGreaterThanToken ||
-				op == ast.KindLessThanEqualsToken ||
-				op == ast.KindGreaterThanEqualsToken
-
-			if isComparison {
-				return Operand{typ: OperandTypeInvalid, node: node}
-			}
-		}
-
-		return Operand{typ: OperandTypePlain, node: node, comparedExpr: unwrapped}
 	}
 
 	return Operand{typ: OperandTypePlain, node: node, comparedExpr: unwrapped}
@@ -1794,8 +1720,7 @@ func (processor *chainProcessor) processChain(node *ast.Node, operatorKind ast.K
 		return
 	}
 
-	_, ok := processor.validateChainRoot(node, operatorKind)
-	if !ok {
+	if isInsideJSX(node) {
 		return
 	}
 
@@ -3689,11 +3614,6 @@ func (processor *chainProcessor) generateOrChainFixAndReport(node *ast.Node, cha
 
 func (processor *chainProcessor) handleEmptyObjectPattern(node *ast.Node) {
 	binExpr := node.AsBinaryExpression()
-	operator := binExpr.OperatorToken.Kind
-
-	if operator != ast.KindBarBarToken && operator != ast.KindQuestionQuestionToken {
-		return
-	}
 
 	rightNode := binExpr.Right
 	var objLit *ast.ObjectLiteralExpression

--- a/internal/rules/prefer_readonly_parameter_types/prefer_readonly_parameter_types.go
+++ b/internal/rules/prefer_readonly_parameter_types/prefer_readonly_parameter_types.go
@@ -138,43 +138,41 @@ func isTypeReadonlyObject(
 	seenTypes map[*checker.Type]struct{},
 ) readonlyness {
 	properties := checker.Checker_getPropertiesOfType(typeChecker, t)
-	if len(properties) > 0 {
-		for _, property := range properties {
-			if opts.treatMethodsAsReadonly && property.Flags&ast.SymbolFlagsMethod != 0 {
-				continue
-			}
-
-			if propertyIsReadonly(typeChecker, property) {
-				continue
-			}
-
-			if propertyHasPrivateIdentifierName(property) {
-				continue
-			}
-			return readonlynessMutable
+	for _, property := range properties {
+		if opts.treatMethodsAsReadonly && property.Flags&ast.SymbolFlagsMethod != 0 {
+			continue
 		}
 
-		for _, property := range properties {
-			if property.Flags&ast.SymbolFlagsMethod != 0 {
-				continue
-			}
+		if propertyIsReadonly(typeChecker, property) {
+			continue
+		}
 
-			propertyType := checker.Checker_getTypeOfPropertyOfType(typeChecker, t, property.Name)
-			if propertyType == nil {
-				propertyType = checker.Checker_getTypeOfSymbol(typeChecker, property)
-			}
+		if propertyHasPrivateIdentifierName(property) {
+			continue
+		}
+		return readonlynessMutable
+	}
 
-			if propertyType == nil {
-				continue
-			}
+	for _, property := range properties {
+		if property.Flags&ast.SymbolFlagsMethod != 0 {
+			continue
+		}
 
-			if _, ok := seenTypes[propertyType]; ok {
-				continue
-			}
+		propertyType := checker.Checker_getTypeOfPropertyOfType(typeChecker, t, property.Name)
+		if propertyType == nil {
+			propertyType = checker.Checker_getTypeOfSymbol(typeChecker, property)
+		}
 
-			if isTypeReadonlyRecurser(program, typeChecker, propertyType, opts, seenTypes) == readonlynessMutable {
-				return readonlynessMutable
-			}
+		if propertyType == nil {
+			continue
+		}
+
+		if _, ok := seenTypes[propertyType]; ok {
+			continue
+		}
+
+		if isTypeReadonlyRecurser(program, typeChecker, propertyType, opts, seenTypes) == readonlynessMutable {
+			return readonlynessMutable
 		}
 	}
 


### PR DESCRIPTION
## Summary

Happy to split this into smaller PRs if preferred, most of the changes are straightforward dead code removal.

Removes code across 11 rules that is unreachable or has no effect. Each item was verified against its call sites before removal — no behavior change, and the existing tests pass unmodified.

Independent of #1078 (no shared hunks); the two can merge in either order.

## What's removed

**prefer-optional-chain** (−90 lines)
- `operandFromNode` had two binary-expression blocks guarded by `isAndChain` and `!isAndChain` whose bodies were token-for-token identical and never read `isAndChain`. Merged them. Because every path in the merged block returns, the `isAndChain` block that followed could never see a binary expression, so it collapsed into the plain-operand return.
- `validateChainRoot` compared the node's operator against the operator its only caller had just read off that same node, and its returned `*ast.BinaryExpression` was discarded. Reduced to the `isInsideJSX` check it actually performs.
- `handleEmptyObjectPattern` re-tested the `||` / `??` operator its only caller already dispatches on.

**no-unnecessary-condition**
- An `else if isPropertyAccess || isElementAccess` nested inside the `else` of an outer chain that had already excluded exactly those kinds — a duplicated branch that could never run.

**consistent-type-exports**
- `checkStarExport` and `analyzeNamedExport` each re-tested the exact negation of the condition the listener dispatches on.

**only-throw-error**
- Checked whether the arrow function it had already proven via `ast.IsArrowFunction` was a spread element. The spread check on the `.then()` `onFulfilled` argument is real and is kept.

**no-deprecated**
- A `break` on the alias flag that the enclosing loop condition already asserts, with no reassignment in between.

**prefer-nullish-coalescing**
- Nil-guards around `isNodeEqual` that duplicate its own `a == nil || b == nil` first line.

**prefer-readonly-parameter-types**
- A `len(properties) > 0` wrapper around nothing but two `range` loops.

**no-unsafe-enum-comparison**
- `len(strings.Split(...)) == 0`, which never holds.

**no-array-delete**, **prefer-includes**
- `if node.Kind != ast.KindX` guards inside listeners keyed on that same kind.

**no-misused-promises**
- An empty `if ast.IsMethodDeclaration(node) {}` body inside a branch where it is already true.

`prefer-includes` also had a `needsParens` switch whose first case re-assigned the zero value. Note this one is *not* a pure deletion: dropping the case list would have made `needsParens` unconditionally true, so the initializer is inverted instead and the kind list is what carries the meaning.

## Test plan

- [x] `go test ./...`
- [x] `go vet ./internal/rules/...`
- [x] `gofmt` clean
### Differential check on real codebases

Built the linter from `main` and from this branch, ran all rules over the corpora below, and compared every diagnostic — rule, file, line/column, exact source range, and the full autofix/suggestion text (not just counts, so a changed fixer would surface). Output is **byte-for-byte identical** on both binaries:

| Corpus | Files | Diagnostics | `main` vs this branch |
| --- | --- | --- | --- |
| `microsoft/vscode` (`src/`) | 7,325 | 201,348 | identical |
| `actualbudget/actual` (`desktop-client`, TSX) | 742 | 16,602 | identical |
| `actualbudget/actual` (`component-library`, TSX) | 427 | 545 | identical |

The vscode count excludes `no-unsafe-type-assertion`, which is nondeterministic across runs independently of this change. Every other rule matched exactly.

The TSX corpora are included because `prefer-optional-chain`'s `validateChainRoot` change turns on `isInsideJSX`, and vscode's `src/` is essentially JSX-free. `prefer-optional-chain` fires 84 times in `desktop-client`, so that path is genuinely exercised.


🤖 Generated with [Claude Code](https://claude.com/claude-code)