### PR TITLE
refactor(no-deprecated): remove redundant alias flag check

### DIFF
--- a/internal/rules/no_deprecated/no_deprecated.go
+++ b/internal/rules/no_deprecated/no_deprecated.go
@@ -164,10 +164,6 @@ var NoDeprecatedRule = rule.Rule{
 					return true, reason
 				}
 
-				if symbol.Flags&ast.SymbolFlagsAlias == 0 {
-					break
-				}
-
 				if checker.Checker_getDeclarationOfAliasSymbol(ctx.TypeChecker, symbol) == nil {
 					break
 				}


### PR DESCRIPTION
## Summary

- remove an alias-flag check already guaranteed by the enclosing loop condition
- preserve alias-chain traversal behavior
