### PR TITLE
fix(no-unnecessary-type-assertion): avoid recursive unknown checks

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-type-assertion.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-type-assertion.snap
@@ -1638,3 +1638,18 @@ Message: This assertion is unnecessary since the receiver accepts the original t
      |                          ~~~~~~~~~~~~~~~~~~~~
    2 | void x;
 ---
+
+[TestNoUnnecessaryTypeAssertion/invalid-121 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:9 - 3:21)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | declare function consume(value: unknown): void;
+   3 | consume(42 as unknown);
+     |         ~~~~~~~~~~~~~
+   4 | const value: unknown = 42 as unknown;
+
+Diagnostic 2: contextuallyUnnecessary (4:24 - 4:36)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   3 | consume(42 as unknown);
+   4 | const value: unknown = 42 as unknown;
+     |                        ~~~~~~~~~~~~~
+---

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -177,42 +177,56 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			return checker.Checker_getTypeArguments(ctx.TypeChecker, t)
 		}
 
-		var typeContains func(t *checker.Type, predicate func(*checker.Type) bool, seen map[*checker.Type]struct{}) bool
-		typeContains = func(t *checker.Type, predicate func(*checker.Type) bool, seen map[*checker.Type]struct{}) bool {
+		var typeContains func(t *checker.Type, predicate func(*checker.Type) bool, seenTypes map[*checker.Type]struct{}, activeSignatures map[*checker.Signature]struct{}) bool
+		typeContains = func(t *checker.Type, predicate func(*checker.Type) bool, seenTypes map[*checker.Type]struct{}, activeSignatures map[*checker.Signature]struct{}) bool {
 			if t == nil {
 				return false
 			}
-			if _, ok := seen[t]; ok {
+			if _, ok := seenTypes[t]; ok {
 				return false
 			}
-			seen[t] = struct{}{}
+			seenTypes[t] = struct{}{}
 			if predicate(t) {
 				return true
 			}
 			for _, part := range utils.UnionTypeParts(t) {
-				if part != t && typeContains(part, predicate, seen) {
+				if part != t && typeContains(part, predicate, seenTypes, activeSignatures) {
 					return true
 				}
 			}
 			for _, part := range utils.IntersectionTypeParts(t) {
-				if part != t && typeContains(part, predicate, seen) {
+				if part != t && typeContains(part, predicate, seenTypes, activeSignatures) {
 					return true
 				}
 			}
 			for _, typeArgument := range getTypeArguments(t) {
-				if typeContains(typeArgument, predicate, seen) {
+				if typeContains(typeArgument, predicate, seenTypes, activeSignatures) {
 					return true
 				}
 			}
 			for _, sig := range utils.GetCallSignatures(ctx.TypeChecker, t) {
-				if typeContains(checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, sig), predicate, seen) {
+				// Generic signature instantiations can produce fresh recursive return
+				// types. If their shared original target is already active,
+				// conservatively assume the predicate could occur in the unseen cycle
+				// instead of making an unsafe autofix.
+				signatureIdentity := sig
+				for signatureIdentity.Target() != nil {
+					signatureIdentity = signatureIdentity.Target()
+				}
+				if _, ok := activeSignatures[signatureIdentity]; ok {
 					return true
 				}
+				activeSignatures[signatureIdentity] = struct{}{}
+
 				for _, param := range checker.Signature_parameters(sig) {
-					if typeContains(checker.Checker_getTypeOfSymbol(ctx.TypeChecker, param), predicate, seen) {
+					if typeContains(checker.Checker_getTypeOfSymbol(ctx.TypeChecker, param), predicate, seenTypes, activeSignatures) {
 						return true
 					}
 				}
+				if typeContains(checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, sig), predicate, seenTypes, activeSignatures) {
+					return true
+				}
+				delete(activeSignatures, signatureIdentity)
 			}
 			return false
 		}
@@ -220,13 +234,13 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 		containsAny := func(t *checker.Type) bool {
 			return typeContains(t, func(part *checker.Type) bool {
 				return utils.IsTypeFlagSet(part, checker.TypeFlagsAny)
-			}, map[*checker.Type]struct{}{})
+			}, map[*checker.Type]struct{}{}, map[*checker.Signature]struct{}{})
 		}
 
 		containsTypeVariable := func(t *checker.Type) bool {
 			return typeContains(t, func(part *checker.Type) bool {
 				return utils.IsTypeFlagSet(part, checker.TypeFlagsTypeVariable|checker.TypeFlagsIndex)
-			}, map[*checker.Type]struct{}{})
+			}, map[*checker.Type]struct{}{}, map[*checker.Signature]struct{}{})
 		}
 
 		hasIndexSignature := func(t *checker.Type) bool {

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
@@ -1094,6 +1094,25 @@ fn((null) as string | null);
 const value: undefined = (() => {})() as undefined;
     `,
 		},
+		{Code: `
+type RecursiveConditional<T> =
+  (value: T extends string ? any : number) => RecursiveConditional<string>;
+
+declare const callable: RecursiveConditional<number>;
+declare function consume(value: unknown): void;
+consume(callable as unknown);
+    `},
+		{Code: `
+type RecursiveCallable<Options = {}> =
+  & (<NewOptions = {}>(options: NewOptions) => RecursiveCallable<Options & NewOptions>)
+  & ((command: string) => void);
+
+declare const callable: RecursiveCallable;
+const value = callable as unknown;
+const contextualValue: unknown = callable as unknown;
+declare function consume(value: unknown): void;
+consume(callable as unknown);
+    `},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code:   "const foo = <3>3;",
@@ -3231,5 +3250,20 @@ fn((() => {})());`},
 					MessageId: "contextuallyUnnecessary",
 				},
 			},
-		}})
+		},
+		{
+			Code: `
+declare function consume(value: unknown): void;
+consume(42 as unknown);
+const value: unknown = 42 as unknown;`,
+			Output: []string{`
+declare function consume(value: unknown): void;
+consume(42);
+const value: unknown = 42;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "contextuallyUnnecessary"},
+				{MessageId: "contextuallyUnnecessary"},
+			},
+		},
+	})
 }


### PR DESCRIPTION
## Summary

- short-circuit assertions from a non-`unknown` type to `unknown` before recursively inspecting nested callable signatures
- cover the generic self-returning callable shape used by Execa with a reduced regression case

The recursive type walk can otherwise keep expanding freshly instantiated return types such as `ExecaMethod<Options & NewOptions>`, causing lint runs to hang.

Fixes #1085