### PR TITLE
fix(utils): resolve relative paths before ComputeConfigFileName to avoid vfs panic

### DIFF
--- a/internal/utils/find_tsconfig.go
+++ b/internal/utils/find_tsconfig.go
@@ -33,20 +33,44 @@ func NewTsConfigResolver(fs vfs.FS, currentDirectory string) *TsConfigResolver {
 	}
 }
 
+// toAbsolute resolves fileName against currentDirectory if it isn't already an
+// absolute (rooted) path. Unlike tspath.GetNormalizedAbsolutePath, this keeps
+// the platform's native path separators intact (filepath.Join on Windows keeps
+// `\`) instead of normalizing to `/` — ComputeConfigFileName's ancestor walk
+// only needs an absolute path, not a particular separator style, and callers
+// elsewhere in this package/its tests compare returned config paths against
+// filepath.Join-built strings, so switching separator style would just move
+// the bug from "panics on relative paths" to "returns paths in an unexpected
+// style" for existing consumers.
+func toAbsolute(fileName string, currentDirectory string) string {
+	if tspath.IsRootedDiskPath(fileName) {
+		return fileName
+	}
+	return filepath.Join(currentDirectory, fileName)
+}
+
 // Finds the tsconfig.json that governs the given file
 // Reference: `findOrCreateDefaultConfiguredProjectForOpenScriptInfo` typescript-go/internal/project/projectcollectionbuilder.go:629-671
 func (r *TsConfigResolver) FindTsconfigForFile(filePath string, skipSearchInDirectoryOfFile bool) (configPath string, found bool) {
-	configFileName := r.configFileRegistryBuilder.ComputeConfigFileName(filePath, skipSearchInDirectoryOfFile, nil)
+	// ComputeConfigFileName walks ancestor directories starting from filePath (via
+	// tspath.GetDirectoryPath + ForEachAncestorDirectory) and hands each candidate
+	// directly to fs.FileExists. It does NOT absolutize its input first, so a
+	// caller-supplied relative filePath produces relative candidate paths, which
+	// panic deep in typescript-go's vfs layer (RootLength/SplitPath assume an
+	// absolute path unconditionally). Resolve to absolute here, at the boundary
+	// where paths first enter tsgolint from the caller.
+	absoluteFilePath := toAbsolute(filePath, r.currentDirectory)
+	configFileName := r.configFileRegistryBuilder.ComputeConfigFileName(absoluteFilePath, skipSearchInDirectoryOfFile, nil)
 
 	if configFileName == "" {
 		return "", false
 	}
 
-	normalizedPath := tspath.ToPath(filePath, r.currentDirectory, r.fs.UseCaseSensitiveFileNames())
+	normalizedPath := tspath.ToPath(absoluteFilePath, r.currentDirectory, r.fs.UseCaseSensitiveFileNames())
 
 	// Search through the config and its references
 	// This corresponds to findOrCreateDefaultConfiguredProjectWorker
-	result := r.findConfigWithReferences(filePath, normalizedPath, configFileName, nil, nil)
+	result := r.findConfigWithReferences(absoluteFilePath, normalizedPath, configFileName, nil, nil)
 
 	if result.configFileName != "" {
 		return result.configFileName, true
@@ -215,7 +239,11 @@ type ResolutionResult struct {
 
 func (r *TsConfigResolver) work(in <-chan string, out chan<- ResolutionResult) {
 	for file := range in {
-		config := r.configFileRegistryBuilder.ComputeConfigFileName(file, false, nil)
+		// See the comment in FindTsconfigForFile: ComputeConfigFileName requires
+		// an absolute path, and `file` here comes straight from the caller-supplied
+		// file list (FindTsConfigParallel), which may be relative.
+		absoluteFile := toAbsolute(file, r.currentDirectory)
+		config := r.configFileRegistryBuilder.ComputeConfigFileName(absoluteFile, false, nil)
 		if config == "" {
 			out <- ResolutionResult{
 				file:   file,
@@ -224,10 +252,10 @@ func (r *TsConfigResolver) work(in <-chan string, out chan<- ResolutionResult) {
 			continue
 		}
 
-		fileNormalized := tspath.ToPath(file, r.currentDirectory, r.fs.UseCaseSensitiveFileNames())
+		fileNormalized := tspath.ToPath(absoluteFile, r.currentDirectory, r.fs.UseCaseSensitiveFileNames())
 
 		// Search through the config and its references
-		result := r.findConfigWithReferences(file, fileNormalized, config, nil, nil)
+		result := r.findConfigWithReferences(absoluteFile, fileNormalized, config, nil, nil)
 		out <- ResolutionResult{
 			config: result.configFileName,
 			file:   file,


### PR DESCRIPTION
## Summary

Pointing oxlint (with the `typescript` plugin active, so the type-aware `oxlint-tsgolint` backend runs) at a directory outside the project's tsconfig `include` — concretely, `node_modules/<some-package>` via `--no-ignore` — panics inside typescript-go's VFS layer while `TsConfigResolver.FindTsConfigParallel` concurrently walks ancestor directories looking for each file's `tsconfig.json`:

```
panic: vfs: path "node_modules/lucide-react/dist/esm/icons/tsconfig.json" is not absolute [recovered, repanicked]

goroutine 10 [running]:
...
github.com/microsoft/typescript-go/internal/vfs/internal.RootLength(...)
github.com/microsoft/typescript-go/internal/vfs/internal.SplitPath(...)
github.com/microsoft/typescript-go/internal/vfs/internal.(*Common).RootAndPath(...)
github.com/microsoft/typescript-go/internal/vfs/internal.(*Common).FileExists(...)
...
github.com/microsoft/typescript-go/internal/project.(*ConfigFileRegistryBuilder).ComputeConfigFileName(...)
github.com/typescript-eslint/tsgolint/internal/utils.(*TsConfigResolver).work(...)
github.com/typescript-eslint/tsgolint/internal/utils.(*TsConfigResolver).FindTsConfigParallel.func1()
...
Error running tsgolint: "exit status: exit code: 2"
```

This is a hard crash that aborts the **entire** lint run — not a false positive/negative on one file, the whole invocation dies with no results at all, including for files that would otherwise resolve fine.

## Root cause

`TsConfigResolver.FindTsconfigForFile` and `.work()` (called from `FindTsConfigParallel`) pass the caller-supplied file path straight into `ComputeConfigFileName`, which walks ancestor directories (`tspath.GetDirectoryPath` + `ForEachAncestorDirectory`) and hands each candidate directly to `fs.FileExists` — without ever absolutizing the input first. If the caller passes a relative path (e.g. oxlint invoked with a relative CLI target), the whole ancestor walk stays relative, and eventually a relative candidate reaches `internal/vfs/internal.RootLength`/`SplitPath`, which assume an absolute path unconditionally and panic instead of erroring.

Since `FindTsConfigParallel` races multiple goroutines over the file list, which file's resolution hits this first (and thus which directory shows up in the panic message) varies run to run — but the crash itself was 100% reproducible any time the resolver was given a relative path outside its own tsconfig's `include`.

## Fix

Resolve to absolute at the boundary where paths enter this package (`toAbsolute` helper), using `filepath.Join` rather than `tspath.GetNormalizedAbsolutePath` — the latter normalizes to `/` separators, which would change the format of paths this package already returns/compares elsewhere (existing tests build expected paths via `filepath.Join`, which keeps `\` on Windows). `tspath.IsRootedDiskPath` is used to skip already-absolute paths.

## Testing
- Confirmed this isn't just a synthetic edge case: oxlint (1.68.0), which vendors tsgolint as oxlint-tsgolint for its --type-aware/typeAware: true mode, hits this exact panic (identical ComputeConfigFileName → FindTsConfigParallel stack) when linting a real project's own node_modules with type-aware rules on — a common real-world scenario, not an artificial one. The identical files linted with type-aware rules off (bypassing this code path entirely) complete with 0 crashes, isolating the crash to this exact resolver.
- Repro'd the panic against several real `node_modules` packages (lucide-react, axios, zod, clsx) with `--no-ignore` — confirmed 100% reproducible before the fix, 0 panics after, across repeated runs.
- `go test ./internal/...` — all packages pass except:
  - `TestFindTsconfigForFile`, `TestFindTsConfigParallel`, `TestFindTsConfigParallel_UsesAncestorConfigWhenNearestConfigExcludesFile`: confirmed these **already fail identically on an unpatched checkout** on Windows (reverted this commit locally and re-ran) — a pre-existing `/` vs `\` path-separator mismatch coming from `ComputeConfigFileName`'s own internal path handling, unrelated to this change. Not fixed here to keep this PR scoped to the crash.
  - `no_deprecated` rule tests: fail in my environment due to a missing `@types/node` in the test fixtures (I didn't run the full `pnpm install`/e2e setup) — environment gap, not a real failure.

## Disclosure

This fix (root cause investigation, patch, and verification) was developed with Claude's (Anthropic) assistance — I reviewed and tested it locally (crash repro across multiple packages + full `go test ./internal/...` run) before submitting.