### PR TITLE
fix(no-unnecessary-type-assertion): preserve generic write casts

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-type-assertion.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-type-assertion.snap
@@ -1685,3 +1685,46 @@ Message: This assertion is unnecessary since the receiver accepts the original t
    3 | f([1, 'x' as string], 1);
      |       ~~~~~~~~~~~~~
 ---
+
+[TestNoUnnecessaryTypeAssertion/invalid-126 - 1]
+Diagnostic 1: unnecessaryAssertion (4:8 - 4:19)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   3 | declare const value: AnyRecord;
+   4 | (value as AnyRecord)['property'] = 1;
+     |        ~~~~~~~~~~~~
+  Label: This expression already has the type 'AnyRecord' (4:2 - 4:6)
+   3 | declare const value: AnyRecord;
+   4 | (value as AnyRecord)['property'] = 1;
+     |  ^^^^^ This expression already has the type 'AnyRecord'
+  Label: Casting it to 'AnyRecord' is unnecessary (4:8 - 4:19)
+   3 | declare const value: AnyRecord;
+   4 | (value as AnyRecord)['property'] = 1;
+     |        ^^^^^^^^^^^^ Casting it to 'AnyRecord' is unnecessary
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-127 - 1]
+Diagnostic 1: unnecessaryAssertion (3:10 - 3:30)
+Message: This assertion is unnecessary since it does not change the type of the expression.
+   2 | function identity<T>(value: T): T {
+   3 |   return value as unknown as T;
+     |          ~~~~~~~~~~~~~~~~~~~~~
+   4 | }
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-128 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:10 - 3:30)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | function upcast<T, U extends T>(value: U): T {
+   3 |   return value as unknown as T;
+     |          ~~~~~~~~~~~~~~~~~~~~~
+   4 | }
+---
+
+[TestNoUnnecessaryTypeAssertion/invalid-129 - 1]
+Diagnostic 1: contextuallyUnnecessary (3:10 - 3:30)
+Message: This assertion is unnecessary since the receiver accepts the original type of the expression.
+   2 | function upcast<T, U extends T & { id: string }>(value: U): T {
+   3 |   return value as unknown as T;
+     |          ~~~~~~~~~~~~~~~~~~~~~
+   4 | }
+---

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -339,9 +339,29 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			return utils.IsTypeFlagSet(t, checker.TypeFlagsStringLiteral|checker.TypeFlagsNumberLiteral|checker.TypeFlagsBigIntLiteral|checker.TypeFlagsBooleanLiteral)
 		}
 
+		isReceiverOfWriteAccess := func(node *ast.Node) bool {
+			current := node.Parent
+			for current != nil && ast.IsParenthesizedExpression(current) {
+				current = current.Parent
+			}
+			for current != nil && ast.IsAccessExpression(current) {
+				if ast.IsWriteAccess(current) {
+					return true
+				}
+				current = current.Parent
+				for current != nil && ast.IsParenthesizedExpression(current) {
+					current = current.Parent
+				}
+			}
+			return false
+		}
+
 		isTypeUnchanged := func(node *ast.Node, expression *ast.Node, uncast, cast *checker.Type) bool {
 			if uncast == cast {
 				return true
+			}
+			if utils.IsTypeParameter(uncast) && isReceiverOfWriteAccess(node) {
+				return false
 			}
 
 			typeNode := node.Type()
@@ -945,11 +965,38 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			originalExpr := getOriginalExpression(node)
 			originalType := ctx.TypeChecker.GetTypeAtLocation(originalExpr)
 			castType := ctx.TypeChecker.GetTypeAtLocation(node)
+			var isConstrainedTo func(source, target *checker.Type, seen map[*checker.Type]struct{}) bool
+			isConstrainedTo = func(source, target *checker.Type, seen map[*checker.Type]struct{}) bool {
+				if source == target {
+					return true
+				}
+				if source == nil {
+					return false
+				}
+				if _, ok := seen[source]; ok {
+					return false
+				}
+				seen[source] = struct{}{}
+
+				if utils.IsTypeParameter(source) {
+					return isConstrainedTo(ctx.TypeChecker.GetConstraintOfTypeParameter(source), target, seen)
+				}
+				if utils.IsIntersectionType(source) {
+					return slices.ContainsFunc(source.Types(), func(part *checker.Type) bool {
+						return isConstrainedTo(part, target, seen)
+					})
+				}
+				return false
+			}
+			differentUnrelatedTypeParameters := originalType != castType &&
+				utils.IsTypeParameter(originalType) &&
+				utils.IsTypeParameter(castType) &&
+				!isConstrainedTo(originalType, castType, map[*checker.Type]struct{}{})
 
 			messageId := ""
 			if isTypeUnchanged(node, innerExpression, originalType, castType) && !isTypeAny(castType) {
 				messageId = "unnecessaryAssertion"
-			} else if contextualType != nil {
+			} else if contextualType != nil && !differentUnrelatedTypeParameters {
 				intermediateType := ctx.TypeChecker.GetTypeAtLocation(innerExpression)
 				if (isTypeAny(intermediateType) || isTypeUnknown(intermediateType)) &&
 					checker.Checker_isTypeAssignableTo(ctx.TypeChecker, originalType, contextualType) {

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
@@ -1181,6 +1181,50 @@ const result = combine(...[[{ id: 0 } as Item], items]);
 result[0].id = 'x';
     `,
 		},
+		{
+			// https://github.com/oxc-project/tsgolint/issues/1047
+			Code: `
+type IAnyObject = Record<any, any>;
+
+const { isArray } = Array;
+
+const isPlainObject = <InferredType extends IAnyObject = IAnyObject>(
+  val: unknown,
+): val is InferredType => Object.prototype.toString.call(val) === '[object Object]';
+
+export const deepAssign = <
+  TargetObject extends IAnyObject,
+  MergedObject extends IAnyObject = TargetObject,
+  FinalObject extends Partial<TargetObject> & Partial<MergedObject> = TargetObject & MergedObject,
+>(
+  originObject: TargetObject,
+  ...overrideObjects: (MergedObject | null | undefined)[]
+): FinalObject => {
+  if (overrideObjects.length === 0) return originObject as unknown as FinalObject;
+
+  const assignObject = overrideObjects.shift();
+
+  if (assignObject) {
+    Object.entries(assignObject).forEach(([property, value]) => {
+      if (property === '__proto__' || property === 'constructor') return;
+      if (isPlainObject(originObject[property]) && isPlainObject(value)) {
+        deepAssign(originObject[property], value);
+      } else if (isArray(value)) {
+        (originObject as IAnyObject)[property] = [...(value as unknown[])];
+      } else if (isPlainObject(value)) {
+        (originObject as IAnyObject)[property] = {
+          ...value,
+        };
+      } else {
+        (originObject as IAnyObject)[property] = assignObject[property] as unknown;
+      }
+    });
+  }
+
+  return deepAssign(originObject, ...overrideObjects);
+};
+    `,
+		},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code:   "const foo = <3>3;",
@@ -3373,6 +3417,66 @@ f([1, 'x' as string], 1);`,
 			Output: []string{`
 declare function f<T>(pair: readonly [T, string], tag: T): void;
 f([1, 'x'], 1);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+type AnyRecord = Record<any, any>;
+declare const value: AnyRecord;
+(value as AnyRecord)['property'] = 1;`,
+			Output: []string{`
+type AnyRecord = Record<any, any>;
+declare const value: AnyRecord;
+(value)['property'] = 1;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryAssertion",
+				},
+			},
+		},
+		{
+			Code: `
+function identity<T>(value: T): T {
+  return value as unknown as T;
+}`,
+			Output: []string{`
+function identity<T>(value: T): T {
+  return value;
+}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryAssertion",
+				},
+			},
+		},
+		{
+			Code: `
+function upcast<T, U extends T>(value: U): T {
+  return value as unknown as T;
+}`,
+			Output: []string{`
+function upcast<T, U extends T>(value: U): T {
+  return value;
+}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "contextuallyUnnecessary",
+				},
+			},
+		},
+		{
+			Code: `
+function upcast<T, U extends T & { id: string }>(value: U): T {
+  return value as unknown as T;
+}`,
+			Output: []string{`
+function upcast<T, U extends T & { id: string }>(value: U): T {
+  return value;
+}`},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "contextuallyUnnecessary",


### PR DESCRIPTION
Fixes #1047.

Follow-up to #1045, which fixed the related generic-array inference case. The #1047 deepAssign reproduction was not fixed by #1045 and still produced four unsafe diagnostics.

## Summary

- preserve casts from type parameters when they are receivers of write accesses
- preserve double assertions between unrelated type parameters while still simplifying constrained U extends T upcasts
- add the complete deepAssign reproduction and guardrail coverage for safe simplifications

## Tests

- go test -mod=readonly ./internal/rules/no_unnecessary_type_assertion -run TestNoUnnecessaryTypeAssertion -count=1
- go test -mod=readonly ./internal/...