### PR TITLE
feat(no-floating-promises): improve diagnostics

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -706,13 +706,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-floating-promises/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<unknown>\`.",
+        "range": {
+          "end": 76,
+          "pos": 69,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 77,
+      "end": 76,
       "pos": 69,
     },
     "rule": "no-floating-promises",
@@ -752,13 +761,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-floating-promises/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<void>\`.",
+        "range": {
+          "end": 165,
+          "pos": 134,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 166,
+      "end": 165,
       "pos": 134,
     },
     "rule": "no-floating-promises",
@@ -798,13 +816,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-floating-promises/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 199,
+          "pos": 168,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 200,
+      "end": 199,
       "pos": 168,
     },
     "rule": "no-floating-promises",
@@ -844,13 +871,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-floating-promises/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 235,
+          "pos": 202,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 236,
+      "end": 235,
       "pos": 202,
     },
     "rule": "no-floating-promises",
@@ -890,13 +926,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-floating-promises/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This array contains Promises and has type \`Promise<number>[]\`.",
+        "range": {
+          "end": 271,
+          "pos": 238,
+        },
+      },
+    ],
     "message": {
       "description": "An array of Promises may be unintentional.",
       "help": "Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the \`void\` operator.",
       "id": "floatingPromiseArrayVoid",
     },
     "range": {
-      "end": 272,
+      "end": 271,
       "pos": 238,
     },
     "rule": "no-floating-promises",
@@ -2807,13 +2852,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/prefer-promise-reject-errors/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 92,
+          "pos": 69,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 93,
+      "end": 92,
       "pos": 69,
     },
     "rule": "no-floating-promises",
@@ -2853,13 +2907,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/prefer-promise-reject-errors/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 138,
+          "pos": 120,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 139,
+      "end": 138,
       "pos": 120,
     },
     "rule": "no-floating-promises",
@@ -2899,13 +2962,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/prefer-promise-reject-errors/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 186,
+          "pos": 166,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 187,
+      "end": 186,
       "pos": 166,
     },
     "rule": "no-floating-promises",
@@ -2945,13 +3017,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/prefer-promise-reject-errors/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 251,
+          "pos": 215,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 252,
+      "end": 251,
       "pos": 215,
     },
     "rule": "no-floating-promises",
@@ -2991,13 +3072,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/prefer-promise-reject-errors/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 305,
+          "pos": 285,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 306,
+      "end": 305,
       "pos": 285,
     },
     "rule": "no-floating-promises",
@@ -3988,13 +4078,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/a.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<unknown>\`.",
+        "range": {
+          "end": 76,
+          "pos": 69,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 77,
+      "end": 76,
       "pos": 69,
     },
     "rule": "no-floating-promises",
@@ -4034,13 +4133,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/a.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<void>\`.",
+        "range": {
+          "end": 165,
+          "pos": 134,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 166,
+      "end": 165,
       "pos": 134,
     },
     "rule": "no-floating-promises",
@@ -4080,13 +4188,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/a.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 199,
+          "pos": 168,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 200,
+      "end": 199,
       "pos": 168,
     },
     "rule": "no-floating-promises",
@@ -4126,13 +4243,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/a.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 235,
+          "pos": 202,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 236,
+      "end": 235,
       "pos": 202,
     },
     "rule": "no-floating-promises",
@@ -4172,13 +4298,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/a.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This array contains Promises and has type \`Promise<number>[]\`.",
+        "range": {
+          "end": 271,
+          "pos": 238,
+        },
+      },
+    ],
     "message": {
       "description": "An array of Promises may be unintentional.",
       "help": "Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the \`void\` operator.",
       "id": "floatingPromiseArrayVoid",
     },
     "range": {
-      "end": 272,
+      "end": 271,
       "pos": 238,
     },
     "rule": "no-floating-promises",
@@ -4302,13 +4437,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/b.mts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<unknown>\`.",
+        "range": {
+          "end": 76,
+          "pos": 69,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 77,
+      "end": 76,
       "pos": 69,
     },
     "rule": "no-floating-promises",
@@ -4348,13 +4492,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/b.mts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<void>\`.",
+        "range": {
+          "end": 165,
+          "pos": 134,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 166,
+      "end": 165,
       "pos": 134,
     },
     "rule": "no-floating-promises",
@@ -4394,13 +4547,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/b.mts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 199,
+          "pos": 168,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 200,
+      "end": 199,
       "pos": 168,
     },
     "rule": "no-floating-promises",
@@ -4440,13 +4602,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/b.mts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 235,
+          "pos": 202,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 236,
+      "end": 235,
       "pos": 202,
     },
     "rule": "no-floating-promises",
@@ -4486,13 +4657,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/b.mts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This array contains Promises and has type \`Promise<number>[]\`.",
+        "range": {
+          "end": 271,
+          "pos": 238,
+        },
+      },
+    ],
     "message": {
       "description": "An array of Promises may be unintentional.",
       "help": "Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the \`void\` operator.",
       "id": "floatingPromiseArrayVoid",
     },
     "range": {
-      "end": 272,
+      "end": 271,
       "pos": 238,
     },
     "rule": "no-floating-promises",
@@ -4616,13 +4796,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/c.cts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<unknown>\`.",
+        "range": {
+          "end": 76,
+          "pos": 69,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 77,
+      "end": 76,
       "pos": 69,
     },
     "rule": "no-floating-promises",
@@ -4662,13 +4851,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/c.cts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<void>\`.",
+        "range": {
+          "end": 165,
+          "pos": 134,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 166,
+      "end": 165,
       "pos": 134,
     },
     "rule": "no-floating-promises",
@@ -4708,13 +4906,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/c.cts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 199,
+          "pos": 168,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 200,
+      "end": 199,
       "pos": 168,
     },
     "rule": "no-floating-promises",
@@ -4754,13 +4961,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/c.cts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 235,
+          "pos": 202,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 236,
+      "end": 235,
       "pos": 202,
     },
     "rule": "no-floating-promises",
@@ -4800,13 +5016,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/c.cts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This array contains Promises and has type \`Promise<number>[]\`.",
+        "range": {
+          "end": 271,
+          "pos": 238,
+        },
+      },
+    ],
     "message": {
       "description": "An array of Promises may be unintentional.",
       "help": "Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the \`void\` operator.",
       "id": "floatingPromiseArrayVoid",
     },
     "range": {
-      "end": 272,
+      "end": 271,
       "pos": 238,
     },
     "rule": "no-floating-promises",
@@ -4930,13 +5155,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/d.tsx",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<unknown>\`.",
+        "range": {
+          "end": 76,
+          "pos": 69,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 77,
+      "end": 76,
       "pos": 69,
     },
     "rule": "no-floating-promises",
@@ -4976,13 +5210,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/d.tsx",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<void>\`.",
+        "range": {
+          "end": 165,
+          "pos": 134,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 166,
+      "end": 165,
       "pos": 134,
     },
     "rule": "no-floating-promises",
@@ -5022,13 +5265,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/d.tsx",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 199,
+          "pos": 168,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 200,
+      "end": 199,
       "pos": 168,
     },
     "rule": "no-floating-promises",
@@ -5068,13 +5320,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/d.tsx",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<never>\`.",
+        "range": {
+          "end": 235,
+          "pos": 202,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 236,
+      "end": 235,
       "pos": 202,
     },
     "rule": "no-floating-promises",
@@ -5114,13 +5375,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/src/d.tsx",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This array contains Promises and has type \`Promise<number>[]\`.",
+        "range": {
+          "end": 271,
+          "pos": 238,
+        },
+      },
+    ],
     "message": {
       "description": "An array of Promises may be unintentional.",
       "help": "Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the \`void\` operator.",
       "id": "floatingPromiseArrayVoid",
     },
     "range": {
-      "end": 272,
+      "end": 271,
       "pos": 238,
     },
     "rule": "no-floating-promises",
@@ -5343,13 +5613,22 @@ exports[`TSGoLint E2E Snapshot Tests > should still report lint rule diagnostics
   {
     "file_path": "fixtures/with-invalid-tsconfig-option-and-lint-errors/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<string>\`.",
+        "range": {
+          "end": 50,
+          "pos": 26,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add void operator to ignore.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the \`void\` operator.",
       "id": "floatingVoid",
     },
     "range": {
-      "end": 51,
+      "end": 50,
       "pos": 26,
     },
     "rule": "no-floating-promises",
@@ -5364,14 +5643,23 @@ exports[`TSGoLint E2E Snapshot Tests > supports passing rule config 1`] = `
   {
     "file_path": "fixtures/basic/rules/no-floating-promises/void.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "This unhandled promise-like value has type \`Promise<string>\`.",
+        "range": {
+          "end": 75,
+          "pos": 59,
+        },
+      },
+    ],
     "message": {
       "description": "Promises must be awaited, add await operator.",
       "help": "The promise must end with a call to .catch, or end with a call to .then with a rejection handler.",
       "id": "floating",
     },
     "range": {
-      "end": 76,
-      "pos": 54,
+      "end": 75,
+      "pos": 59,
     },
     "rule": "no-floating-promises",
   },

--- a/internal/rule_tester/__snapshots__/no-floating-promises.snap
+++ b/internal/rule_tester/__snapshots__/no-floating-promises.snap
@@ -1,620 +1,905 @@
 
 [TestNoFloatingPromisesRule/invalid-0 - 1]
-Diagnostic 1: floatingVoid (3:3 - 3:27)
+Diagnostic 1: floatingVoid (3:3 - 3:26)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | async function test() {
    3 |   Promise.resolve('value');
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |   Promise.resolve('value').then(() => {});
+  Label: This unhandled promise-like value has type `Promise<string>`. (3:3 - 3:26)
+   2 | async function test() {
+   3 |   Promise.resolve('value');
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<string>`.
    4 |   Promise.resolve('value').then(() => {});
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (4:3 - 4:42)
+Diagnostic 2: floatingVoid (4:3 - 4:41)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 |   Promise.resolve('value');
    4 |   Promise.resolve('value').then(() => {});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 |   Promise.resolve('value').catch();
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:3 - 4:41)
+   3 |   Promise.resolve('value');
+   4 |   Promise.resolve('value').then(() => {});
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |   Promise.resolve('value').catch();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (5:3 - 5:35)
+Diagnostic 3: floatingVoid (5:3 - 5:34)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    4 |   Promise.resolve('value').then(() => {});
    5 |   Promise.resolve('value').catch();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 |   Promise.resolve('value').finally();
+  Label: This unhandled promise-like value has type `Promise<string>`. (5:3 - 5:34)
+   4 |   Promise.resolve('value').then(() => {});
+   5 |   Promise.resolve('value').catch();
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<string>`.
    6 |   Promise.resolve('value').finally();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 4: floatingVoid (6:3 - 6:37)
+Diagnostic 4: floatingVoid (6:3 - 6:36)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 |   Promise.resolve('value').catch();
    6 |   Promise.resolve('value').finally();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 | }
+  Label: This unhandled promise-like value has type `Promise<string>`. (6:3 - 6:36)
+   5 |   Promise.resolve('value').catch();
+   6 |   Promise.resolve('value').finally();
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<string>`.
    7 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-1 - 1]
-Diagnostic 1: floatingVoid (11:3 - 11:19)
+Diagnostic 1: floatingVoid (11:3 - 11:18)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   10 | ): Promise<void> => {
   11 |   obj1.a?.b?.c?.();
-     |   ~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~
+  12 |   obj2.a?.b?.c();
+  Label: This unhandled promise-like value has type `Promise<void> | undefined`. (11:3 - 11:18)
+  10 | ): Promise<void> => {
+  11 |   obj1.a?.b?.c?.();
+     |   ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void> | undefined`.
   12 |   obj2.a?.b?.c();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (12:3 - 12:17)
+Diagnostic 2: floatingVoid (12:3 - 12:16)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   11 |   obj1.a?.b?.c?.();
   12 |   obj2.a?.b?.c();
-     |   ~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~
+  13 |   obj3.a?.b.c?.();
+  Label: This unhandled promise-like value has type `Promise<void> | undefined`. (12:3 - 12:16)
+  11 |   obj1.a?.b?.c?.();
+  12 |   obj2.a?.b?.c();
+     |   ^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void> | undefined`.
   13 |   obj3.a?.b.c?.();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (13:3 - 13:18)
+Diagnostic 3: floatingVoid (13:3 - 13:17)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   12 |   obj2.a?.b?.c();
   13 |   obj3.a?.b.c?.();
-     |   ~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~
+  14 |   obj4.a.b.c?.();
+  Label: This unhandled promise-like value has type `Promise<void> | undefined`. (13:3 - 13:17)
+  12 |   obj2.a?.b?.c();
+  13 |   obj3.a?.b.c?.();
+     |   ^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void> | undefined`.
   14 |   obj4.a.b.c?.();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 4: floatingVoid (14:3 - 14:17)
+Diagnostic 4: floatingVoid (14:3 - 14:16)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   13 |   obj3.a?.b.c?.();
   14 |   obj4.a.b.c?.();
-     |   ~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~
+  15 |   obj5.a?.().b?.c?.();
+  Label: This unhandled promise-like value has type `Promise<void> | undefined`. (14:3 - 14:16)
+  13 |   obj3.a?.b.c?.();
+  14 |   obj4.a.b.c?.();
+     |   ^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void> | undefined`.
   15 |   obj5.a?.().b?.c?.();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 5: floatingVoid (15:3 - 15:22)
+Diagnostic 5: floatingVoid (15:3 - 15:21)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   14 |   obj4.a.b.c?.();
   15 |   obj5.a?.().b?.c?.();
-     |   ~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~
+  16 |   obj6?.a.b.c?.();
+  Label: This unhandled promise-like value has type `Promise<void> | undefined`. (15:3 - 15:21)
+  14 |   obj4.a.b.c?.();
+  15 |   obj5.a?.().b?.c?.();
+     |   ^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void> | undefined`.
   16 |   obj6?.a.b.c?.();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 6: floatingVoid (16:3 - 16:18)
+Diagnostic 6: floatingVoid (16:3 - 16:17)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   15 |   obj5.a?.().b?.c?.();
   16 |   obj6?.a.b.c?.();
-     |   ~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~
+  17 | 
+  Label: This unhandled promise-like value has type `Promise<void> | undefined`. (16:3 - 16:17)
+  15 |   obj5.a?.().b?.c?.();
+  16 |   obj6?.a.b.c?.();
+     |   ^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void> | undefined`.
   17 | 
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 7: floatingVoid (18:3 - 18:15)
+Diagnostic 7: floatingVoid (18:3 - 18:14)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   17 | 
   18 |   callback?.();
-     |   ~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~
+  19 | };
+  Label: This unhandled promise-like value has type `Promise<void> | undefined`. (18:3 - 18:14)
+  17 | 
+  18 |   callback?.();
+     |   ^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void> | undefined`.
   19 | };
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 8: floatingVoid (21:1 - 21:14)
+Diagnostic 8: floatingVoid (21:1 - 21:13)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   20 | 
   21 | doSomething();
-     | ~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~
+  22 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (21:1 - 21:13)
+  20 | 
+  21 | doSomething();
+     | ^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
   22 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-2 - 1]
-Diagnostic 1: floatingVoid (3:1 - 3:11)
+Diagnostic 1: floatingVoid (3:1 - 3:10)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
    3 | myTag`abc`;
-     | ~~~~~~~~~~~
+     | ~~~~~~~~~~
+   4 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (3:1 - 3:10)
+   2 | declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
+   3 | myTag`abc`;
+     | ^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    4 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-3 - 1]
-Diagnostic 1: floatingVoid (3:1 - 3:26)
+Diagnostic 1: floatingVoid (3:1 - 3:25)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
    3 | myTag`abc`.then(() => {});
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (3:1 - 3:25)
+   2 | declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
+   3 | myTag`abc`.then(() => {});
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    4 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-4 - 1]
-Diagnostic 1: floatingVoid (3:1 - 3:29)
+Diagnostic 1: floatingVoid (3:1 - 3:28)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
    3 | myTag`abc`.finally(() => {});
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (3:1 - 3:28)
+   2 | declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
+   3 | myTag`abc`.finally(() => {});
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    4 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-5 - 1]
-Diagnostic 1: floatingVoid (3:3 - 3:27)
+Diagnostic 1: floatingVoid (3:3 - 3:26)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | async function test() {
    3 |   Promise.resolve('value');
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~
+   4 | }
+  Label: This unhandled promise-like value has type `Promise<string>`. (3:3 - 3:26)
+   2 | async function test() {
+   3 |   Promise.resolve('value');
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<string>`.
    4 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-6 - 1]
-Diagnostic 1: floatingVoid (3:3 - 3:39)
+Diagnostic 1: floatingVoid (3:3 - 3:38)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | async function test() {
    3 |   Promise.reject(new Error('message'));
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |   Promise.reject(new Error('message')).then(() => {});
+  Label: This unhandled promise-like value has type `Promise<never>`. (3:3 - 3:38)
+   2 | async function test() {
+   3 |   Promise.reject(new Error('message'));
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    4 |   Promise.reject(new Error('message')).then(() => {});
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (4:3 - 4:54)
+Diagnostic 2: floatingVoid (4:3 - 4:53)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 |   Promise.reject(new Error('message'));
    4 |   Promise.reject(new Error('message')).then(() => {});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 |   Promise.reject(new Error('message')).catch();
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:3 - 4:53)
+   3 |   Promise.reject(new Error('message'));
+   4 |   Promise.reject(new Error('message')).then(() => {});
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |   Promise.reject(new Error('message')).catch();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (5:3 - 5:47)
+Diagnostic 3: floatingVoid (5:3 - 5:46)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    4 |   Promise.reject(new Error('message')).then(() => {});
    5 |   Promise.reject(new Error('message')).catch();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 |   Promise.reject(new Error('message')).finally();
+  Label: This unhandled promise-like value has type `Promise<never>`. (5:3 - 5:46)
+   4 |   Promise.reject(new Error('message')).then(() => {});
+   5 |   Promise.reject(new Error('message')).catch();
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    6 |   Promise.reject(new Error('message')).finally();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 4: floatingVoid (6:3 - 6:49)
+Diagnostic 4: floatingVoid (6:3 - 6:48)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 |   Promise.reject(new Error('message')).catch();
    6 |   Promise.reject(new Error('message')).finally();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 | }
+  Label: This unhandled promise-like value has type `Promise<never>`. (6:3 - 6:48)
+   5 |   Promise.reject(new Error('message')).catch();
+   6 |   Promise.reject(new Error('message')).finally();
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    7 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-7 - 1]
-Diagnostic 1: floatingVoid (3:3 - 3:23)
+Diagnostic 1: floatingVoid (3:3 - 3:22)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | async function test() {
    3 |   (async () => true)();
-     |   ~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~
+   4 |   (async () => true)().then(() => {});
+  Label: This unhandled promise-like value has type `Promise<boolean>`. (3:3 - 3:22)
+   2 | async function test() {
+   3 |   (async () => true)();
+     |   ^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<boolean>`.
    4 |   (async () => true)().then(() => {});
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (4:3 - 4:38)
+Diagnostic 2: floatingVoid (4:3 - 4:37)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 |   (async () => true)();
    4 |   (async () => true)().then(() => {});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 |   (async () => true)().catch();
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:3 - 4:37)
+   3 |   (async () => true)();
+   4 |   (async () => true)().then(() => {});
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |   (async () => true)().catch();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (5:3 - 5:31)
+Diagnostic 3: floatingVoid (5:3 - 5:30)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    4 |   (async () => true)().then(() => {});
    5 |   (async () => true)().catch();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 | }
+  Label: This unhandled promise-like value has type `Promise<boolean>`. (5:3 - 5:30)
+   4 |   (async () => true)().then(() => {});
+   5 |   (async () => true)().catch();
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<boolean>`.
    6 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-8 - 1]
-Diagnostic 1: floatingVoid (5:3 - 5:19)
+Diagnostic 1: floatingVoid (5:3 - 5:18)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    4 | 
    5 |   returnsPromise();
-     |   ~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~
+   6 |   returnsPromise().then(() => {});
+  Label: This unhandled promise-like value has type `Promise<void>`. (5:3 - 5:18)
+   4 | 
+   5 |   returnsPromise();
+     |   ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    6 |   returnsPromise().then(() => {});
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (6:3 - 6:34)
+Diagnostic 2: floatingVoid (6:3 - 6:33)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 |   returnsPromise();
    6 |   returnsPromise().then(() => {});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 |   returnsPromise().catch();
+  Label: This unhandled promise-like value has type `Promise<void>`. (6:3 - 6:33)
+   5 |   returnsPromise();
+   6 |   returnsPromise().then(() => {});
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    7 |   returnsPromise().catch();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (7:3 - 7:27)
+Diagnostic 3: floatingVoid (7:3 - 7:26)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    6 |   returnsPromise().then(() => {});
    7 |   returnsPromise().catch();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~
+   8 |   returnsPromise().finally();
+  Label: This unhandled promise-like value has type `Promise<void>`. (7:3 - 7:26)
+   6 |   returnsPromise().then(() => {});
+   7 |   returnsPromise().catch();
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    8 |   returnsPromise().finally();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 4: floatingVoid (8:3 - 8:29)
+Diagnostic 4: floatingVoid (8:3 - 8:28)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    7 |   returnsPromise().catch();
    8 |   returnsPromise().finally();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   9 | }
+  Label: This unhandled promise-like value has type `Promise<void>`. (8:3 - 8:28)
+   7 |   returnsPromise().catch();
+   8 |   returnsPromise().finally();
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    9 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-9 - 1]
-Diagnostic 1: floatingVoid (3:3 - 3:49)
+Diagnostic 1: floatingVoid (3:25 - 3:41)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | async function test() {
    3 |   Math.random() > 0.5 ? Promise.resolve() : null;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                         ~~~~~~~~~~~~~~~~~
+   4 |   Math.random() > 0.5 ? null : Promise.resolve();
+  Label: This unhandled promise-like value has type `Promise<void>`. (3:25 - 3:41)
+   2 | async function test() {
+   3 |   Math.random() > 0.5 ? Promise.resolve() : null;
+     |                         ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    4 |   Math.random() > 0.5 ? null : Promise.resolve();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (4:3 - 4:49)
+Diagnostic 2: floatingVoid (4:32 - 4:48)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 |   Math.random() > 0.5 ? Promise.resolve() : null;
    4 |   Math.random() > 0.5 ? null : Promise.resolve();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                                ~~~~~~~~~~~~~~~~~
+   5 | }
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:32 - 4:48)
+   3 |   Math.random() > 0.5 ? Promise.resolve() : null;
+   4 |   Math.random() > 0.5 ? null : Promise.resolve();
+     |                                ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-10 - 1]
-Diagnostic 1: floatingVoid (3:3 - 3:27)
+Diagnostic 1: floatingVoid (3:4 - 3:20)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | async function test() {
    3 |   (Promise.resolve(), 123);
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+     |    ~~~~~~~~~~~~~~~~~
+   4 |   (123, Promise.resolve());
+  Label: This unhandled promise-like value has type `Promise<void>`. (3:4 - 3:20)
+   2 | async function test() {
+   3 |   (Promise.resolve(), 123);
+     |    ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    4 |   (123, Promise.resolve());
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (4:3 - 4:27)
+Diagnostic 2: floatingVoid (4:9 - 4:25)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 |   (Promise.resolve(), 123);
    4 |   (123, Promise.resolve());
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~~~~~~~~~~~~
+   5 |   (123, Promise.resolve(), 123);
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:9 - 4:25)
+   3 |   (Promise.resolve(), 123);
+   4 |   (123, Promise.resolve());
+     |         ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |   (123, Promise.resolve(), 123);
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (5:3 - 5:32)
+Diagnostic 3: floatingVoid (5:9 - 5:25)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    4 |   (123, Promise.resolve());
    5 |   (123, Promise.resolve(), 123);
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~~~~~~~~~~~~
+   6 | }
+  Label: This unhandled promise-like value has type `Promise<void>`. (5:9 - 5:25)
+   4 |   (123, Promise.resolve());
+   5 |   (123, Promise.resolve(), 123);
+     |         ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    6 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-11 - 1]
-Diagnostic 1: floating (3:3 - 3:25)
+Diagnostic 1: floating (3:8 - 3:24)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    2 | async function test() {
    3 |   void Promise.resolve();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~
+     |        ~~~~~~~~~~~~~~~~~
+   4 | }
+  Label: This unhandled promise-like value has type `Promise<void>`. (3:8 - 3:24)
+   2 | async function test() {
+   3 |   void Promise.resolve();
+     |        ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    4 | }
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-12 - 1]
-Diagnostic 1: floating (4:3 - 4:10)
+Diagnostic 1: floating (4:3 - 4:9)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    3 |   const promise = new Promise((resolve, reject) => resolve('value'));
    4 |   promise;
-     |   ~~~~~~~~
+     |   ~~~~~~~
+   5 | }
+  Label: This unhandled promise-like value has type `Promise<unknown>`. (4:3 - 4:9)
+   3 |   const promise = new Promise((resolve, reject) => resolve('value'));
+   4 |   promise;
+     |   ^^^^^^^ This unhandled promise-like value has type `Promise<unknown>`.
    5 | }
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-13 - 1]
-Diagnostic 1: floating (5:1 - 5:22)
+Diagnostic 1: floating (5:6 - 5:21)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    4 | }
    5 | void returnsPromise();
-     | ~~~~~~~~~~~~~~~~~~~~~~
+     |      ~~~~~~~~~~~~~~~~
+   6 |       
+  Label: This unhandled promise-like value has type `Promise<string>`. (5:6 - 5:21)
+   4 | }
+   5 | void returnsPromise();
+     |      ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<string>`.
    6 |       
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-14 - 1]
-Diagnostic 1: floating (5:1 - 5:32)
+Diagnostic 1: floating (5:16 - 5:31)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    4 | }
    5 | void /* ... */ returnsPromise();
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                ~~~~~~~~~~~~~~~~
+   6 |       
+  Label: This unhandled promise-like value has type `Promise<string>`. (5:16 - 5:31)
+   4 | }
+   5 | void /* ... */ returnsPromise();
+     |                ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<string>`.
    6 |       
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-15 - 1]
-Diagnostic 1: floating (5:1 - 5:22)
+Diagnostic 1: floating (5:5 - 5:20)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    4 | }
    5 | (1, returnsPromise());
-     | ~~~~~~~~~~~~~~~~~~~~~~
+     |     ~~~~~~~~~~~~~~~~
+   6 |       
+  Label: This unhandled promise-like value has type `Promise<string>`. (5:5 - 5:20)
+   4 | }
+   5 | (1, returnsPromise());
+     |     ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<string>`.
    6 |       
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-16 - 1]
-Diagnostic 1: floating (5:1 - 5:31)
+Diagnostic 1: floating (5:8 - 5:23)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    4 | }
    5 | bool ? returnsPromise() : null;
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |        ~~~~~~~~~~~~~~~~
+   6 |       
+  Label: This unhandled promise-like value has type `Promise<string>`. (5:8 - 5:23)
+   4 | }
+   5 | bool ? returnsPromise() : null;
+     |        ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<string>`.
    6 |       
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-17 - 1]
-Diagnostic 1: floatingVoid (4:3 - 4:10)
+Diagnostic 1: floatingVoid (4:3 - 4:9)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 |   const obj = { foo: Promise.resolve() };
    4 |   obj.foo;
-     |   ~~~~~~~~
+     |   ~~~~~~~
+   5 | }
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:3 - 4:9)
+   3 |   const obj = { foo: Promise.resolve() };
+   4 |   obj.foo;
+     |   ^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-18 - 1]
-Diagnostic 1: floatingVoid (3:3 - 3:36)
+Diagnostic 1: floatingVoid (3:3 - 3:35)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | async function test() {
    3 |   new Promise(resolve => resolve());
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 | }
+  Label: This unhandled promise-like value has type `Promise<unknown>`. (3:3 - 3:35)
+   2 | async function test() {
+   3 |   new Promise(resolve => resolve());
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<unknown>`.
    4 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-19 - 1]
-Diagnostic 1: floatingVoid (5:3 - 5:15)
+Diagnostic 1: floatingVoid (5:3 - 5:14)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    4 | async function test() {
    5 |   promiseValue;
-     |   ~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~
+   6 |   promiseValue.then(() => {});
+  Label: This unhandled promise-like value has type `Promise<number>`. (5:3 - 5:14)
+   4 | async function test() {
+   5 |   promiseValue;
+     |   ^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    6 |   promiseValue.then(() => {});
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (6:3 - 6:30)
+Diagnostic 2: floatingVoid (6:3 - 6:29)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 |   promiseValue;
    6 |   promiseValue.then(() => {});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 |   promiseValue.catch();
+  Label: This unhandled promise-like value has type `Promise<void>`. (6:3 - 6:29)
+   5 |   promiseValue;
+   6 |   promiseValue.then(() => {});
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    7 |   promiseValue.catch();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (7:3 - 7:23)
+Diagnostic 3: floatingVoid (7:3 - 7:22)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    6 |   promiseValue.then(() => {});
    7 |   promiseValue.catch();
-     |   ~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~
+   8 |   promiseValue.finally();
+  Label: This unhandled promise-like value has type `Promise<number>`. (7:3 - 7:22)
+   6 |   promiseValue.then(() => {});
+   7 |   promiseValue.catch();
+     |   ^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    8 |   promiseValue.finally();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 4: floatingVoid (8:3 - 8:25)
+Diagnostic 4: floatingVoid (8:3 - 8:24)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    7 |   promiseValue.catch();
    8 |   promiseValue.finally();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~
+   9 | }
+  Label: This unhandled promise-like value has type `Promise<number>`. (8:3 - 8:24)
+   7 |   promiseValue.catch();
+   8 |   promiseValue.finally();
+     |   ^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    9 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-20 - 1]
-Diagnostic 1: floatingVoid (5:3 - 5:15)
+Diagnostic 1: floatingVoid (5:3 - 5:14)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    4 | async function test() {
    5 |   promiseUnion;
-     |   ~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~
+   6 | }
+  Label: This unhandled promise-like value has type `number | Promise<number>`. (5:3 - 5:14)
+   4 | async function test() {
+   5 |   promiseUnion;
+     |   ^^^^^^^^^^^^ This unhandled promise-like value has type `number | Promise<number>`.
    6 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-21 - 1]
-Diagnostic 1: floatingVoid (5:3 - 5:22)
+Diagnostic 1: floatingVoid (5:3 - 5:21)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    4 | async function test() {
    5 |   promiseIntersection;
-     |   ~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~
+   6 |   promiseIntersection.then(() => {});
+  Label: This unhandled promise-like value has type `Promise<number> & number`. (5:3 - 5:21)
+   4 | async function test() {
+   5 |   promiseIntersection;
+     |   ^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number> & number`.
    6 |   promiseIntersection.then(() => {});
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (6:3 - 6:37)
+Diagnostic 2: floatingVoid (6:3 - 6:36)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 |   promiseIntersection;
    6 |   promiseIntersection.then(() => {});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 |   promiseIntersection.catch();
+  Label: This unhandled promise-like value has type `Promise<void>`. (6:3 - 6:36)
+   5 |   promiseIntersection;
+   6 |   promiseIntersection.then(() => {});
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    7 |   promiseIntersection.catch();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (7:3 - 7:30)
+Diagnostic 3: floatingVoid (7:3 - 7:29)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    6 |   promiseIntersection.then(() => {});
    7 |   promiseIntersection.catch();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   8 | }
+  Label: This unhandled promise-like value has type `Promise<number>`. (7:3 - 7:29)
+   6 |   promiseIntersection.then(() => {});
+   7 |   promiseIntersection.catch();
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    8 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-22 - 1]
-Diagnostic 1: floatingVoid (6:3 - 6:10)
+Diagnostic 1: floatingVoid (6:3 - 6:9)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 | 
    6 |   canThen;
-     |   ~~~~~~~~
+     |   ~~~~~~~
+   7 |   canThen.then(() => {});
+  Label: This unhandled promise-like value has type `CanThen`. (6:3 - 6:9)
+   5 | 
+   6 |   canThen;
+     |   ^^^^^^^ This unhandled promise-like value has type `CanThen`.
    7 |   canThen.then(() => {});
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (7:3 - 7:25)
+Diagnostic 2: floatingVoid (7:3 - 7:24)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    6 |   canThen;
    7 |   canThen.then(() => {});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~
+   8 |   canThen.catch();
+  Label: This unhandled promise-like value has type `Promise<void>`. (7:3 - 7:24)
+   6 |   canThen;
+   7 |   canThen.then(() => {});
+     |   ^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    8 |   canThen.catch();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (8:3 - 8:18)
+Diagnostic 3: floatingVoid (8:3 - 8:17)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    7 |   canThen.then(() => {});
    8 |   canThen.catch();
-     |   ~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~
+   9 |   canThen.finally();
+  Label: This unhandled promise-like value has type `Promise<number>`. (8:3 - 8:17)
+   7 |   canThen.then(() => {});
+   8 |   canThen.catch();
+     |   ^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    9 |   canThen.finally();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 4: floatingVoid (9:3 - 9:20)
+Diagnostic 4: floatingVoid (9:3 - 9:19)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    8 |   canThen.catch();
    9 |   canThen.finally();
-     |   ~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~
+  10 | }
+  Label: This unhandled promise-like value has type `Promise<number>`. (9:3 - 9:19)
+   8 |   canThen.catch();
+   9 |   canThen.finally();
+     |   ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
   10 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-23 - 1]
-Diagnostic 1: floatingVoid (10:3 - 10:11)
+Diagnostic 1: floatingVoid (10:3 - 10:10)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    9 | 
   10 |   thenable;
-     |   ~~~~~~~~~
+     |   ~~~~~~~~
+  11 |   thenable.then(() => {});
+  Label: This unhandled promise-like value has type `CatchableThenable`. (10:3 - 10:10)
+   9 | 
+  10 |   thenable;
+     |   ^^^^^^^^ This unhandled promise-like value has type `CatchableThenable`.
   11 |   thenable.then(() => {});
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (11:3 - 11:26)
+Diagnostic 2: floatingVoid (11:3 - 11:25)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   10 |   thenable;
   11 |   thenable.then(() => {});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~
+  12 | }
+  Label: This unhandled promise-like value has type `CatchableThenable`. (11:3 - 11:25)
+  10 |   thenable;
+  11 |   thenable.then(() => {});
+     |   ^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `CatchableThenable`.
   12 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-24 - 1]
-Diagnostic 1: floatingVoid (18:3 - 18:10)
+Diagnostic 1: floatingVoid (18:3 - 18:9)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   17 | 
   18 |   promise;
-     |   ~~~~~~~~
+     |   ~~~~~~~
+  19 |   promise.then(() => {});
+  Label: This unhandled promise-like value has type `Promise<unknown>`. (18:3 - 18:9)
+  17 | 
+  18 |   promise;
+     |   ^^^^^^^ This unhandled promise-like value has type `Promise<unknown>`.
   19 |   promise.then(() => {});
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (19:3 - 19:25)
+Diagnostic 2: floatingVoid (19:3 - 19:24)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   18 |   promise;
   19 |   promise.then(() => {});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~
+  20 |   promise.catch();
+  Label: This unhandled promise-like value has type `Promise<void>`. (19:3 - 19:24)
+  18 |   promise;
+  19 |   promise.then(() => {});
+     |   ^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
   20 |   promise.catch();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (20:3 - 20:18)
+Diagnostic 3: floatingVoid (20:3 - 20:17)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   19 |   promise.then(() => {});
   20 |   promise.catch();
-     |   ~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~
+  21 | }
+  Label: This unhandled promise-like value has type `Promise<unknown>`. (20:3 - 20:17)
+  19 |   promise.then(() => {});
+  20 |   promise.catch();
+     |   ^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<unknown>`.
   21 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-25 - 1]
-Diagnostic 1: floatingVoid (2:9 - 4:13)
+Diagnostic 1: floatingVoid (2:9 - 4:12)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
@@ -623,14 +908,23 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
    3 |           await something();
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    4 |         })();
-     | ~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (2:9 - 4:12)
+   1 | 
+   2 |         (async () => {
+     |         ^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   3 |           await something();
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   4 |         })();
+     | ^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-26 - 1]
-Diagnostic 1: floatingVoid (2:9 - 4:13)
+Diagnostic 1: floatingVoid (2:9 - 4:12)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
@@ -639,36 +933,53 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
    3 |           something();
      | ~~~~~~~~~~~~~~~~~~~~~~
    4 |         })();
-     | ~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (2:9 - 4:12)
+   1 | 
+   2 |         (async () => {
+     |         ^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   3 |           something();
+     | ^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   4 |         })();
+     | ^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-27 - 1]
-Diagnostic 1: floatingVoid (1:1 - 1:28)
+Diagnostic 1: floatingVoid (1:1 - 1:27)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | (async function foo() {})();
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Label: This unhandled promise-like value has type `Promise<void>`. (1:1 - 1:27)
+   1 | (async function foo() {})();
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-28 - 1]
-Diagnostic 1: floatingVoid (3:11 - 3:38)
+Diagnostic 1: floatingVoid (3:11 - 3:37)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 |         function foo() {
    3 |           (async function bar() {})();
-     |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |         }
+  Label: This unhandled promise-like value has type `Promise<void>`. (3:11 - 3:37)
+   2 |         function foo() {
+   3 |           (async function bar() {})();
+     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    4 |         }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-29 - 1]
-Diagnostic 1: floatingVoid (4:13 - 6:17)
+Diagnostic 1: floatingVoid (4:13 - 6:16)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 |           new Promise(res => {
@@ -677,14 +988,23 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
    5 |               await res(1);
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    6 |             })();
-     | ~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~
+   7 |           });
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:13 - 6:16)
+   3 |           new Promise(res => {
+   4 |             (async function () {
+     |             ^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   5 |               await res(1);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   6 |             })();
+     | ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    7 |           });
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-30 - 1]
-Diagnostic 1: floatingVoid (2:9 - 4:13)
+Diagnostic 1: floatingVoid (2:9 - 4:12)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
@@ -693,385 +1013,659 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
    3 |           await res(1);
      | ~~~~~~~~~~~~~~~~~~~~~~~
    4 |         })();
-     | ~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (2:9 - 4:12)
+   1 | 
+   2 |         (async function () {
+     |         ^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   3 |           await res(1);
+     | ^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   4 |         })();
+     | ^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-31 - 1]
-Diagnostic 1: floatingVoid (3:11 - 3:28)
+Diagnostic 1: floatingVoid (3:11 - 3:27)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 |         (async function () {
    3 |           Promise.resolve();
-     |           ~~~~~~~~~~~~~~~~~~
+     |           ~~~~~~~~~~~~~~~~~
+   4 |         })();
+  Label: This unhandled promise-like value has type `Promise<void>`. (3:11 - 3:27)
+   2 |         (async function () {
+   3 |           Promise.resolve();
+     |           ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    4 |         })();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-32 - 1]
-Diagnostic 1: floatingVoid (4:3 - 4:22)
+Diagnostic 1: floatingVoid (4:3 - 4:21)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | (async function () {
    4 |   promiseIntersection;
-     |   ~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~
+   5 |   promiseIntersection.then(() => {});
+  Label: This unhandled promise-like value has type `Promise<number> & number`. (4:3 - 4:21)
+   3 | (async function () {
+   4 |   promiseIntersection;
+     |   ^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number> & number`.
    5 |   promiseIntersection.then(() => {});
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingVoid (5:3 - 5:37)
+Diagnostic 2: floatingVoid (5:3 - 5:36)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    4 |   promiseIntersection;
    5 |   promiseIntersection.then(() => {});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 |   promiseIntersection.catch();
+  Label: This unhandled promise-like value has type `Promise<void>`. (5:3 - 5:36)
+   4 |   promiseIntersection;
+   5 |   promiseIntersection.then(() => {});
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    6 |   promiseIntersection.catch();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingVoid (6:3 - 6:30)
+Diagnostic 3: floatingVoid (6:3 - 6:29)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 |   promiseIntersection.then(() => {});
    6 |   promiseIntersection.catch();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 |   promiseIntersection.finally();
+  Label: This unhandled promise-like value has type `Promise<number>`. (6:3 - 6:29)
+   5 |   promiseIntersection.then(() => {});
+   6 |   promiseIntersection.catch();
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    7 |   promiseIntersection.finally();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 4: floatingVoid (7:3 - 7:32)
+Diagnostic 4: floatingVoid (7:3 - 7:31)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    6 |   promiseIntersection.catch();
    7 |   promiseIntersection.finally();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   8 | })();
+  Label: This unhandled promise-like value has type `Promise<number>`. (7:3 - 7:31)
+   6 |   promiseIntersection.catch();
+   7 |   promiseIntersection.finally();
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    8 | })();
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-33 - 1]
-Diagnostic 1: floatingVoid (6:3 - 6:32)
+Diagnostic 1: floatingVoid (6:21 - 6:31)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 | 
    6 |   void condition || myPromise();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                     ~~~~~~~~~~~
+   7 | }
+  Label: This unhandled promise-like value has type `Promise<undefined>`. (6:21 - 6:31)
+   5 | 
+   6 |   void condition || myPromise();
+     |                     ^^^^^^^^^^^ This unhandled promise-like value has type `Promise<undefined>`.
    7 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-34 - 1]
-Diagnostic 1: floating (6:3 - 6:35)
+Diagnostic 1: floating (6:24 - 6:34)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    5 | 
    6 |   (await condition) && myPromise();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                        ~~~~~~~~~~~
+   7 | }
+  Label: This unhandled promise-like value has type `Promise<undefined>`. (6:24 - 6:34)
+   5 | 
+   6 |   (await condition) && myPromise();
+     |                        ^^^^^^^^^^^ This unhandled promise-like value has type `Promise<undefined>`.
    7 | }
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-35 - 1]
-Diagnostic 1: floatingVoid (6:3 - 6:27)
+Diagnostic 1: floatingVoid (6:16 - 6:26)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 | 
    6 |   condition && myPromise();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                ~~~~~~~~~~~
+   7 | }
+  Label: This unhandled promise-like value has type `Promise<undefined>`. (6:16 - 6:26)
+   5 | 
+   6 |   condition && myPromise();
+     |                ^^^^^^^^^^^ This unhandled promise-like value has type `Promise<undefined>`.
    7 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-36 - 1]
-Diagnostic 1: floatingVoid (6:3 - 6:27)
+Diagnostic 1: floatingVoid (6:16 - 6:26)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 | 
    6 |   condition || myPromise();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                ~~~~~~~~~~~
+   7 | }
+  Label: This unhandled promise-like value has type `Promise<undefined>`. (6:16 - 6:26)
+   5 | 
+   6 |   condition || myPromise();
+     |                ^^^^^^^^^^^ This unhandled promise-like value has type `Promise<undefined>`.
    7 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-37 - 1]
-Diagnostic 1: floatingVoid (6:3 - 6:27)
+Diagnostic 1: floatingVoid (6:16 - 6:26)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 | 
    6 |   condition ?? myPromise();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                ~~~~~~~~~~~
+   7 | }
+  Label: This unhandled promise-like value has type `Promise<undefined>`. (6:16 - 6:26)
+   5 | 
+   6 |   condition ?? myPromise();
+     |                ^^^^^^^^^^^ This unhandled promise-like value has type `Promise<undefined>`.
    7 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-38 - 1]
-Diagnostic 1: floating (5:3 - 5:25)
+Diagnostic 1: floating (5:16 - 5:24)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    4 |   let condition = true;
    5 |   condition && myPromise;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~
+     |                ~~~~~~~~~
+   6 | }
+  Label: This unhandled promise-like value has type `Promise<boolean>`. (5:16 - 5:24)
+   4 |   let condition = true;
+   5 |   condition && myPromise;
+     |                ^^^^^^^^^ This unhandled promise-like value has type `Promise<boolean>`.
    6 | }
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-39 - 1]
-Diagnostic 1: floating (5:3 - 5:25)
+Diagnostic 1: floating (5:16 - 5:24)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    4 |   let condition = false;
    5 |   condition || myPromise;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~
+     |                ~~~~~~~~~
+   6 | }
+  Label: This unhandled promise-like value has type `Promise<boolean>`. (5:16 - 5:24)
+   4 |   let condition = false;
+   5 |   condition || myPromise;
+     |                ^^^^^^^^^ This unhandled promise-like value has type `Promise<boolean>`.
    6 | }
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-40 - 1]
-Diagnostic 1: floating (5:3 - 5:25)
+Diagnostic 1: floating (5:16 - 5:24)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    4 |   let condition = null;
    5 |   condition ?? myPromise;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~
+     |                ~~~~~~~~~
+   6 | }
+  Label: This unhandled promise-like value has type `Promise<boolean>`. (5:16 - 5:24)
+   4 |   let condition = null;
+   5 |   condition ?? myPromise;
+     |                ^^^^^^^^^ This unhandled promise-like value has type `Promise<boolean>`.
    6 | }
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-41 - 1]
-Diagnostic 1: floatingVoid (6:3 - 6:40)
+Diagnostic 1: floatingVoid (6:29 - 6:39)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 | 
    6 |   condition || condition || myPromise();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                             ~~~~~~~~~~~
+   7 | }
+  Label: This unhandled promise-like value has type `Promise<undefined>`. (6:29 - 6:39)
+   5 | 
+   6 |   condition || condition || myPromise();
+     |                             ^^^^^^^^^^^ This unhandled promise-like value has type `Promise<undefined>`.
    7 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-42 - 1]
-Diagnostic 1: floatingUselessRejectionHandlerVoid (4:1 - 4:44)
+Diagnostic 1: floatingUselessRejectionHandlerVoid (4:1 - 4:43)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator. A rejection handler that is not a function will be ignored.
    3 | declare const definitelyCallable: () => void;
    4 | Promise.resolve().then(() => {}, undefined);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 | Promise.resolve().then(() => {}, null);
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:1 - 4:43)
+   3 | declare const definitelyCallable: () => void;
+   4 | Promise.resolve().then(() => {}, undefined);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   5 | Promise.resolve().then(() => {}, null);
+  Label: This rejection handler has type `undefined`, which is not callable. (4:34 - 4:42)
+   3 | declare const definitelyCallable: () => void;
+   4 | Promise.resolve().then(() => {}, undefined);
+     |                                  ^^^^^^^^^ This rejection handler has type `undefined`, which is not callable.
    5 | Promise.resolve().then(() => {}, null);
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingUselessRejectionHandlerVoid (5:1 - 5:39)
+Diagnostic 2: floatingUselessRejectionHandlerVoid (5:1 - 5:38)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator. A rejection handler that is not a function will be ignored.
    4 | Promise.resolve().then(() => {}, undefined);
    5 | Promise.resolve().then(() => {}, null);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 | Promise.resolve().then(() => {}, 3);
+  Label: This unhandled promise-like value has type `Promise<void>`. (5:1 - 5:38)
+   4 | Promise.resolve().then(() => {}, undefined);
+   5 | Promise.resolve().then(() => {}, null);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   6 | Promise.resolve().then(() => {}, 3);
+  Label: This rejection handler has type `null`, which is not callable. (5:34 - 5:37)
+   4 | Promise.resolve().then(() => {}, undefined);
+   5 | Promise.resolve().then(() => {}, null);
+     |                                  ^^^^ This rejection handler has type `null`, which is not callable.
    6 | Promise.resolve().then(() => {}, 3);
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingUselessRejectionHandlerVoid (6:1 - 6:36)
+Diagnostic 3: floatingUselessRejectionHandlerVoid (6:1 - 6:35)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator. A rejection handler that is not a function will be ignored.
    5 | Promise.resolve().then(() => {}, null);
    6 | Promise.resolve().then(() => {}, 3);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 | Promise.resolve().then(() => {}, maybeCallable);
+  Label: This unhandled promise-like value has type `Promise<void>`. (6:1 - 6:35)
+   5 | Promise.resolve().then(() => {}, null);
+   6 | Promise.resolve().then(() => {}, 3);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   7 | Promise.resolve().then(() => {}, maybeCallable);
+  Label: This rejection handler has type `3`, which is not callable. (6:34 - 6:34)
+   5 | Promise.resolve().then(() => {}, null);
+   6 | Promise.resolve().then(() => {}, 3);
+     |                                  ^ This rejection handler has type `3`, which is not callable.
    7 | Promise.resolve().then(() => {}, maybeCallable);
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 4: floatingUselessRejectionHandlerVoid (7:1 - 7:48)
+Diagnostic 4: floatingUselessRejectionHandlerVoid (7:1 - 7:47)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator. A rejection handler that is not a function will be ignored.
    6 | Promise.resolve().then(() => {}, 3);
    7 | Promise.resolve().then(() => {}, maybeCallable);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   8 | Promise.resolve().then(() => {}, definitelyCallable);
+  Label: This unhandled promise-like value has type `Promise<void>`. (7:1 - 7:47)
+   6 | Promise.resolve().then(() => {}, 3);
+   7 | Promise.resolve().then(() => {}, maybeCallable);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   8 | Promise.resolve().then(() => {}, definitelyCallable);
+  Label: This rejection handler has type `string | (() => void)`, which is not callable. (7:34 - 7:46)
+   6 | Promise.resolve().then(() => {}, 3);
+   7 | Promise.resolve().then(() => {}, maybeCallable);
+     |                                  ^^^^^^^^^^^^^ This rejection handler has type `string | (() => void)`, which is not callable.
    8 | Promise.resolve().then(() => {}, definitelyCallable);
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 5: floatingUselessRejectionHandlerVoid (10:1 - 10:35)
+Diagnostic 5: floatingUselessRejectionHandlerVoid (10:1 - 10:34)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator. A rejection handler that is not a function will be ignored.
    9 | 
   10 | Promise.resolve().catch(undefined);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  11 | Promise.resolve().catch(null);
+  Label: This unhandled promise-like value has type `Promise<void>`. (10:1 - 10:34)
+   9 | 
+  10 | Promise.resolve().catch(undefined);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+  11 | Promise.resolve().catch(null);
+  Label: This rejection handler has type `undefined`, which is not callable. (10:25 - 10:33)
+   9 | 
+  10 | Promise.resolve().catch(undefined);
+     |                         ^^^^^^^^^ This rejection handler has type `undefined`, which is not callable.
   11 | Promise.resolve().catch(null);
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 6: floatingUselessRejectionHandlerVoid (11:1 - 11:30)
+Diagnostic 6: floatingUselessRejectionHandlerVoid (11:1 - 11:29)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator. A rejection handler that is not a function will be ignored.
   10 | Promise.resolve().catch(undefined);
   11 | Promise.resolve().catch(null);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  12 | Promise.resolve().catch(3);
+  Label: This unhandled promise-like value has type `Promise<void>`. (11:1 - 11:29)
+  10 | Promise.resolve().catch(undefined);
+  11 | Promise.resolve().catch(null);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+  12 | Promise.resolve().catch(3);
+  Label: This rejection handler has type `null`, which is not callable. (11:25 - 11:28)
+  10 | Promise.resolve().catch(undefined);
+  11 | Promise.resolve().catch(null);
+     |                         ^^^^ This rejection handler has type `null`, which is not callable.
   12 | Promise.resolve().catch(3);
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 7: floatingUselessRejectionHandlerVoid (12:1 - 12:27)
+Diagnostic 7: floatingUselessRejectionHandlerVoid (12:1 - 12:26)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator. A rejection handler that is not a function will be ignored.
   11 | Promise.resolve().catch(null);
   12 | Promise.resolve().catch(3);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  13 | Promise.resolve().catch(maybeCallable);
+  Label: This unhandled promise-like value has type `Promise<void>`. (12:1 - 12:26)
+  11 | Promise.resolve().catch(null);
+  12 | Promise.resolve().catch(3);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+  13 | Promise.resolve().catch(maybeCallable);
+  Label: This rejection handler has type `3`, which is not callable. (12:25 - 12:25)
+  11 | Promise.resolve().catch(null);
+  12 | Promise.resolve().catch(3);
+     |                         ^ This rejection handler has type `3`, which is not callable.
   13 | Promise.resolve().catch(maybeCallable);
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 
-Diagnostic 8: floatingUselessRejectionHandlerVoid (13:1 - 13:39)
+Diagnostic 8: floatingUselessRejectionHandlerVoid (13:1 - 13:38)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator. A rejection handler that is not a function will be ignored.
   12 | Promise.resolve().catch(3);
   13 | Promise.resolve().catch(maybeCallable);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  14 | Promise.resolve().catch(definitelyCallable);
+  Label: This unhandled promise-like value has type `Promise<void>`. (13:1 - 13:38)
+  12 | Promise.resolve().catch(3);
+  13 | Promise.resolve().catch(maybeCallable);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+  14 | Promise.resolve().catch(definitelyCallable);
+  Label: This rejection handler has type `string | (() => void)`, which is not callable. (13:25 - 13:37)
+  12 | Promise.resolve().catch(3);
+  13 | Promise.resolve().catch(maybeCallable);
+     |                         ^^^^^^^^^^^^^ This rejection handler has type `string | (() => void)`, which is not callable.
   14 | Promise.resolve().catch(definitelyCallable);
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-43 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:22)
+Diagnostic 1: floatingVoid (2:1 - 2:16)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | Promise.reject() || 3;
-     | ~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<never>`. (2:1 - 2:16)
+   1 | 
+   2 | Promise.reject() || 3;
+     | ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-44 - 1]
-Diagnostic 1: floatingUselessRejectionHandler (2:1 - 2:49)
+Diagnostic 1: floatingUselessRejectionHandler (2:6 - 2:48)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler. A rejection handler that is not a function will be ignored.
    1 | 
    2 | void Promise.resolve().then(() => {}, undefined);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (2:6 - 2:48)
+   1 | 
+   2 | void Promise.resolve().then(() => {}, undefined);
+     |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   3 |       
+  Label: This rejection handler has type `undefined`, which is not callable. (2:39 - 2:47)
+   1 | 
+   2 | void Promise.resolve().then(() => {}, undefined);
+     |                                       ^^^^^^^^^ This rejection handler has type `undefined`, which is not callable.
    3 |       
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-45 - 1]
-Diagnostic 1: floatingUselessRejectionHandler (3:1 - 3:48)
+Diagnostic 1: floatingUselessRejectionHandler (3:1 - 3:47)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler. A rejection handler that is not a function will be ignored.
    2 | declare const maybeCallable: string | (() => void);
    3 | Promise.resolve().then(() => {}, maybeCallable);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (3:1 - 3:47)
+   2 | declare const maybeCallable: string | (() => void);
+   3 | Promise.resolve().then(() => {}, maybeCallable);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   4 |       
+  Label: This rejection handler has type `string | (() => void)`, which is not callable. (3:34 - 3:46)
+   2 | declare const maybeCallable: string | (() => void);
+   3 | Promise.resolve().then(() => {}, maybeCallable);
+     |                                  ^^^^^^^^^^^^^ This rejection handler has type `string | (() => void)`, which is not callable.
    4 |       
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-46 - 1]
-Diagnostic 1: floatingUselessRejectionHandler (4:1 - 4:44)
+Diagnostic 1: floatingUselessRejectionHandler (4:1 - 4:43)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler. A rejection handler that is not a function will be ignored.
    3 | declare const definitelyCallable: () => void;
    4 | Promise.resolve().then(() => {}, undefined);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 | Promise.resolve().then(() => {}, null);
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:1 - 4:43)
+   3 | declare const definitelyCallable: () => void;
+   4 | Promise.resolve().then(() => {}, undefined);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   5 | Promise.resolve().then(() => {}, null);
+  Label: This rejection handler has type `undefined`, which is not callable. (4:34 - 4:42)
+   3 | declare const definitelyCallable: () => void;
+   4 | Promise.resolve().then(() => {}, undefined);
+     |                                  ^^^^^^^^^ This rejection handler has type `undefined`, which is not callable.
    5 | Promise.resolve().then(() => {}, null);
   Suggestion 1: [floatingFixAwait] Add await operator.
 
-Diagnostic 2: floatingUselessRejectionHandler (5:1 - 5:39)
+Diagnostic 2: floatingUselessRejectionHandler (5:1 - 5:38)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler. A rejection handler that is not a function will be ignored.
    4 | Promise.resolve().then(() => {}, undefined);
    5 | Promise.resolve().then(() => {}, null);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 | Promise.resolve().then(() => {}, 3);
+  Label: This unhandled promise-like value has type `Promise<void>`. (5:1 - 5:38)
+   4 | Promise.resolve().then(() => {}, undefined);
+   5 | Promise.resolve().then(() => {}, null);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   6 | Promise.resolve().then(() => {}, 3);
+  Label: This rejection handler has type `null`, which is not callable. (5:34 - 5:37)
+   4 | Promise.resolve().then(() => {}, undefined);
+   5 | Promise.resolve().then(() => {}, null);
+     |                                  ^^^^ This rejection handler has type `null`, which is not callable.
    6 | Promise.resolve().then(() => {}, 3);
   Suggestion 1: [floatingFixAwait] Add await operator.
 
-Diagnostic 3: floatingUselessRejectionHandler (6:1 - 6:36)
+Diagnostic 3: floatingUselessRejectionHandler (6:1 - 6:35)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler. A rejection handler that is not a function will be ignored.
    5 | Promise.resolve().then(() => {}, null);
    6 | Promise.resolve().then(() => {}, 3);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 | Promise.resolve().then(() => {}, maybeCallable);
+  Label: This unhandled promise-like value has type `Promise<void>`. (6:1 - 6:35)
+   5 | Promise.resolve().then(() => {}, null);
+   6 | Promise.resolve().then(() => {}, 3);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   7 | Promise.resolve().then(() => {}, maybeCallable);
+  Label: This rejection handler has type `3`, which is not callable. (6:34 - 6:34)
+   5 | Promise.resolve().then(() => {}, null);
+   6 | Promise.resolve().then(() => {}, 3);
+     |                                  ^ This rejection handler has type `3`, which is not callable.
    7 | Promise.resolve().then(() => {}, maybeCallable);
   Suggestion 1: [floatingFixAwait] Add await operator.
 
-Diagnostic 4: floatingUselessRejectionHandler (7:1 - 7:48)
+Diagnostic 4: floatingUselessRejectionHandler (7:1 - 7:47)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler. A rejection handler that is not a function will be ignored.
    6 | Promise.resolve().then(() => {}, 3);
    7 | Promise.resolve().then(() => {}, maybeCallable);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   8 | Promise.resolve().then(() => {}, definitelyCallable);
+  Label: This unhandled promise-like value has type `Promise<void>`. (7:1 - 7:47)
+   6 | Promise.resolve().then(() => {}, 3);
+   7 | Promise.resolve().then(() => {}, maybeCallable);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   8 | Promise.resolve().then(() => {}, definitelyCallable);
+  Label: This rejection handler has type `string | (() => void)`, which is not callable. (7:34 - 7:46)
+   6 | Promise.resolve().then(() => {}, 3);
+   7 | Promise.resolve().then(() => {}, maybeCallable);
+     |                                  ^^^^^^^^^^^^^ This rejection handler has type `string | (() => void)`, which is not callable.
    8 | Promise.resolve().then(() => {}, definitelyCallable);
   Suggestion 1: [floatingFixAwait] Add await operator.
 
-Diagnostic 5: floatingUselessRejectionHandler (10:1 - 10:35)
+Diagnostic 5: floatingUselessRejectionHandler (10:1 - 10:34)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler. A rejection handler that is not a function will be ignored.
    9 | 
   10 | Promise.resolve().catch(undefined);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  11 | Promise.resolve().catch(null);
+  Label: This unhandled promise-like value has type `Promise<void>`. (10:1 - 10:34)
+   9 | 
+  10 | Promise.resolve().catch(undefined);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+  11 | Promise.resolve().catch(null);
+  Label: This rejection handler has type `undefined`, which is not callable. (10:25 - 10:33)
+   9 | 
+  10 | Promise.resolve().catch(undefined);
+     |                         ^^^^^^^^^ This rejection handler has type `undefined`, which is not callable.
   11 | Promise.resolve().catch(null);
   Suggestion 1: [floatingFixAwait] Add await operator.
 
-Diagnostic 6: floatingUselessRejectionHandler (11:1 - 11:30)
+Diagnostic 6: floatingUselessRejectionHandler (11:1 - 11:29)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler. A rejection handler that is not a function will be ignored.
   10 | Promise.resolve().catch(undefined);
   11 | Promise.resolve().catch(null);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  12 | Promise.resolve().catch(3);
+  Label: This unhandled promise-like value has type `Promise<void>`. (11:1 - 11:29)
+  10 | Promise.resolve().catch(undefined);
+  11 | Promise.resolve().catch(null);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+  12 | Promise.resolve().catch(3);
+  Label: This rejection handler has type `null`, which is not callable. (11:25 - 11:28)
+  10 | Promise.resolve().catch(undefined);
+  11 | Promise.resolve().catch(null);
+     |                         ^^^^ This rejection handler has type `null`, which is not callable.
   12 | Promise.resolve().catch(3);
   Suggestion 1: [floatingFixAwait] Add await operator.
 
-Diagnostic 7: floatingUselessRejectionHandler (12:1 - 12:27)
+Diagnostic 7: floatingUselessRejectionHandler (12:1 - 12:26)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler. A rejection handler that is not a function will be ignored.
   11 | Promise.resolve().catch(null);
   12 | Promise.resolve().catch(3);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  13 | Promise.resolve().catch(maybeCallable);
+  Label: This unhandled promise-like value has type `Promise<void>`. (12:1 - 12:26)
+  11 | Promise.resolve().catch(null);
+  12 | Promise.resolve().catch(3);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+  13 | Promise.resolve().catch(maybeCallable);
+  Label: This rejection handler has type `3`, which is not callable. (12:25 - 12:25)
+  11 | Promise.resolve().catch(null);
+  12 | Promise.resolve().catch(3);
+     |                         ^ This rejection handler has type `3`, which is not callable.
   13 | Promise.resolve().catch(maybeCallable);
   Suggestion 1: [floatingFixAwait] Add await operator.
 
-Diagnostic 8: floatingUselessRejectionHandler (13:1 - 13:39)
+Diagnostic 8: floatingUselessRejectionHandler (13:1 - 13:38)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler. A rejection handler that is not a function will be ignored.
   12 | Promise.resolve().catch(3);
   13 | Promise.resolve().catch(maybeCallable);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  14 | Promise.resolve().catch(definitelyCallable);
+  Label: This unhandled promise-like value has type `Promise<void>`. (13:1 - 13:38)
+  12 | Promise.resolve().catch(3);
+  13 | Promise.resolve().catch(maybeCallable);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+  14 | Promise.resolve().catch(definitelyCallable);
+  Label: This rejection handler has type `string | (() => void)`, which is not callable. (13:25 - 13:37)
+  12 | Promise.resolve().catch(3);
+  13 | Promise.resolve().catch(maybeCallable);
+     |                         ^^^^^^^^^^^^^ This rejection handler has type `string | (() => void)`, which is not callable.
   14 | Promise.resolve().catch(definitelyCallable);
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-47 - 1]
-Diagnostic 1: floating (2:1 - 2:22)
+Diagnostic 1: floating (2:1 - 2:16)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    1 | 
    2 | Promise.reject() || 3;
-     | ~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<never>`. (2:1 - 2:16)
+   1 | 
+   2 | Promise.reject() || 3;
+     | ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    3 |       
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-48 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:35)
+Diagnostic 1: floatingVoid (2:1 - 2:34)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | Promise.reject().finally(() => {});
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<never>`. (2:1 - 2:34)
+   1 | 
+   2 | Promise.reject().finally(() => {});
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-49 - 1]
-Diagnostic 1: floating (2:1 - 4:21)
+Diagnostic 1: floating (2:1 - 4:20)
 Message: Promises must be awaited, add await operator.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler.
    1 | 
@@ -1080,13 +1674,22 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
    3 |   .finally(() => {})
      | ~~~~~~~~~~~~~~~~~~~~
    4 |   .finally(() => {});
-     | ~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<never>`. (2:1 - 4:20)
+   1 | 
+   2 | Promise.reject()
+     | ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
+   3 |   .finally(() => {})
+     | ^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
+   4 |   .finally(() => {});
+     | ^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    5 |       
   Suggestion 1: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-50 - 1]
-Diagnostic 1: floatingVoid (2:1 - 5:21)
+Diagnostic 1: floatingVoid (2:1 - 5:20)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
@@ -1097,14 +1700,25 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
    4 |   .finally(() => {})
      | ~~~~~~~~~~~~~~~~~~~~
    5 |   .finally(() => {});
-     | ~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~
+   6 |       
+  Label: This unhandled promise-like value has type `Promise<never>`. (2:1 - 5:20)
+   1 | 
+   2 | Promise.reject()
+     | ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
+   3 |   .finally(() => {})
+     | ^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
+   4 |   .finally(() => {})
+     | ^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
+   5 |   .finally(() => {});
+     | ^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    6 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-51 - 1]
-Diagnostic 1: floatingVoid (2:1 - 4:21)
+Diagnostic 1: floatingVoid (2:1 - 4:20)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
@@ -1113,146 +1727,215 @@ Help: The promise must end with a call to .catch, or end with a call to .then wi
    3 |   .then(() => {})
      | ~~~~~~~~~~~~~~~~~
    4 |   .finally(() => {});
-     | ~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (2:1 - 4:20)
+   1 | 
+   2 | Promise.reject()
+     | ^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   3 |   .then(() => {})
+     | ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   4 |   .finally(() => {});
+     | ^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-52 - 1]
-Diagnostic 1: floatingVoid (3:1 - 3:36)
+Diagnostic 1: floatingVoid (3:1 - 3:35)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | declare const returnsPromise: () => Promise<void> | null;
    3 | returnsPromise()?.finally(() => {});
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+  Label: This unhandled promise-like value has type `Promise<void> | undefined`. (3:1 - 3:35)
+   2 | declare const returnsPromise: () => Promise<void> | null;
+   3 | returnsPromise()?.finally(() => {});
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void> | undefined`.
    4 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-53 - 1]
-Diagnostic 1: floatingVoid (3:1 - 3:38)
+Diagnostic 1: floatingVoid (3:1 - 3:37)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | const promiseIntersection: Promise<number> & number;
    3 | promiseIntersection.finally(() => {});
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+  Label: This unhandled promise-like value has type `Promise<number>`. (3:1 - 3:37)
+   2 | const promiseIntersection: Promise<number> & number;
+   3 | promiseIntersection.finally(() => {});
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    4 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-54 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:43)
+Diagnostic 1: floatingVoid (2:2 - 2:36)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | (Promise.resolve().finally(() => {}), 123);
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (2:2 - 2:36)
+   1 | 
+   2 | (Promise.resolve().finally(() => {}), 123);
+     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-55 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:31)
+Diagnostic 1: floatingVoid (2:1 - 2:30)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | (async () => true)().finally();
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<boolean>`. (2:1 - 2:30)
+   1 | 
+   2 | (async () => true)().finally();
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<boolean>`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-56 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:55)
+Diagnostic 1: floatingVoid (2:1 - 2:54)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | Promise.reject(new Error('message')).finally(() => {});
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<never>`. (2:1 - 2:54)
+   1 | 
+   2 | Promise.reject(new Error('message')).finally(() => {});
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-57 - 1]
-Diagnostic 1: floatingVoid (5:3 - 5:25)
+Diagnostic 1: floatingVoid (5:3 - 5:24)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    4 | ): void {
    5 |   maybePromiseArray?.[0];
-     |   ~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~
+   6 | }
+  Label: This unhandled promise-like value has type `T | Promise<T> | undefined`. (5:3 - 5:24)
+   4 | ): void {
+   5 |   maybePromiseArray?.[0];
+     |   ^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `T | Promise<T> | undefined`.
    6 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-58 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (2:1 - 2:38)
+Diagnostic 1: floatingPromiseArrayVoid (2:1 - 2:37)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    1 | 
    2 | [1, 2, 3].map(() => Promise.reject());
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This array contains Promises and has type `Promise<never>[]`. (2:1 - 2:37)
+   1 | 
+   2 | [1, 2, 3].map(() => Promise.reject());
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `Promise<never>[]`.
    3 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-59 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (3:1 - 3:34)
+Diagnostic 1: floatingPromiseArrayVoid (3:1 - 3:33)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    2 | declare const array: unknown[];
    3 | array.map(() => Promise.reject());
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+  Label: This array contains Promises and has type `Promise<never>[]`. (3:1 - 3:33)
+   2 | declare const array: unknown[];
+   3 | array.map(() => Promise.reject());
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `Promise<never>[]`.
    4 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-60 - 1]
-Diagnostic 1: floatingPromiseArray (3:1 - 3:18)
+Diagnostic 1: floatingPromiseArray (3:6 - 3:17)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar.
    2 | declare const promiseArray: Array<Promise<unknown>>;
    3 | void promiseArray;
-     | ~~~~~~~~~~~~~~~~~~
+     |      ~~~~~~~~~~~~
+   4 |       
+  Label: This array contains Promises and has type `Promise<unknown>[]`. (3:6 - 3:17)
+   2 | declare const promiseArray: Array<Promise<unknown>>;
+   3 | void promiseArray;
+     |      ^^^^^^^^^^^^ This array contains Promises and has type `Promise<unknown>[]`.
    4 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-61 - 1]
-Diagnostic 1: floatingPromiseArray (4:3 - 4:21)
+Diagnostic 1: floatingPromiseArray (4:3 - 4:20)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar.
    3 | async function f() {
    4 |   await promiseArray;
-     |   ~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~
+   5 | }
+  Label: This array contains Promises and has type `Promise<unknown>[]`. (4:3 - 4:20)
+   3 | async function f() {
+   4 |   await promiseArray;
+     |   ^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `Promise<unknown>[]`.
    5 | }
 ---
 
 [TestNoFloatingPromisesRule/invalid-62 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (2:1 - 2:28)
+Diagnostic 1: floatingPromiseArrayVoid (2:1 - 2:27)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    1 | 
    2 | [1, 2, Promise.reject(), 3];
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This array contains Promises and has type `(number | Promise<never>)[]`. (2:1 - 2:27)
+   1 | 
+   2 | [1, 2, Promise.reject(), 3];
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `(number | Promise<never>)[]`.
    3 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-63 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (2:1 - 2:44)
+Diagnostic 1: floatingPromiseArrayVoid (2:1 - 2:43)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    1 | 
    2 | [1, 2, Promise.reject().catch(() => {}), 3];
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This array contains Promises and has type `(number | Promise<void>)[]`. (2:1 - 2:43)
+   1 | 
+   2 | [1, 2, Promise.reject().catch(() => {}), 3];
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `(number | Promise<void>)[]`.
    3 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-64 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (3:1 - 5:3)
+Diagnostic 1: floatingPromiseArrayVoid (3:1 - 5:2)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    2 | const data = ['test'];
@@ -1261,72 +1944,111 @@ Help: Consider handling the promises' fulfillment or rejection with Promise.all 
    4 |   await new Promise((_res, rej) => setTimeout(rej, 1000));
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    5 | });
-     | ~~~
+     | ~~
+   6 |       
+  Label: This array contains Promises and has type `Promise<void>[]`. (3:1 - 5:2)
+   2 | const data = ['test'];
+   3 | data.map(async () => {
+     | ^^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `Promise<void>[]`.
+   4 |   await new Promise((_res, rej) => setTimeout(rej, 1000));
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `Promise<void>[]`.
+   5 | });
+     | ^^ This array contains Promises and has type `Promise<void>[]`.
    6 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-65 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (5:3 - 5:30)
+Diagnostic 1: floatingPromiseArrayVoid (5:3 - 5:29)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    4 | ): void {
    5 |   maybePromiseArrayArray?.[0];
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 | }
+  Label: This array contains Promises and has type `T | (T | Promise<T>)[] | undefined`. (5:3 - 5:29)
+   4 | ): void {
+   5 |   maybePromiseArrayArray?.[0];
+     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `T | (T | Promise<T>)[] | undefined`.
    6 | }
 ---
 
 [TestNoFloatingPromisesRule/invalid-66 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (3:3 - 3:4)
+Diagnostic 1: floatingPromiseArrayVoid (3:3 - 3:3)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    2 | function f<T extends Array<Promise<number>>>(a: T): void {
    3 |   a;
-     |   ~~
+     |   ~
+   4 | }
+  Label: This array contains Promises and has type `T`. (3:3 - 3:3)
+   2 | function f<T extends Array<Promise<number>>>(a: T): void {
+   3 |   a;
+     |   ^ This array contains Promises and has type `T`.
    4 | }
 ---
 
 [TestNoFloatingPromisesRule/invalid-67 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (3:1 - 3:2)
+Diagnostic 1: floatingPromiseArrayVoid (3:1 - 3:1)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    2 | declare const a: Array<Promise<number>> | undefined;
    3 | a;
-     | ~~
+     | ~
+   4 |       
+  Label: This array contains Promises and has type `Promise<number>[] | undefined`. (3:1 - 3:1)
+   2 | declare const a: Array<Promise<number>> | undefined;
+   3 | a;
+     | ^ This array contains Promises and has type `Promise<number>[] | undefined`.
    4 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-68 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (3:3 - 3:4)
+Diagnostic 1: floatingPromiseArrayVoid (3:3 - 3:3)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    2 | function f<T extends Array<Promise<number>>>(a: T | undefined): void {
    3 |   a;
-     |   ~~
+     |   ~
+   4 | }
+  Label: This array contains Promises and has type `T | undefined`. (3:3 - 3:3)
+   2 | function f<T extends Array<Promise<number>>>(a: T | undefined): void {
+   3 |   a;
+     |   ^ This array contains Promises and has type `T | undefined`.
    4 | }
 ---
 
 [TestNoFloatingPromisesRule/invalid-69 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (2:1 - 2:28)
+Diagnostic 1: floatingPromiseArrayVoid (2:1 - 2:27)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    1 | 
    2 | [Promise.reject()] as const;
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This array contains Promises and has type `readonly [Promise<never>]`. (2:1 - 2:27)
+   1 | 
+   2 | [Promise.reject()] as const;
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `readonly [Promise<never>]`.
    3 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-70 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (3:1 - 3:9)
+Diagnostic 1: floatingPromiseArrayVoid (3:1 - 3:8)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    2 | declare function cursed(): [Promise<number>, Promise<string>];
    3 | cursed();
-     | ~~~~~~~~~
+     | ~~~~~~~~
+   4 |       
+  Label: This array contains Promises and has type `[Promise<number>, Promise<string>]`. (3:1 - 3:8)
+   2 | declare function cursed(): [Promise<number>, Promise<string>];
+   3 | cursed();
+     | ^^^^^^^^ This array contains Promises and has type `[Promise<number>, Promise<string>]`.
    4 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-71 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (2:1 - 8:11)
+Diagnostic 1: floatingPromiseArrayVoid (2:1 - 8:10)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    1 | 
@@ -1343,343 +2065,527 @@ Help: Consider handling the promises' fulfillment or rejection with Promise.all 
    7 |   'but it still is flagged',
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    8 | ] as const;
-     | ~~~~~~~~~~~
+     | ~~~~~~~~~~
+   9 |       
+  Label: This array contains Promises and has type `readonly ["Type Argument number ", 1, "is not", Promise<void>, "but it still is flagged"]`. (2:1 - 8:10)
+   1 | 
+   2 | [
+     | ^ This array contains Promises and has type `readonly ["Type Argument number ", 1, "is not", Promise<void>, "but it still is flagged"]`.
+   3 |   'Type Argument number ',
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `readonly ["Type Argument number ", 1, "is not", Promise<void>, "but it still is flagged"]`.
+   4 |   1,
+     | ^^^^ This array contains Promises and has type `readonly ["Type Argument number ", 1, "is not", Promise<void>, "but it still is flagged"]`.
+   5 |   'is not',
+     | ^^^^^^^^^^^ This array contains Promises and has type `readonly ["Type Argument number ", 1, "is not", Promise<void>, "but it still is flagged"]`.
+   6 |   Promise.resolve(),
+     | ^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `readonly ["Type Argument number ", 1, "is not", Promise<void>, "but it still is flagged"]`.
+   7 |   'but it still is flagged',
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `readonly ["Type Argument number ", 1, "is not", Promise<void>, "but it still is flagged"]`.
+   8 | ] as const;
+     | ^^^^^^^^^^ This array contains Promises and has type `readonly ["Type Argument number ", 1, "is not", Promise<void>, "but it still is flagged"]`.
    9 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-72 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (5:9 - 5:28)
+Diagnostic 1: floatingPromiseArrayVoid (5:9 - 5:27)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    4 |           | [number, number, Promise<unknown>, string];
    5 |         arrayOrPromiseTuple;
-     |         ~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~~~~~~~~~~~~~~
+   6 |       
+  Label: This array contains Promises and has type `number[] | [number, number, Promise<unknown>, string]`. (5:9 - 5:27)
+   4 |           | [number, number, Promise<unknown>, string];
+   5 |         arrayOrPromiseTuple;
+     |         ^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `number[] | [number, number, Promise<unknown>, string]`.
    6 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-73 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (3:9 - 3:30)
+Diagnostic 1: floatingPromiseArrayVoid (3:9 - 3:29)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    2 |         declare const okArrayOrPromiseArray: Array<number> | Array<Promise<unknown>>;
    3 |         okArrayOrPromiseArray;
-     |         ~~~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+  Label: This array contains Promises and has type `number[] | Promise<unknown>[]`. (3:9 - 3:29)
+   2 |         declare const okArrayOrPromiseArray: Array<number> | Array<Promise<unknown>>;
+   3 |         okArrayOrPromiseArray;
+     |         ^^^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `number[] | Promise<unknown>[]`.
    4 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-74 - 1]
-Diagnostic 1: floatingVoid (15:1 - 15:8)
+Diagnostic 1: floatingVoid (15:1 - 15:7)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
   14 | let promise: UnsafeThenable<number> = Promise.resolve(5);
   15 | promise;
-     | ~~~~~~~~
+     | ~~~~~~~
+  16 |       
+  Label: This unhandled promise-like value has type `UnsafeThenable<number>`. (15:1 - 15:7)
+  14 | let promise: UnsafeThenable<number> = Promise.resolve(5);
+  15 | promise;
+     | ^^^^^^^ This unhandled promise-like value has type `UnsafeThenable<number>`.
   16 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-75 - 1]
-Diagnostic 1: floatingVoid (4:1 - 4:16)
+Diagnostic 1: floatingVoid (4:1 - 4:15)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | let promise: SafePromise<number> = Promise.resolve(5);
    4 | promise.catch();
-     | ~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<number>`. (4:1 - 4:15)
+   3 | let promise: SafePromise<number> = Promise.resolve(5);
+   4 | promise.catch();
+     | ^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-76 - 1]
-Diagnostic 1: floatingVoid (4:1 - 4:20)
+Diagnostic 1: floatingVoid (4:1 - 4:19)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | let promise: () => UnsafePromise<number> = async () => 5;
    4 | promise().finally();
-     | ~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<number>`. (4:1 - 4:19)
+   3 | let promise: () => UnsafePromise<number> = async () => 5;
+   4 | promise().finally();
+     | ^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-77 - 1]
-Diagnostic 1: floatingVoid (4:1 - 4:24)
+Diagnostic 1: floatingVoid (4:5 - 4:19)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | let promise: UnsafePromise = Promise.resolve(5);
    4 | 0 ? promise.catch() : 2;
-     | ~~~~~~~~~~~~~~~~~~~~~~~~
+     |     ~~~~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<number>`. (4:5 - 4:19)
+   3 | let promise: UnsafePromise = Promise.resolve(5);
+   4 | 0 ? promise.catch() : 2;
+     |     ^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-78 - 1]
-Diagnostic 1: floatingVoid (4:1 - 4:26)
+Diagnostic 1: floatingVoid (4:9 - 4:25)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | let promise: () => UnsafePromise = async () => 5;
    4 | null ?? promise().catch();
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<number>`. (4:9 - 4:25)
+   3 | let promise: () => UnsafePromise = async () => 5;
+   4 | null ?? promise().catch();
+     |         ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-79 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (4:1 - 4:20)
+Diagnostic 1: floatingPromiseArrayVoid (4:1 - 4:19)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    3 | declare const arrayOrPromiseTuple: Foo<unknown>[];
    4 | arrayOrPromiseTuple;
-     | ~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~
+   5 |       
+  Label: This array contains Promises and has type `Foo<unknown>[]`. (4:1 - 4:19)
+   3 | declare const arrayOrPromiseTuple: Foo<unknown>[];
+   4 | arrayOrPromiseTuple;
+     | ^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `Foo<unknown>[]`.
    5 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-80 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (5:1 - 5:4)
+Diagnostic 1: floatingPromiseArrayVoid (5:1 - 5:3)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    4 | let bar = [Promise.resolve(2), foo];
    5 | bar;
-     | ~~~~
+     | ~~~
+   6 |       
+  Label: This array contains Promises and has type `Promise<number>[]`. (5:1 - 5:3)
+   4 | let bar = [Promise.resolve(2), foo];
+   5 | bar;
+     | ^^^ This array contains Promises and has type `Promise<number>[]`.
    6 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-81 - 1]
-Diagnostic 1: floatingPromiseArrayVoid (4:1 - 4:20)
+Diagnostic 1: floatingPromiseArrayVoid (4:1 - 4:19)
 Message: An array of Promises may be unintentional.
 Help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.
    3 | declare const arrayOrPromiseTuple: [Foo<unknown>, 5];
    4 | arrayOrPromiseTuple;
-     | ~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~
+   5 |       
+  Label: This array contains Promises and has type `[Foo<unknown>, 5]`. (4:1 - 4:19)
+   3 | declare const arrayOrPromiseTuple: [Foo<unknown>, 5];
+   4 | arrayOrPromiseTuple;
+     | ^^^^^^^^^^^^^^^^^^^ This array contains Promises and has type `[Foo<unknown>, 5]`.
    5 |       
 ---
 
 [TestNoFloatingPromisesRule/invalid-82 - 1]
-Diagnostic 1: floatingVoid (4:1 - 4:11)
+Diagnostic 1: floatingVoid (4:1 - 4:10)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | declare const myTag: (strings: TemplateStringsArray) => SafePromise;
    4 | myTag`abc`;
-     | ~~~~~~~~~~~
+     | ~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `SafePromise`. (4:1 - 4:10)
+   3 | declare const myTag: (strings: TemplateStringsArray) => SafePromise;
+   4 | myTag`abc`;
+     | ^^^^^^^^^^ This unhandled promise-like value has type `SafePromise`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-83 - 1]
-Diagnostic 1: floatingVoid (4:9 - 4:32)
+Diagnostic 1: floatingVoid (4:9 - 4:31)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | 
    4 |         unsafe('...', () => {});
-     |         ~~~~~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~~~~~~~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:9 - 4:31)
+   3 | 
+   4 |         unsafe('...', () => {});
+     |         ^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-84 - 1]
-Diagnostic 1: floatingVoid (4:9 - 4:43)
+Diagnostic 1: floatingVoid (4:9 - 4:42)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | 
    4 |         it('...', () => {}).then(() => {});
-     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:9 - 4:42)
+   3 | 
+   4 |         it('...', () => {}).then(() => {});
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-85 - 1]
-Diagnostic 1: floatingVoid (4:9 - 4:46)
+Diagnostic 1: floatingVoid (4:9 - 4:45)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | 
    4 |         it('...', () => {}).finally(() => {});
-     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (4:9 - 4:45)
+   3 | 
+   4 |         it('...', () => {}).finally(() => {});
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-86 - 1]
-Diagnostic 1: floatingVoid (3:1 - 3:16)
+Diagnostic 1: floatingVoid (3:1 - 3:15)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | declare const createPromise: () => PromiseLike<number>;
    3 | createPromise();
-     | ~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~
+   4 |       
+  Label: This unhandled promise-like value has type `PromiseLike<number>`. (3:1 - 3:15)
+   2 | declare const createPromise: () => PromiseLike<number>;
+   3 | createPromise();
+     | ^^^^^^^^^^^^^^^ This unhandled promise-like value has type `PromiseLike<number>`.
    4 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-87 - 1]
-Diagnostic 1: floatingVoid (8:1 - 8:19)
+Diagnostic 1: floatingVoid (8:1 - 8:18)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    7 | 
    8 | createMyThenable();
-     | ~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~
+   9 |       
+  Label: This unhandled promise-like value has type `MyThenable`. (8:1 - 8:18)
+   7 | 
+   8 | createMyThenable();
+     | ^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `MyThenable`.
    9 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-88 - 1]
-Diagnostic 1: floatingVoid (3:1 - 3:16)
+Diagnostic 1: floatingVoid (3:1 - 3:15)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | declare const createPromise: () => Promise<number>;
    3 | createPromise();
-     | ~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~
+   4 |       
+  Label: This unhandled promise-like value has type `Promise<number>`. (3:1 - 3:15)
+   2 | declare const createPromise: () => Promise<number>;
+   3 | createPromise();
+     | ^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    4 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-89 - 1]
-Diagnostic 1: floatingVoid (4:1 - 4:18)
+Diagnostic 1: floatingVoid (4:1 - 4:17)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | declare const createMyPromise: () => MyPromise<number>;
    4 | createMyPromise();
-     | ~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~
+   5 |       
+  Label: This unhandled promise-like value has type `MyPromise<number>`. (4:1 - 4:17)
+   3 | declare const createMyPromise: () => MyPromise<number>;
+   4 | createMyPromise();
+     | ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `MyPromise<number>`.
    5 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-90 - 1]
-Diagnostic 1: floatingVoid (6:1 - 6:18)
+Diagnostic 1: floatingVoid (6:1 - 6:17)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    5 | declare const createMyPromise: () => MyPromise<number>;
    6 | createMyPromise();
-     | ~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~
+   7 |       
+  Label: This unhandled promise-like value has type `MyPromise<number>`. (6:1 - 6:17)
+   5 | declare const createMyPromise: () => MyPromise<number>;
+   6 | createMyPromise();
+     | ^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `MyPromise<number>`.
    7 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-91 - 1]
-Diagnostic 1: floatingVoid (4:3 - 4:10)
+Diagnostic 1: floatingVoid (4:3 - 4:9)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | function* generator(): Generator<number, void, Promise<number>> {
    4 |   yield x;
-     |   ~~~~~~~~
+     |   ~~~~~~~
+   5 | }
+  Label: This unhandled promise-like value has type `Promise<number>`. (4:3 - 4:9)
+   3 | function* generator(): Generator<number, void, Promise<number>> {
+   4 |   yield x;
+     |   ^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    5 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-92 - 1]
-Diagnostic 1: floatingVoid (4:3 - 4:11)
+Diagnostic 1: floatingVoid (4:3 - 4:10)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    3 | function* generator(): Generator<number, void, void> {
    4 |   yield* x;
-     |   ~~~~~~~~~
+     |   ~~~~~~~~
+   5 | }
+  Label: This unhandled promise-like value has type `Promise<number>`. (4:3 - 4:10)
+   3 | function* generator(): Generator<number, void, void> {
+   4 |   yield* x;
+     |   ^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    5 | }
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-93 - 1]
-Diagnostic 1: floatingVoid (3:1 - 3:25)
+Diagnostic 1: floatingVoid (3:1 - 3:24)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    2 | const value = {};
    3 | value as Promise<number>;
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |       
+  Label: This unhandled promise-like value has type `Promise<number>`. (3:1 - 3:24)
+   2 | const value = {};
+   3 | value as Promise<number>;
+     | ^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    4 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-94 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:33)
+Diagnostic 1: floatingVoid (2:1 - 2:32)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | ({}) as Promise<number> & number;
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<number> & number`. (2:1 - 2:32)
+   1 | 
+   2 | ({}) as Promise<number> & number;
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number> & number`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-95 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:44)
+Diagnostic 1: floatingVoid (2:1 - 2:43)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | ({}) as Promise<number> & { yolo?: string };
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<number> & { yolo?: string | undefined; }`. (2:1 - 2:43)
+   1 | 
+   2 | ({}) as Promise<number> & { yolo?: string };
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number> & { yolo?: string | undefined; }`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-96 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:20)
+Diagnostic 1: floatingVoid (2:1 - 2:19)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | <Promise<number>>{};
-     | ~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<number>`. (2:1 - 2:19)
+   1 | 
+   2 | <Promise<number>>{};
+     | ^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<number>`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-97 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:29)
+Diagnostic 1: floatingVoid (2:1 - 2:28)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | Promise.reject('foo').then();
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<never>`. (2:1 - 2:28)
+   1 | 
+   2 | Promise.reject('foo').then();
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-98 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:32)
+Diagnostic 1: floatingVoid (2:1 - 2:31)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | Promise.reject('foo').finally();
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<never>`. (2:1 - 2:31)
+   1 | 
+   2 | Promise.reject('foo').finally();
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-99 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:47)
+Diagnostic 1: floatingVoid (2:1 - 2:46)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | Promise.reject('foo').finally(...[], () => {});
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<never>`. (2:1 - 2:46)
+   1 | 
+   2 | Promise.reject('foo').finally(...[], () => {});
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.
 ---
 
 [TestNoFloatingPromisesRule/invalid-100 - 1]
-Diagnostic 1: floatingVoid (2:1 - 2:44)
+Diagnostic 1: floatingVoid (2:1 - 2:43)
 Message: Promises must be awaited, add void operator to ignore.
 Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
    1 | 
    2 | Promise.reject('foo').then(...[], () => {});
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<void>`. (2:1 - 2:43)
+   1 | 
+   2 | Promise.reject('foo').then(...[], () => {});
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<void>`.
+   3 |       
+  Suggestion 1: [floatingFixVoid] Add void operator to ignore.
+  Suggestion 2: [floatingFixAwait] Add await operator.
+---
+
+[TestNoFloatingPromisesRule/invalid-102 - 1]
+Diagnostic 1: floatingUselessRejectionHandlerVoid (2:1 - 2:51)
+Message: Promises must be awaited, add void operator to ignore.
+Help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator. A rejection handler that is not a function will be ignored.
+   1 | 
+   2 | Promise.reject().catch(undefined).finally(() => {});
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   3 |       
+  Label: This unhandled promise-like value has type `Promise<never>`. (2:1 - 2:51)
+   1 | 
+   2 | Promise.reject().catch(undefined).finally(() => {});
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This unhandled promise-like value has type `Promise<never>`.
+   3 |       
+  Label: This rejection handler has type `undefined`, which is not callable. (2:24 - 2:32)
+   1 | 
+   2 | Promise.reject().catch(undefined).finally(() => {});
+     |                        ^^^^^^^^^ This rejection handler has type `undefined`, which is not callable.
    3 |       
   Suggestion 1: [floatingFixVoid] Add void operator to ignore.
   Suggestion 2: [floatingFixAwait] Add await operator.

--- a/internal/rules/no_floating_promises/no_floating_promises.go
+++ b/internal/rules/no_floating_promises/no_floating_promises.go
@@ -1,6 +1,8 @@
 package no_floating_promises
 
 import (
+	"fmt"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/scanner"
@@ -250,22 +252,17 @@ var NoFloatingPromisesRule = rule.Rule{
 			return !utils.Some(args.Nodes[:index+1], ast.IsSpreadElement)
 		}
 
-		var isUnhandledPromise func(
-			node *ast.Node,
-		) (
-			bool, // isUnhandled
-			bool, // nonFunctionHandler
-			bool, // promiseArray
-		)
-		isUnhandledPromise = func(
-			node *ast.Node,
-		) (
-			bool, // isUnhandled
-			bool, // nonFunctionHandler
-			bool, // promiseArray
-		) {
+		type unhandledPromise struct {
+			node               *ast.Node
+			t                  *checker.Type
+			promiseArray       bool
+			nonFunctionHandler *ast.Node
+		}
+
+		var isUnhandledPromise func(node *ast.Node) *unhandledPromise
+		isUnhandledPromise = func(node *ast.Node) *unhandledPromise {
 			if ast.IsAssignmentExpression(node, false) {
-				return false, false, false
+				return nil
 			}
 
 			// First, check expressions whose resulting types may not be promise-like
@@ -274,9 +271,8 @@ var NoFloatingPromisesRule = rule.Rule{
 				// Any child in a comma expression could return a potentially unhandled
 				// promise, so we check them all regardless of whether the final returned
 				// value is promise-like.
-				isUnhandled, nonFunctionHandler, promiseArray := isUnhandledPromise(expr.Left)
-				if isUnhandled {
-					return isUnhandled, nonFunctionHandler, promiseArray
+				if result := isUnhandledPromise(expr.Left); result != nil {
+					return result
 				}
 				return isUnhandledPromise(expr.Right)
 			}
@@ -292,7 +288,7 @@ var NoFloatingPromisesRule = rule.Rule{
 
 			t := ctx.TypeChecker.GetTypeAtLocation(node)
 			if isPromiseArray(node, t) {
-				return true, false, true
+				return &unhandledPromise{node: node, t: t, promiseArray: true}
 			}
 
 			// await expression addresses promises, but not promise arrays.
@@ -301,11 +297,11 @@ var NoFloatingPromisesRule = rule.Rule{
 				// anyway checking the type of the expression, but, unfortunately TS
 				// reports the result of `await (promise as Promise<number> & number)`
 				// as `Promise<number> & number` instead of `number`.
-				return false, false, false
+				return nil
 			}
 
 			if !isPromiseLike(node, t) {
-				return false, false, false
+				return nil
 			}
 
 			if ast.IsCallExpression(node) {
@@ -322,55 +318,94 @@ var NoFloatingPromisesRule = rule.Rule{
 
 					if methodName == "catch" && len(callExpr.Arguments.Nodes) >= 1 {
 						if !isKnownArgumentAt(callExpr.Arguments, 0) {
-							return true, false, false
+							return &unhandledPromise{node: node, t: t}
 						}
 						if isValidRejectionHandler(callExpr.Arguments.Nodes[0]) {
-							return false, false, false
+							return nil
 						}
-						return true, true, false
+						return &unhandledPromise{
+							node:               node,
+							t:                  t,
+							nonFunctionHandler: callExpr.Arguments.Nodes[0],
+						}
 					}
 					if methodName == "then" && len(callExpr.Arguments.Nodes) >= 2 {
 						if !isKnownArgumentAt(callExpr.Arguments, 1) {
-							return true, false, false
+							return &unhandledPromise{node: node, t: t}
 						}
 						if isValidRejectionHandler(callExpr.Arguments.Nodes[1]) {
-							return false, false, false
+							return nil
 						}
-						return true, true, false
+						return &unhandledPromise{
+							node:               node,
+							t:                  t,
+							nonFunctionHandler: callExpr.Arguments.Nodes[1],
+						}
 					}
 					// `x.finally()` is transparent to resolution of the promise, so check `x`.
 					// ("object" in this context is the `x` in `x.finally()`)
 					if methodName == "finally" {
-						return isUnhandledPromise(callee.Expression())
+						result := isUnhandledPromise(callee.Expression())
+						if result == nil {
+							return nil
+						}
+						result.node = node
+						result.t = t
+						return result
 					}
 				}
 
 				// All other cases are unhandled.
-				return true, false, false
+				return &unhandledPromise{node: node, t: t}
 			}
 
 			if node.Kind == ast.KindConditionalExpression {
 				expr := node.AsConditionalExpression()
 				// We must be getting the promise-like value from one of the branches of the
 				// ternary. Check them directly.
-				isUnhandled, nonFunctionHandler, promiseArray := isUnhandledPromise(expr.WhenFalse)
-				if isUnhandled {
-					return isUnhandled, nonFunctionHandler, promiseArray
+				if result := isUnhandledPromise(expr.WhenFalse); result != nil {
+					return result
 				}
 				return isUnhandledPromise(expr.WhenTrue)
 			}
 
 			if ast.IsLogicalOrCoalescingBinaryExpression(node) {
 				expr := node.AsBinaryExpression()
-				isUnhandled, nonFunctionHandler, promiseArray := isUnhandledPromise(expr.Left)
-				if isUnhandled {
-					return isUnhandled, nonFunctionHandler, promiseArray
+				if result := isUnhandledPromise(expr.Left); result != nil {
+					return result
 				}
 				return isUnhandledPromise(expr.Right)
 			}
 
 			// Anything else is unhandled.
-			return true, false, false
+			return &unhandledPromise{node: node, t: t}
+		}
+
+		buildDiagnostic := func(result *unhandledPromise, msg rule.RuleMessage) rule.RuleDiagnostic {
+			diagnosticRange := utils.TrimNodeTextRange(ctx.SourceFile, result.node)
+			typeDescription := "This unhandled promise-like value"
+			if result.promiseArray {
+				typeDescription = "This array contains Promises and"
+			}
+			labels := []rule.RuleLabeledRange{{
+				Label: fmt.Sprintf("%s has type `%s`.", typeDescription, ctx.TypeChecker.TypeToString(result.t)),
+				Range: diagnosticRange,
+			}}
+			if result.nonFunctionHandler != nil {
+				handlerType := ctx.TypeChecker.GetTypeAtLocation(result.nonFunctionHandler)
+				labels = append(labels, rule.RuleLabeledRange{
+					Label: fmt.Sprintf(
+						"This rejection handler has type `%s`, which is not callable.",
+						ctx.TypeChecker.TypeToString(handlerType),
+					),
+					Range: utils.TrimNodeTextRange(ctx.SourceFile, result.nonFunctionHandler),
+				})
+			}
+			return rule.RuleDiagnostic{
+				Range:         diagnosticRange,
+				Message:       msg,
+				LabeledRanges: labels,
+			}
 		}
 
 		return rule.RuleListeners{
@@ -387,28 +422,28 @@ var NoFloatingPromisesRule = rule.Rule{
 					return
 				}
 
-				isUnhandled, nonFunctionHandler, promiseArray := isUnhandledPromise(expression)
+				result := isUnhandledPromise(expression)
 
-				if !isUnhandled {
+				if result == nil {
 					return
 				}
-				if promiseArray {
+				if result.promiseArray {
 					var msg rule.RuleMessage
 					if opts.IgnoreVoid {
 						msg = buildFloatingPromiseArrayVoidMessage()
 					} else {
 						msg = buildFloatingPromiseArrayMessage()
 					}
-					ctx.ReportNode(node, msg)
+					ctx.ReportDiagnostic(buildDiagnostic(result, msg))
 				} else if opts.IgnoreVoid {
 					var msg rule.RuleMessage
-					if nonFunctionHandler {
+					if result.nonFunctionHandler != nil {
 						msg = buildFloatingUselessRejectionHandlerVoidMessage()
 					} else {
 						msg = buildFloatingVoidMessage()
 					}
 
-					ctx.ReportNodeWithSuggestions(node, msg, func() []rule.RuleSuggestion {
+					ctx.ReportDiagnosticWithSuggestions(buildDiagnostic(result, msg), func() []rule.RuleSuggestion {
 						return []rule.RuleSuggestion{
 							{
 								Message: buildFloatingFixVoidMessage(),
@@ -430,12 +465,12 @@ var NoFloatingPromisesRule = rule.Rule{
 					})
 				} else {
 					var msg rule.RuleMessage
-					if nonFunctionHandler {
+					if result.nonFunctionHandler != nil {
 						msg = buildFloatingUselessRejectionHandlerMessage()
 					} else {
 						msg = buildFloatingMessage()
 					}
-					ctx.ReportNodeWithSuggestions(node, msg, func() []rule.RuleSuggestion {
+					ctx.ReportDiagnosticWithSuggestions(buildDiagnostic(result, msg), func() []rule.RuleSuggestion {
 						return []rule.RuleSuggestion{{
 							Message:  buildFloatingFixAwaitMessage(),
 							FixesArr: addAwait(expression, exprStatement),

--- a/internal/rules/no_floating_promises/no_floating_promises_test.go
+++ b/internal/rules/no_floating_promises/no_floating_promises_test.go
@@ -1922,6 +1922,9 @@ async function test() {
 				{
 					MessageId: "floatingVoid",
 					Line:      3,
+					Column:    25,
+					EndLine:   3,
+					EndColumn: 42,
 					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 						{
 							MessageId: "floatingFixVoid",
@@ -1946,6 +1949,9 @@ async function test() {
 				{
 					MessageId: "floatingVoid",
 					Line:      4,
+					Column:    32,
+					EndLine:   4,
+					EndColumn: 49,
 					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 						{
 							MessageId: "floatingFixVoid",
@@ -1981,6 +1987,9 @@ async function test() {
 				{
 					MessageId: "floatingVoid",
 					Line:      3,
+					Column:    4,
+					EndLine:   3,
+					EndColumn: 21,
 					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 						{
 							MessageId: "floatingFixVoid",
@@ -2007,6 +2016,9 @@ async function test() {
 				{
 					MessageId: "floatingVoid",
 					Line:      4,
+					Column:    9,
+					EndLine:   4,
+					EndColumn: 26,
 					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 						{
 							MessageId: "floatingFixVoid",
@@ -2033,6 +2045,9 @@ async function test() {
 				{
 					MessageId: "floatingVoid",
 					Line:      5,
+					Column:    9,
+					EndLine:   5,
+					EndColumn: 26,
 					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 						{
 							MessageId: "floatingFixVoid",
@@ -2069,6 +2084,9 @@ async function test() {
 				{
 					MessageId: "floating",
 					Line:      3,
+					Column:    8,
+					EndLine:   3,
+					EndColumn: 25,
 					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 						{
 							MessageId: "floatingFixAwait",
@@ -3681,6 +3699,9 @@ Promise.resolve().catch(definitelyCallable);
 				{
 					MessageId: "floatingUselessRejectionHandlerVoid",
 					Line:      4,
+					Column:    1,
+					EndLine:   4,
+					EndColumn: 44,
 					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 						{
 							MessageId: "floatingFixVoid",
@@ -4323,6 +4344,9 @@ Promise.reject().finally(() => {});
 				{
 					MessageId: "floatingVoid",
 					Line:      2,
+					Column:    1,
+					EndLine:   2,
+					EndColumn: 35,
 					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 						{
 							MessageId: "floatingFixVoid",
@@ -5683,6 +5707,32 @@ await Promise.reject('foo').then(...[], () => {});
 					},
 				},
 			},
+		},
+		{
+			Code: `
+Promise.reject().catch(undefined).finally(() => {});
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "floatingUselessRejectionHandlerVoid",
+				Line:      2,
+				Column:    1,
+				EndLine:   2,
+				EndColumn: 52,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{
+						MessageId: "floatingFixVoid",
+						Output: `
+void Promise.reject().catch(undefined).finally(() => {});
+      `,
+					},
+					{
+						MessageId: "floatingFixAwait",
+						Output: `
+await Promise.reject().catch(undefined).finally(() => {});
+      `,
+					},
+				},
+			}},
 		},
 	})
 }


### PR DESCRIPTION
Part of #677.

Improves no-floating-promises diagnostics by:
- retaining and reporting the exact unhandled promise subexpression
- narrowing ranges through comma, ternary, logical, void, and finally expressions
- labeling promise and promise-array expressions with their rendered types
- labeling non-callable rejection handlers
- preserving existing options, messages, fixes, and suggestions

Test: go test ./internal/rules/no_floating_promises