### PR TITLE
ci: use pnpm publish and drop global npm install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,11 @@ jobs:
           TSGOLINT_VERSION: ${{ inputs.version }}
         run: node ./tools/gen-npm-packages.mjs
 
-      - run: npm install -g npm@latest # For trusted publishing support
-
       - name: Publish
         run: |
           for package in npm/*; do
             pushd "$package"
-            npm publish --provenance --access public
+            pnpm publish --provenance --access public
             popd
           done
 


### PR DESCRIPTION
Removes the `npm install -g npm@latest` step and switches the publish command to `pnpm publish`.

That global npm install only existed to get a recent npm for trusted publishing (OIDC provenance). With `pnpm publish` handling the publish, the globally-installed npm version is irrelevant, so the step is dropped.