### PR TITLE
fix(no-unnecessary-type-assertion): preserve type-changing assertions

### DIFF
--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -356,11 +356,26 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			return false
 		}
 
+		isElementAccessArgument := func(node *ast.Node) bool {
+			current := node
+			parent := current.Parent
+			for parent != nil && ast.IsParenthesizedExpression(parent) {
+				current = parent
+				parent = parent.Parent
+			}
+			return parent != nil &&
+				ast.IsElementAccessExpression(parent) &&
+				parent.AsElementAccessExpression().ArgumentExpression == current
+		}
+
 		isTypeUnchanged := func(node *ast.Node, expression *ast.Node, uncast, cast *checker.Type) bool {
 			if uncast == cast {
 				return true
 			}
 			if utils.IsTypeParameter(uncast) && isReceiverOfWriteAccess(node) {
+				return false
+			}
+			if compilerOptions.NoUncheckedIndexedAccess.IsTrue() && isElementAccessArgument(node) {
 				return false
 			}
 
@@ -376,7 +391,7 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			}
 
 			if (utils.IsTypeFlagSet(uncast, checker.TypeFlagsNonPrimitive) && !utils.IsTypeFlagSet(cast, checker.TypeFlagsNonPrimitive)) ||
-				(hasIndexSignature(uncast) && !hasIndexSignature(cast)) ||
+				(hasIndexSignature(uncast) != hasIndexSignature(cast)) ||
 				containsAny(uncast) ||
 				containsAny(cast) ||
 				(containsTypeVariable(cast) && !containsTypeVariable(uncast)) {
@@ -805,7 +820,9 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			}
 			objectParent := objectExpr.Parent
 			return objectParent != nil &&
-				(ast.IsSatisfiesExpression(objectParent) ||
+				(ast.IsAsExpression(objectParent) ||
+					ast.IsTypeAssertion(objectParent) ||
+					ast.IsSatisfiesExpression(objectParent) ||
 					(ast.IsCallExpression(objectParent) && objectParent.Parent != nil && ast.IsSatisfiesExpression(objectParent.Parent)))
 		}
 
@@ -906,6 +923,23 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			return false
 		}
 
+		isPropertyInInferredCallbackReturn := func(node *ast.Node) bool {
+			parent := node.Parent
+			if parent == nil || !ast.IsPropertyAssignment(parent) || parent.Initializer() != node {
+				return false
+			}
+			objectExpr := parent.Parent
+			if objectExpr == nil || !ast.IsObjectLiteralExpression(objectExpr) {
+				return false
+			}
+
+			callback := parentThroughParens(objectExpr)
+			return callback != nil &&
+				ast.IsArrowFunction(callback) &&
+				ast.SkipParentheses(callback.Body()) == objectExpr &&
+				isInGenericContext(node)
+		}
+
 		skipParentTypeForContextualAny := func(node *ast.Node) bool {
 			parent := parentThroughParens(node)
 			return parent != nil &&
@@ -919,7 +953,9 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 		shouldSkipContextualTypeFallback := func(node *ast.Node, castIsAny bool) bool {
 			parent := parentThroughParens(node)
 			if castIsAny {
-				return (parent != nil && ast.IsLogicalExpression(parent)) || isInGenericContext(node)
+				return (parent != nil && ast.IsLogicalExpression(parent)) ||
+					isInGenericContext(node) ||
+					isPropertyInProblematicContext(node)
 			}
 
 			if skipParentTypeForContextualAny(node) ||
@@ -927,6 +963,7 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 				isNestedInArrayLiteralArgumentToGenericCall(node) ||
 				isInDestructuringDeclaration(node) ||
 				isPropertyInProblematicContext(node) ||
+				isPropertyInInferredCallbackReturn(node) ||
 				isAssignmentInNonStatementContext(node) ||
 				isRightHandSideOfLogicalAssignment(node) ||
 				isArgumentToOverloadedFunction(node) {

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
@@ -1225,6 +1225,101 @@ export const deepAssign = <
 };
     `,
 		},
+		{
+			// https://github.com/oxc-project/tsgolint/issues/1094
+			Code: `
+type AccountId = string & { __brand: 'AccountId' };
+
+interface Req {
+  params: Record<string, string>;
+  query: Record<string, string>;
+  method: string;
+}
+
+declare const accountId: AccountId;
+
+export const req = {
+  params: { id: accountId } as any,
+  query: {},
+} as Req;
+    `,
+		},
+		{
+			Code: `
+enum Lang {
+  EN = 'en-US',
+  SV = 'sv-SE',
+}
+
+const LANGUAGE_NAMES: Record<Lang, string> = {
+  [Lang.EN]: 'English',
+  [Lang.SV]: 'Svenska',
+};
+
+export const options = Object.values(Lang)
+  .map(lang => ({
+    label: LANGUAGE_NAMES[lang],
+    value: lang as string,
+  }))
+  .concat([{ label: 'български език', value: 'bg-BG' }]);
+    `,
+		},
+		{
+			Code: `
+type AnyObject = Record<string, any>;
+
+declare function isEditArray(item: unknown): item is { type: string }[];
+
+export function getEdits(bucket: { data: unknown }): { type: string }[] {
+  const { data } = bucket;
+  if (!data) return [];
+
+  const { edits } = data as AnyObject;
+
+  if (!isEditArray(edits)) return [];
+  return edits;
+}
+    `,
+		},
+		{
+			Code: `
+enum AppTracker {
+  MOOD = 1,
+  ENERGY = 2,
+}
+
+export function categoryFor(tracker: string): string {
+  return AppTracker[Number(tracker) as AppTracker];
+}
+    `,
+			TSConfig: "./tsconfig.noUncheckedIndexedAccess.json",
+		},
+		{
+			Code: `
+enum GuideId {
+  MEASURE = 'measure',
+}
+
+interface Guide {
+  id: GuideId;
+  title: string;
+  thumbnailUrl: string;
+}
+
+interface GlossaryItem {
+  id: string;
+  title: string;
+}
+
+export const item: { content: Guide | GlossaryItem } = {
+  content: {
+    id: 'how-to-measure' as any,
+    title: 'How to measure',
+    thumbnailUrl: 'https://example.com/thumb.jpg',
+  },
+};
+    `,
+		},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code:   "const foo = <3>3;",


### PR DESCRIPTION
## Summary

- preserve assertions whose removal changes enclosing object-literal, union, or generic callback inference
- treat index-signature changes and indexed-access key narrowing under `noUncheckedIndexedAccess` as semantically meaningful
- cover all five unsafe autofix patterns reported in the issue

Fixes #1094