### PR TITLE
fix(ci): disable pnpm git checks for generated release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           for package in npm/*; do
             pushd "$package"
-            pnpm publish --provenance --access public
+            pnpm publish --no-git-checks --provenance --access public
             popd
           done
 


### PR DESCRIPTION
The release workflow generates package manifests and downloads binaries into the working tree before publishing. Since PR #1095 switched from npm publish to pnpm publish, pnpm's default Git cleanliness check rejects these expected untracked release artifacts.

Pass --no-git-checks to pnpm publish so the generated packages can be published while retaining provenance and public access.

Fixes the publish failure in https://github.com/oxc-project/tsgolint/actions/runs/29832181709/job/88640788258