### PR TITLE
fix(release): preserve binary executable permissions

### DIFF
--- a/tools/gen-npm-packages.mjs
+++ b/tools/gen-npm-packages.mjs
@@ -67,6 +67,10 @@ await Promise.all([
           JSON.stringify(
             {
               ...commonPackageJson,
+              publishConfig: {
+                ...commonPackageJson.publishConfig,
+                executableFiles: [binaryName],
+              },
               name: npmPackageName,
               preferUnplugged: true,
               files: [binaryName],


### PR DESCRIPTION
pnpm normalizes packaged files that are not declared as binaries to mode 0644. This caused the Linux tsgolint binary in 7.0.2000 to lose its executable bit and fail with EACCES when consumed by Oxc.

Add each platform binary to publishConfig.executableFiles in the generated package manifest. A local generator and pnpm pack check confirms the Linux tar entry is emitted as 0755.