### PR TITLE
feat(no-unsafe-assignment): improve diagnostics

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -496,13 +496,29 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-confusing-void-expression/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Assigned value has type \`error\`.",
+        "range": {
+          "end": 215,
+          "pos": 185,
+        },
+      },
+      {
+        "label": "Target is inferred as \`error\`.",
+        "range": {
+          "end": 182,
+          "pos": 176,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assignment of an error typed value.",
       "id": "anyAssignment",
     },
     "range": {
-      "end": 215,
-      "pos": 176,
+      "end": 184,
+      "pos": 183,
     },
     "rule": "no-unsafe-assignment",
   },
@@ -2108,52 +2124,116 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unsafe-assignment/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Assigned value has type \`any\`.",
+        "range": {
+          "end": 119,
+          "pos": 111,
+        },
+      },
+      {
+        "label": "Target expects type \`string\`.",
+        "range": {
+          "end": 108,
+          "pos": 102,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assignment of an any value.",
       "id": "anyAssignment",
     },
     "range": {
-      "end": 119,
-      "pos": 97,
+      "end": 110,
+      "pos": 109,
     },
     "rule": "no-unsafe-assignment",
   },
   {
     "file_path": "fixtures/basic/rules/no-unsafe-assignment/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Assigned value has type \`any\`.",
+        "range": {
+          "end": 174,
+          "pos": 166,
+        },
+      },
+      {
+        "label": "Target expects type \`number\`.",
+        "range": {
+          "end": 163,
+          "pos": 160,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assignment of an any value.",
       "id": "anyAssignment",
     },
     "range": {
-      "end": 174,
-      "pos": 160,
+      "end": 165,
+      "pos": 164,
     },
     "rule": "no-unsafe-assignment",
   },
   {
     "file_path": "fixtures/basic/rules/no-unsafe-assignment/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Assigned value has type \`any\`.",
+        "range": {
+          "end": 235,
+          "pos": 220,
+        },
+      },
+      {
+        "label": "Target expects type \`any\`.",
+        "range": {
+          "end": 218,
+          "pos": 214,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assignment of an any value.",
       "id": "anyAssignment",
     },
     "range": {
-      "end": 235,
-      "pos": 214,
+      "end": 219,
+      "pos": 218,
     },
     "rule": "no-unsafe-assignment",
   },
   {
     "file_path": "fixtures/basic/rules/no-unsafe-call/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Assigned value has type \`any\`.",
+        "range": {
+          "end": 180,
+          "pos": 163,
+        },
+      },
+      {
+        "label": "Target is inferred as \`any\`.",
+        "range": {
+          "end": 160,
+          "pos": 154,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assignment of an any value.",
       "id": "anyAssignment",
     },
     "range": {
-      "end": 180,
-      "pos": 154,
+      "end": 162,
+      "pos": 161,
     },
     "rule": "no-unsafe-assignment",
   },
@@ -2352,13 +2432,29 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unsafe-member-access/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Assigned value has type \`any\`.",
+        "range": {
+          "end": 266,
+          "pos": 249,
+        },
+      },
+      {
+        "label": "Target is inferred as \`any\`.",
+        "range": {
+          "end": 246,
+          "pos": 240,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assignment of an any value.",
       "id": "anyAssignment",
     },
     "range": {
-      "end": 266,
-      "pos": 240,
+      "end": 248,
+      "pos": 247,
     },
     "rule": "no-unsafe-assignment",
   },
@@ -2469,26 +2565,58 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unsafe-type-assertion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Assigned value has type \`any\`.",
+        "range": {
+          "end": 120,
+          "pos": 108,
+        },
+      },
+      {
+        "label": "Target is inferred as \`any\`.",
+        "range": {
+          "end": 105,
+          "pos": 102,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assignment of an any value.",
       "id": "anyAssignment",
     },
     "range": {
-      "end": 120,
-      "pos": 102,
+      "end": 107,
+      "pos": 106,
     },
     "rule": "no-unsafe-assignment",
   },
   {
     "file_path": "fixtures/basic/rules/no-unsafe-type-assertion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Assigned value has type \`any\`.",
+        "range": {
+          "end": 289,
+          "pos": 277,
+        },
+      },
+      {
+        "label": "Target is inferred as \`any\`.",
+        "range": {
+          "end": 274,
+          "pos": 265,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assignment of an any value.",
       "id": "anyAssignment",
     },
     "range": {
-      "end": 289,
-      "pos": 265,
+      "end": 276,
+      "pos": 275,
     },
     "rule": "no-unsafe-assignment",
   },
@@ -3643,13 +3771,29 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/restrict-plus-operands/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Assigned value has type \`any\`.",
+        "range": {
+          "end": 16,
+          "pos": 10,
+        },
+      },
+      {
+        "label": "Target is inferred as \`any\`.",
+        "range": {
+          "end": 7,
+          "pos": 4,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assignment of an any value.",
       "id": "anyAssignment",
     },
     "range": {
-      "end": 16,
-      "pos": 4,
+      "end": 9,
+      "pos": 8,
     },
     "rule": "no-unsafe-assignment",
   },

--- a/internal/rule_tester/__snapshots__/no-unsafe-assignment.snap
+++ b/internal/rule_tester/__snapshots__/no-unsafe-assignment.snap
@@ -1,60 +1,122 @@
 
 [TestNoUnsafeAssignmentRule/invalid-0 - 1]
-Diagnostic 1: anyAssignment (1:7 - 1:18)
+Diagnostic 1: anyAssignment (1:9 - 1:9)
 Message: Unsafe assignment of an any value.
    1 | const x = 1 as any;
-     |       ~~~~~~~~~~~~
+     |         ~
+  Label: Assigned value has type `any`. (1:11 - 1:18)
+   1 | const x = 1 as any;
+     |           ^^^^^^^^ Assigned value has type `any`.
+  Label: Target is inferred as `any`. (1:7 - 1:7)
+   1 | const x = 1 as any;
+     |       ^ Target is inferred as `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-1 - 1]
-Diagnostic 1: anyAssignment (2:7 - 2:18)
+Diagnostic 1: anyAssignment (2:9 - 2:9)
 Message: Unsafe assignment of an any value.
    1 | 
    2 | const x = 1 as any,
-     |       ~~~~~~~~~~~~
+     |         ~
+   3 |   y = 1;
+  Label: Assigned value has type `any`. (2:11 - 2:18)
+   1 | 
+   2 | const x = 1 as any,
+     |           ^^^^^^^^ Assigned value has type `any`.
+   3 |   y = 1;
+  Label: Target is inferred as `any`. (2:7 - 2:7)
+   1 | 
+   2 | const x = 1 as any,
+     |       ^ Target is inferred as `any`.
    3 |   y = 1;
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-2 - 1]
-Diagnostic 1: anyAssignment (1:14 - 1:25)
+Diagnostic 1: anyAssignment (1:16 - 1:16)
 Message: Unsafe assignment of an any value.
    1 | function foo(a = 1 as any) {}
-     |              ~~~~~~~~~~~~
+     |                ~
+  Label: Assigned value has type `any`. (1:18 - 1:25)
+   1 | function foo(a = 1 as any) {}
+     |                  ^^^^^^^^ Assigned value has type `any`.
+  Label: Target expects type `any`. (1:14 - 1:14)
+   1 | function foo(a = 1 as any) {}
+     |              ^ Target expects type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-3 - 1]
-Diagnostic 1: anyAssignment (3:15 - 3:34)
+Diagnostic 1: anyAssignment (3:25 - 3:25)
 Message: Unsafe assignment of an any value.
    2 | class Foo {
    3 |   constructor(private a = 1 as any) {}
-     |               ~~~~~~~~~~~~~~~~~~~~
+     |                         ~
+   4 | }
+  Label: Assigned value has type `any`. (3:27 - 3:34)
+   2 | class Foo {
+   3 |   constructor(private a = 1 as any) {}
+     |                           ^^^^^^^^ Assigned value has type `any`.
+   4 | }
+  Label: Target expects type `any`. (3:23 - 3:23)
+   2 | class Foo {
+   3 |   constructor(private a = 1 as any) {}
+     |                       ^ Target expects type `any`.
    4 | }
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-4 - 1]
-Diagnostic 1: anyAssignment (3:3 - 3:23)
+Diagnostic 1: anyAssignment (3:13 - 3:13)
 Message: Unsafe assignment of an any value.
    2 | class Foo {
    3 |   private a = 1 as any;
-     |   ~~~~~~~~~~~~~~~~~~~~~
+     |             ~
+   4 | }
+  Label: Assigned value has type `any`. (3:15 - 3:22)
+   2 | class Foo {
+   3 |   private a = 1 as any;
+     |               ^^^^^^^^ Assigned value has type `any`.
+   4 | }
+  Label: Target is inferred as `any`. (3:11 - 3:11)
+   2 | class Foo {
+   3 |   private a = 1 as any;
+     |           ^ Target is inferred as `any`.
    4 | }
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-5 - 1]
-Diagnostic 1: anyAssignment (3:3 - 3:24)
+Diagnostic 1: anyAssignment (3:14 - 3:14)
 Message: Unsafe assignment of an any value.
    2 | class Foo {
    3 |   accessor a = 1 as any;
-     |   ~~~~~~~~~~~~~~~~~~~~~~
+     |              ~
+   4 | }
+  Label: Assigned value has type `any`. (3:16 - 3:23)
+   2 | class Foo {
+   3 |   accessor a = 1 as any;
+     |                ^^^^^^^^ Assigned value has type `any`.
+   4 | }
+  Label: Target is inferred as `any`. (3:12 - 3:12)
+   2 | class Foo {
+   3 |   accessor a = 1 as any;
+     |            ^ Target is inferred as `any`.
    4 | }
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-6 - 1]
-Diagnostic 1: anyAssignment (2:7 - 2:18)
+Diagnostic 1: anyAssignment (2:11 - 2:11)
 Message: Unsafe assignment of an error typed value.
    1 | 
    2 | const [x] = spooky;
-     |       ~~~~~~~~~~~~
+     |           ~
+   3 |       
+  Label: Assigned value has type `error`. (2:13 - 2:18)
+   1 | 
+   2 | const [x] = spooky;
+     |             ^^^^^^ Assigned value has type `error`.
+   3 |       
+  Label: Target is inferred as `error`. (2:7 - 2:9)
+   1 | 
+   2 | const [x] = spooky;
+     |       ^^^ Target is inferred as `error`.
    3 |       
 ---
 
@@ -65,6 +127,16 @@ Message: Unsafe array destructuring of a tuple element with an error typed value
    2 | const [[[x]]] = [spooky];
      |        ~~~~~
    3 |       
+  Label: Destructured source provides type `error`. (2:17 - 2:24)
+   1 | 
+   2 | const [[[x]]] = [spooky];
+     |                 ^^^^^^^^ Destructured source provides type `error`.
+   3 |       
+  Label: This binding receives type `error`. (2:8 - 2:12)
+   1 | 
+   2 | const [[[x]]] = [spooky];
+     |        ^^^^^ This binding receives type `error`.
+   3 |       
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-8 - 1]
@@ -74,30 +146,70 @@ Message: Unsafe array destructuring of a tuple element with an error typed value
    3 |   x: { y: z },
      |      ~~~~~~~~
    4 | } = { x: spooky };
+  Label: Destructured source provides type `error`. (4:5 - 4:17)
+   3 |   x: { y: z },
+   4 | } = { x: spooky };
+     |     ^^^^^^^^^^^^^ Destructured source provides type `error`.
+   5 |       
+  Label: This binding receives type `error`. (3:6 - 3:13)
+   2 | const {
+   3 |   x: { y: z },
+     |      ^^^^^^^^ This binding receives type `error`.
+   4 | } = { x: spooky };
 
-Diagnostic 2: anyAssignment (4:7 - 4:15)
+Diagnostic 2: anyAssignment (4:8 - 4:8)
 Message: Unsafe assignment of an error typed value.
    3 |   x: { y: z },
    4 | } = { x: spooky };
-     |       ~~~~~~~~~
+     |        ~
+   5 |       
+  Label: Assigned value has type `error`. (4:10 - 4:15)
+   3 |   x: { y: z },
+   4 | } = { x: spooky };
+     |          ^^^^^^ Assigned value has type `error`.
+   5 |       
+  Label: Target expects type `{ y: any; }`. (4:7 - 4:7)
+   3 |   x: { y: z },
+   4 | } = { x: spooky };
+     |       ^ Target expects type `{ y: any; }`.
    5 |       
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-9 - 1]
-Diagnostic 1: anyAssignment (4:1 - 4:14)
+Diagnostic 1: anyAssignment (4:7 - 4:7)
 Message: Unsafe assignment of an error typed value.
    3 | 
    4 | value = spooky;
-     | ~~~~~~~~~~~~~~
+     |       ~
+   5 |       
+  Label: Assigned value has type `error`. (4:9 - 4:14)
+   3 | 
+   4 | value = spooky;
+     |         ^^^^^^ Assigned value has type `error`.
+   5 |       
+  Label: Target expects type `number`. (4:1 - 4:5)
+   3 | 
+   4 | value = spooky;
+     | ^^^^^ Target expects type `number`.
    5 |       
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-10 - 1]
-Diagnostic 1: anyAssignment (2:7 - 2:20)
+Diagnostic 1: anyAssignment (2:11 - 2:11)
 Message: Unsafe assignment of an any value.
    1 | 
    2 | const [x] = 1 as any;
-     |       ~~~~~~~~~~~~~~
+     |           ~
+   3 |       
+  Label: Assigned value has type `any`. (2:13 - 2:20)
+   1 | 
+   2 | const [x] = 1 as any;
+     |             ^^^^^^^^ Assigned value has type `any`.
+   3 |       
+  Label: Target is inferred as `any`. (2:7 - 2:9)
+   1 | 
+   2 | const [x] = 1 as any;
+     |       ^^^ Target is inferred as `any`.
    3 |       
 ---
 
@@ -108,34 +220,68 @@ Message: Unsafe array destructuring of an any array value.
    2 | const [x] = [] as any[];
      |       ~~~
    3 |       
+  Label: Destructured source provides type `any[]`. (2:13 - 2:23)
+   1 | 
+   2 | const [x] = [] as any[];
+     |             ^^^^^^^^^^^ Destructured source provides type `any[]`.
+   3 |       
+  Label: This binding receives type `any`. (2:7 - 2:9)
+   1 | 
+   2 | const [x] = [] as any[];
+     |       ^^^ This binding receives type `any`.
+   3 |       
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-12 - 1]
-Diagnostic 1: unsafeAssignment (1:7 - 1:37)
-Message: Unsafe assignment of type Set<any> to a variable of type Set<string>.
+Diagnostic 1: unsafeAssignment (1:22 - 1:22)
+Message: Unsafe assignment between incompatible types.
    1 | const x: Set<string> = new Set<any>();
-     |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                      ~
+  Label: Assigned value has type `Set<any>`. (1:24 - 1:37)
+   1 | const x: Set<string> = new Set<any>();
+     |                        ^^^^^^^^^^^^^^ Assigned value has type `Set<any>`.
+  Label: Target expects type `Set<string>`. (1:10 - 1:20)
+   1 | const x: Set<string> = new Set<any>();
+     |          ^^^^^^^^^^^ Target expects type `Set<string>`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-13 - 1]
-Diagnostic 1: unsafeAssignment (1:7 - 1:53)
-Message: Unsafe assignment of type Map<string, any> to a variable of type Map<string, string>.
+Diagnostic 1: unsafeAssignment (1:30 - 1:30)
+Message: Unsafe assignment between incompatible types.
    1 | const x: Map<string, string> = new Map<string, any>();
-     |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                              ~
+  Label: Assigned value has type `Map<string, any>`. (1:32 - 1:53)
+   1 | const x: Map<string, string> = new Map<string, any>();
+     |                                ^^^^^^^^^^^^^^^^^^^^^^ Assigned value has type `Map<string, any>`.
+  Label: Target expects type `Map<string, string>`. (1:10 - 1:28)
+   1 | const x: Map<string, string> = new Map<string, any>();
+     |          ^^^^^^^^^^^^^^^^^^^ Target expects type `Map<string, string>`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-14 - 1]
-Diagnostic 1: unsafeAssignment (1:7 - 1:41)
-Message: Unsafe assignment of type Set<any[]> to a variable of type Set<string[]>.
+Diagnostic 1: unsafeAssignment (1:24 - 1:24)
+Message: Unsafe assignment between incompatible types.
    1 | const x: Set<string[]> = new Set<any[]>();
-     |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                        ~
+  Label: Assigned value has type `Set<any[]>`. (1:26 - 1:41)
+   1 | const x: Set<string[]> = new Set<any[]>();
+     |                          ^^^^^^^^^^^^^^^^ Assigned value has type `Set<any[]>`.
+  Label: Target expects type `Set<string[]>`. (1:10 - 1:22)
+   1 | const x: Set<string[]> = new Set<any[]>();
+     |          ^^^^^^^^^^^^^ Target expects type `Set<string[]>`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-15 - 1]
-Diagnostic 1: unsafeAssignment (1:7 - 1:57)
-Message: Unsafe assignment of type Set<Set<Set<any>>> to a variable of type Set<Set<Set<string>>>.
+Diagnostic 1: unsafeAssignment (1:32 - 1:32)
+Message: Unsafe assignment between incompatible types.
    1 | const x: Set<Set<Set<string>>> = new Set<Set<Set<any>>>();
-     |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                                ~
+  Label: Assigned value has type `Set<Set<Set<any>>>`. (1:34 - 1:57)
+   1 | const x: Set<Set<Set<string>>> = new Set<Set<Set<any>>>();
+     |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ Assigned value has type `Set<Set<Set<any>>>`.
+  Label: Target expects type `Set<Set<Set<string>>>`. (1:10 - 1:30)
+   1 | const x: Set<Set<Set<string>>> = new Set<Set<Set<any>>>();
+     |          ^^^^^^^^^^^^^^^^^^^^^ Target expects type `Set<Set<Set<string>>>`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-16 - 1]
@@ -143,6 +289,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:8 - 1:8)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | const [x] = [1] as [any]
      |        ~
+  Label: Destructured source provides type `any`. (1:13 - 1:24)
+   1 | const [x] = [1] as [any]
+     |             ^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:8 - 1:8)
+   1 | const [x] = [1] as [any]
+     |        ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-17 - 1]
@@ -150,6 +302,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:15 - 1:15)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | function foo([x] = [1] as [any]) {}
      |               ~
+  Label: Destructured source provides type `any`. (1:20 - 1:31)
+   1 | function foo([x] = [1] as [any]) {}
+     |                    ^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:15 - 1:15)
+   1 | function foo([x] = [1] as [any]) {}
+     |               ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-18 - 1]
@@ -157,6 +315,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:3 - 1:3)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | ([x] = [1] as [any])
      |   ~
+  Label: Destructured source provides type `any`. (1:8 - 1:19)
+   1 | ([x] = [1] as [any])
+     |        ^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:3 - 1:3)
+   1 | ([x] = [1] as [any])
+     |   ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-19 - 1]
@@ -164,6 +328,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:11 - 1:11)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | const [[[[x]]]] = [[[[1 as any]]]]
      |           ~
+  Label: Destructured source provides type `any`. (1:19 - 1:34)
+   1 | const [[[[x]]]] = [[[[1 as any]]]]
+     |                   ^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:11 - 1:11)
+   1 | const [[[[x]]]] = [[[[1 as any]]]]
+     |           ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-20 - 1]
@@ -171,6 +341,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:18 - 1:18)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | function foo([[[[x]]]] = [[[[1 as any]]]]) {}
      |                  ~
+  Label: Destructured source provides type `any`. (1:26 - 1:41)
+   1 | function foo([[[[x]]]] = [[[[1 as any]]]]) {}
+     |                          ^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:18 - 1:18)
+   1 | function foo([[[[x]]]] = [[[[1 as any]]]]) {}
+     |                  ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-21 - 1]
@@ -178,6 +354,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:6 - 1:6)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | ([[[[x]]]] = [[[[1 as any]]]])
      |      ~
+  Label: Destructured source provides type `any`. (1:14 - 1:29)
+   1 | ([[[[x]]]] = [[[[1 as any]]]])
+     |              ^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:6 - 1:6)
+   1 | ([[[[x]]]] = [[[[1 as any]]]])
+     |      ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-22 - 1]
@@ -185,6 +367,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:8 - 1:14)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | const [[[[x]]]] = [1 as any]
      |        ~~~~~~~
+  Label: Destructured source provides type `any`. (1:19 - 1:28)
+   1 | const [[[[x]]]] = [1 as any]
+     |                   ^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:8 - 1:14)
+   1 | const [[[[x]]]] = [1 as any]
+     |        ^^^^^^^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-23 - 1]
@@ -192,6 +380,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:15 - 1:21)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | function foo([[[[x]]]] = [1 as any]) {}
      |               ~~~~~~~
+  Label: Destructured source provides type `any`. (1:26 - 1:35)
+   1 | function foo([[[[x]]]] = [1 as any]) {}
+     |                          ^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:15 - 1:21)
+   1 | function foo([[[[x]]]] = [1 as any]) {}
+     |               ^^^^^^^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-24 - 1]
@@ -199,6 +393,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:9 - 1:9)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | const [{x}] = [{x: 1}] as [{x: any}]
      |         ~
+  Label: Destructured source provides type `any`. (1:15 - 1:36)
+   1 | const [{x}] = [{x: 1}] as [{x: any}]
+     |               ^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:9 - 1:9)
+   1 | const [{x}] = [{x: 1}] as [{x: any}]
+     |         ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-25 - 1]
@@ -206,6 +406,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:16 - 1:16)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | function foo([{x}] = [{x: 1}] as [{x: any}]) {}
      |                ~
+  Label: Destructured source provides type `any`. (1:22 - 1:43)
+   1 | function foo([{x}] = [{x: 1}] as [{x: any}]) {}
+     |                      ^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:16 - 1:16)
+   1 | function foo([{x}] = [{x: 1}] as [{x: any}]) {}
+     |                ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-26 - 1]
@@ -213,6 +419,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:4 - 1:4)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | ([{x}] = [{x: 1}] as [{x: any}])
      |    ~
+  Label: Destructured source provides type `any`. (1:10 - 1:31)
+   1 | ([{x}] = [{x: 1}] as [{x: any}])
+     |          ^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:4 - 1:4)
+   1 | ([{x}] = [{x: 1}] as [{x: any}])
+     |    ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-27 - 1]
@@ -220,6 +432,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:16 - 1:16)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | const [{['x']: x}] = [{['x']: 1}] as [{['x']: any}]
      |                ~
+  Label: Destructured source provides type `any`. (1:22 - 1:51)
+   1 | const [{['x']: x}] = [{['x']: 1}] as [{['x']: any}]
+     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:16 - 1:16)
+   1 | const [{['x']: x}] = [{['x']: 1}] as [{['x']: any}]
+     |                ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-28 - 1]
@@ -227,6 +445,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:23 - 1:23)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | function foo([{['x']: x}] = [{['x']: 1}] as [{['x']: any}]) {}
      |                       ~
+  Label: Destructured source provides type `any`. (1:29 - 1:58)
+   1 | function foo([{['x']: x}] = [{['x']: 1}] as [{['x']: any}]) {}
+     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:23 - 1:23)
+   1 | function foo([{['x']: x}] = [{['x']: 1}] as [{['x']: any}]) {}
+     |                       ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-29 - 1]
@@ -234,6 +458,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:11 - 1:11)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | ([{['x']: x}] = [{['x']: 1}] as [{['x']: any}])
      |           ~
+  Label: Destructured source provides type `any`. (1:17 - 1:46)
+   1 | ([{['x']: x}] = [{['x']: 1}] as [{['x']: any}])
+     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:11 - 1:11)
+   1 | ([{['x']: x}] = [{['x']: 1}] as [{['x']: any}])
+     |           ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-30 - 1]
@@ -241,6 +471,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:16 - 1:16)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | const [{[`x`]: x}] = [{[`x`]: 1}] as [{[`x`]: any}]
      |                ~
+  Label: Destructured source provides type `any`. (1:22 - 1:51)
+   1 | const [{[`x`]: x}] = [{[`x`]: 1}] as [{[`x`]: any}]
+     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:16 - 1:16)
+   1 | const [{[`x`]: x}] = [{[`x`]: 1}] as [{[`x`]: any}]
+     |                ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-31 - 1]
@@ -248,6 +484,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:23 - 1:23)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | function foo([{[`x`]: x}] = [{[`x`]: 1}] as [{[`x`]: any}]) {}
      |                       ~
+  Label: Destructured source provides type `any`. (1:29 - 1:58)
+   1 | function foo([{[`x`]: x}] = [{[`x`]: 1}] as [{[`x`]: any}]) {}
+     |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:23 - 1:23)
+   1 | function foo([{[`x`]: x}] = [{[`x`]: 1}] as [{[`x`]: any}]) {}
+     |                       ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-32 - 1]
@@ -255,30 +497,52 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:11 - 1:11)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | ([{[`x`]: x}] = [{[`x`]: 1}] as [{[`x`]: any}])
      |           ~
+  Label: Destructured source provides type `any`. (1:17 - 1:46)
+   1 | ([{[`x`]: x}] = [{[`x`]: 1}] as [{[`x`]: any}])
+     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:11 - 1:11)
+   1 | ([{[`x`]: x}] = [{[`x`]: 1}] as [{[`x`]: any}])
+     |           ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-33 - 1]
-Diagnostic 1: unsafeAssignment (1:1 - 1:22)
-Message: Unsafe assignment of type [any] to a variable of type [[[[any]]]].
+Diagnostic 1: unsafeAssignment (1:11 - 1:11)
+Message: Unsafe assignment between incompatible types.
    1 | [[[[x]]]] = [1 as any];
-     | ~~~~~~~~~~~~~~~~~~~~~~
+     |           ~
+  Label: Assigned value has type `[any]`. (1:13 - 1:22)
+   1 | [[[[x]]]] = [1 as any];
+     |             ^^^^^^^^^^ Assigned value has type `[any]`.
+  Label: Target expects type `[[[[any]]]]`. (1:1 - 1:9)
+   1 | [[[[x]]]] = [1 as any];
+     | ^^^^^^^^^ Target expects type `[[[[any]]]]`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-34 - 1]
-Diagnostic 1: unsafeArraySpread (2:12 - 2:24)
+Diagnostic 1: unsafeArraySpread (2:12 - 2:14)
 Message: Unsafe spread of an any value in an array.
    1 | 
    2 | const x = [...(1 as any)];
-     |            ~~~~~~~~~~~~~
+     |            ~~~
+   3 |       
+  Label: Spread value has type `any`. (2:15 - 2:24)
+   1 | 
+   2 | const x = [...(1 as any)];
+     |               ^^^^^^^^^^ Spread value has type `any`.
    3 |       
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-35 - 1]
-Diagnostic 1: unsafeArraySpread (2:12 - 2:27)
+Diagnostic 1: unsafeArraySpread (2:12 - 2:14)
 Message: Unsafe spread of an any value in an array.
    1 | 
    2 | const x = [...([] as any[])];
-     |            ~~~~~~~~~~~~~~~~
+     |            ~~~
+   3 |       
+  Label: Spread value has type `any[]`. (2:15 - 2:27)
+   1 | 
+   2 | const x = [...([] as any[])];
+     |               ^^^^^^^^^^^^^ Spread value has type `any[]`.
    3 |       
 ---
 
@@ -287,6 +551,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:8 - 1:8)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | const {x} = {x: 1} as {x: any}
      |        ~
+  Label: Destructured source provides type `any`. (1:13 - 1:30)
+   1 | const {x} = {x: 1} as {x: any}
+     |             ^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:8 - 1:8)
+   1 | const {x} = {x: 1} as {x: any}
+     |        ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-37 - 1]
@@ -294,6 +564,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:15 - 1:15)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | function foo({x} = {x: 1} as {x: any}) {}
      |               ~
+  Label: Destructured source provides type `any`. (1:20 - 1:37)
+   1 | function foo({x} = {x: 1} as {x: any}) {}
+     |                    ^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:15 - 1:15)
+   1 | function foo({x} = {x: 1} as {x: any}) {}
+     |               ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-38 - 1]
@@ -301,6 +577,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:3 - 1:3)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | ({x} = {x: 1} as {x: any})
      |   ~
+  Label: Destructured source provides type `any`. (1:8 - 1:25)
+   1 | ({x} = {x: 1} as {x: any})
+     |        ^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:3 - 1:3)
+   1 | ({x} = {x: 1} as {x: any})
+     |   ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-39 - 1]
@@ -308,6 +590,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:11 - 1:11)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | const {x: y} = {x: 1} as {x: any}
      |           ~
+  Label: Destructured source provides type `any`. (1:16 - 1:33)
+   1 | const {x: y} = {x: 1} as {x: any}
+     |                ^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:11 - 1:11)
+   1 | const {x: y} = {x: 1} as {x: any}
+     |           ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-40 - 1]
@@ -315,6 +603,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:18 - 1:18)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | function foo({x: y} = {x: 1} as {x: any}) {}
      |                  ~
+  Label: Destructured source provides type `any`. (1:23 - 1:40)
+   1 | function foo({x: y} = {x: 1} as {x: any}) {}
+     |                       ^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:18 - 1:18)
+   1 | function foo({x: y} = {x: 1} as {x: any}) {}
+     |                  ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-41 - 1]
@@ -322,6 +616,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:6 - 1:6)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | ({x: y} = {x: 1} as {x: any})
      |      ~
+  Label: Destructured source provides type `any`. (1:11 - 1:28)
+   1 | ({x: y} = {x: 1} as {x: any})
+     |           ^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:6 - 1:6)
+   1 | ({x: y} = {x: 1} as {x: any})
+     |      ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-42 - 1]
@@ -329,6 +629,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:12 - 1:12)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | const {x: {y}} = {x: {y: 1}} as {x: {y: any}}
      |            ~
+  Label: Destructured source provides type `any`. (1:18 - 1:45)
+   1 | const {x: {y}} = {x: {y: 1}} as {x: {y: any}}
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:12 - 1:12)
+   1 | const {x: {y}} = {x: {y: 1}} as {x: {y: any}}
+     |            ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-43 - 1]
@@ -336,6 +642,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:19 - 1:19)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | function foo({x: {y}} = {x: {y: 1}} as {x: {y: any}}) {}
      |                   ~
+  Label: Destructured source provides type `any`. (1:25 - 1:52)
+   1 | function foo({x: {y}} = {x: {y: 1}} as {x: {y: any}}) {}
+     |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:19 - 1:19)
+   1 | function foo({x: {y}} = {x: {y: 1}} as {x: {y: any}}) {}
+     |                   ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-44 - 1]
@@ -343,6 +655,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:7 - 1:7)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | ({x: {y}} = {x: {y: 1}} as {x: {y: any}})
      |       ~
+  Label: Destructured source provides type `any`. (1:13 - 1:40)
+   1 | ({x: {y}} = {x: {y: 1}} as {x: {y: any}})
+     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:7 - 1:7)
+   1 | ({x: {y}} = {x: {y: 1}} as {x: {y: any}})
+     |       ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-45 - 1]
@@ -350,6 +668,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:12 - 1:12)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | const {x: [y]} = {x: {y: 1}} as {x: [any]}
      |            ~
+  Label: Destructured source provides type `any`. (1:18 - 1:42)
+   1 | const {x: [y]} = {x: {y: 1}} as {x: [any]}
+     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:12 - 1:12)
+   1 | const {x: [y]} = {x: {y: 1}} as {x: [any]}
+     |            ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-46 - 1]
@@ -357,6 +681,12 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:19 - 1:19)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | function foo({x: [y]} = {x: {y: 1}} as {x: [any]}) {}
      |                   ~
+  Label: Destructured source provides type `any`. (1:25 - 1:49)
+   1 | function foo({x: [y]} = {x: {y: 1}} as {x: [any]}) {}
+     |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:19 - 1:19)
+   1 | function foo({x: [y]} = {x: {y: 1}} as {x: [any]}) {}
+     |                   ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-47 - 1]
@@ -364,62 +694,122 @@ Diagnostic 1: unsafeArrayPatternFromTuple (1:7 - 1:7)
 Message: Unsafe array destructuring of a tuple element with an any value.
    1 | ({x: [y]} = {x: {y: 1}} as {x: [any]})
      |       ~
+  Label: Destructured source provides type `any`. (1:13 - 1:37)
+   1 | ({x: [y]} = {x: {y: 1}} as {x: [any]})
+     |             ^^^^^^^^^^^^^^^^^^^^^^^^^ Destructured source provides type `any`.
+  Label: This binding receives type `any`. (1:7 - 1:7)
+   1 | ({x: [y]} = {x: {y: 1}} as {x: [any]})
+     |       ^ This binding receives type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-48 - 1]
-Diagnostic 1: anyAssignment (1:13 - 1:23)
+Diagnostic 1: anyAssignment (1:14 - 1:14)
 Message: Unsafe assignment of an any value.
    1 | const x = { y: 1 as any };
-     |             ~~~~~~~~~~~
+     |              ~
+  Label: Assigned value has type `any`. (1:16 - 1:23)
+   1 | const x = { y: 1 as any };
+     |                ^^^^^^^^ Assigned value has type `any`.
+  Label: Target expects type `any`. (1:13 - 1:13)
+   1 | const x = { y: 1 as any };
+     |             ^ Target expects type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-49 - 1]
-Diagnostic 1: anyAssignment (1:18 - 1:28)
+Diagnostic 1: anyAssignment (1:19 - 1:19)
 Message: Unsafe assignment of an any value.
    1 | const x = { y: { z: 1 as any } };
-     |                  ~~~~~~~~~~~
+     |                   ~
+  Label: Assigned value has type `any`. (1:21 - 1:28)
+   1 | const x = { y: { z: 1 as any } };
+     |                     ^^^^^^^^ Assigned value has type `any`.
+  Label: Target expects type `any`. (1:18 - 1:18)
+   1 | const x = { y: { z: 1 as any } };
+     |                  ^ Target expects type `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-50 - 1]
-Diagnostic 1: unsafeAssignment (1:43 - 1:69)
-Message: Unsafe assignment of type Set<Set<Set<any>>> to a variable of type Set<Set<Set<string>>>.
+Diagnostic 1: unsafeAssignment (1:44 - 1:44)
+Message: Unsafe assignment between incompatible types.
    1 | const x: { y: Set<Set<Set<string>>> } = { y: new Set<Set<Set<any>>>() };
-     |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                                            ~
+  Label: Assigned value has type `Set<Set<Set<any>>>`. (1:46 - 1:69)
+   1 | const x: { y: Set<Set<Set<string>>> } = { y: new Set<Set<Set<any>>>() };
+     |                                              ^^^^^^^^^^^^^^^^^^^^^^^^ Assigned value has type `Set<Set<Set<any>>>`.
+  Label: Target expects type `Set<Set<Set<string>>>`. (1:43 - 1:43)
+   1 | const x: { y: Set<Set<Set<string>>> } = { y: new Set<Set<Set<any>>>() };
+     |                                           ^ Target expects type `Set<Set<Set<string>>>`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-51 - 1]
-Diagnostic 1: anyAssignment (1:7 - 1:27)
+Diagnostic 1: anyAssignment (1:9 - 1:9)
 Message: Unsafe assignment of an any value.
    1 | const x = { ...(1 as any) };
-     |       ~~~~~~~~~~~~~~~~~~~~~
+     |         ~
+  Label: Assigned value has type `any`. (1:11 - 1:27)
+   1 | const x = { ...(1 as any) };
+     |           ^^^^^^^^^^^^^^^^^ Assigned value has type `any`.
+  Label: Target is inferred as `any`. (1:7 - 1:7)
+   1 | const x = { ...(1 as any) };
+     |       ^ Target is inferred as `any`.
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-52 - 1]
-Diagnostic 1: anyAssignment (4:9 - 4:16)
+Diagnostic 1: anyAssignment (4:7 - 4:7)
 Message: Unsafe assignment of an any value.
    3 | declare function Foo(props: Props): never;
    4 | <Foo a={1 as any} />;
-     |         ~~~~~~~~
+     |       ~
+   5 |       
+  Label: Assigned value has type `any`. (4:9 - 4:16)
+   3 | declare function Foo(props: Props): never;
+   4 | <Foo a={1 as any} />;
+     |         ^^^^^^^^ Assigned value has type `any`.
+   5 |       
+  Label: Target expects type `string`. (4:6 - 4:6)
+   3 | declare function Foo(props: Props): never;
+   4 | <Foo a={1 as any} />;
+     |      ^ Target expects type `string`.
    5 |       
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-53 - 1]
-Diagnostic 1: anyAssignmentThis (3:9 - 3:18)
+Diagnostic 1: anyAssignmentThis (3:13 - 3:13)
 Message: Unsafe assignment of an any value. `this` is typed as `any`.
 
 Help: You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.
    2 | function foo() {
    3 |   const bar = this;
-     |         ~~~~~~~~~~
+     |             ~
+   4 | }
+  Label: `this` has type `any`. (3:15 - 3:18)
+   2 | function foo() {
+   3 |   const bar = this;
+     |               ^^^^ `this` has type `any`.
+   4 | }
+  Label: Target is inferred as `any`. (3:9 - 3:11)
+   2 | function foo() {
+   3 |   const bar = this;
+     |         ^^^ Target is inferred as `any`.
    4 | }
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-54 - 1]
-Diagnostic 1: anyAssignment (3:7 - 3:37)
+Diagnostic 1: anyAssignment (3:15 - 3:15)
 Message: Unsafe assignment of an any value.
    2 | type T = [string, T[]];
    3 | const test: T = ['string', []] as any;
-     |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |               ~
+   4 |       
+  Label: Assigned value has type `any`. (3:17 - 3:37)
+   2 | type T = [string, T[]];
+   3 | const test: T = ['string', []] as any;
+     |                 ^^^^^^^^^^^^^^^^^^^^^ Assigned value has type `any`.
+   4 |       
+  Label: Target expects type `T`. (3:13 - 3:13)
+   2 | type T = [string, T[]];
+   3 | const test: T = ['string', []] as any;
+     |             ^ Target expects type `T`.
    4 |       
 ---
 
@@ -430,22 +820,52 @@ Message: Unsafe assignment of an any value.
    4 | const foo: Foo = { bar };
      |                    ~~~
    5 |       
+  Label: Assigned value has type `any`. (4:20 - 4:22)
+   3 | const bar: any = 1;
+   4 | const foo: Foo = { bar };
+     |                    ^^^ Assigned value has type `any`.
+   5 |       
+  Label: Target expects type `number`. (4:20 - 4:22)
+   3 | const bar: any = 1;
+   4 | const foo: Foo = { bar };
+     |                    ^^^ Target expects type `number`.
+   5 |       
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-56 - 1]
-Diagnostic 1: anyAssignment (9:5 - 9:53)
+Diagnostic 1: anyAssignment (9:33 - 9:33)
 Message: Unsafe assignment of an any value.
    8 |   constructor(
    9 |     private readonly param: Bar = Object.create(null)
-     |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                                 ~
+  10 |   ) {}
+  Label: Assigned value has type `any`. (9:35 - 9:53)
+   8 |   constructor(
+   9 |     private readonly param: Bar = Object.create(null)
+     |                                   ^^^^^^^^^^^^^^^^^^^ Assigned value has type `any`.
+  10 |   ) {}
+  Label: Target expects type `Bar`. (9:29 - 9:31)
+   8 |   constructor(
+   9 |     private readonly param: Bar = Object.create(null)
+     |                             ^^^ Target expects type `Bar`.
   10 |   ) {}
 ---
 
 [TestNoUnsafeAssignmentRule/invalid-57 - 1]
-Diagnostic 1: anyAssignment (4:1 - 4:23)
+Diagnostic 1: anyAssignment (4:5 - 4:5)
 Message: Unsafe assignment of an any value.
    3 | 
    4 | foo = { bar: 2 } as any;
-     | ~~~~~~~~~~~~~~~~~~~~~~~
+     |     ~
+   5 |       
+  Label: Assigned value has type `any`. (4:7 - 4:23)
+   3 | 
+   4 | foo = { bar: 2 } as any;
+     |       ^^^^^^^^^^^^^^^^^ Assigned value has type `any`.
+   5 |       
+  Label: Target expects type `{ foo: 1; }`. (4:1 - 4:3)
+   3 | 
+   4 | foo = { bar: 2 } as any;
+     | ^^^ Target expects type `{ foo: 1; }`.
    5 |       
 ---

--- a/internal/rules/no_unsafe_assignment/no_unsafe_assignment.go
+++ b/internal/rules/no_unsafe_assignment/no_unsafe_assignment.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/typescript-eslint/tsgolint/internal/rule"
 	"github.com/typescript-eslint/tsgolint/internal/utils"
 )
@@ -47,11 +49,131 @@ func buildUnsafeArraySpreadMessage(sender *checker.Type) rule.RuleMessage {
 		Description: fmt.Sprintf("Unsafe spread of an %v value in an array.", formatSenderType(sender)),
 	}
 }
-func buildUnsafeAssignmentMessage(typeChecker *checker.Checker, sender, receiver *checker.Type) rule.RuleMessage {
+func buildUnsafeAssignmentMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unsafeAssignment",
-		Description: fmt.Sprintf("Unsafe assignment of type %v to a variable of type %v.", typeChecker.TypeToString(sender), typeChecker.TypeToString(receiver)),
+		Description: "Unsafe assignment between incompatible types.",
 	}
+}
+
+func buildAssignmentDiagnostic(
+	primaryRange core.TextRange,
+	senderRange core.TextRange,
+	receiverRange core.TextRange,
+	senderType string,
+	receiverType string,
+	message rule.RuleMessage,
+) rule.RuleDiagnostic {
+	return rule.RuleDiagnostic{
+		Range:   primaryRange,
+		Message: message,
+		LabeledRanges: []rule.RuleLabeledRange{
+			{
+				Label: fmt.Sprintf("Assigned value has type `%s`.", senderType),
+				Range: senderRange,
+			},
+			{
+				Label: fmt.Sprintf("Target expects type `%s`.", receiverType),
+				Range: receiverRange,
+			},
+		},
+	}
+}
+
+func buildThisAssignmentDiagnostic(
+	primaryRange core.TextRange,
+	thisRange core.TextRange,
+	receiverRange core.TextRange,
+	thisType string,
+	receiverType string,
+	message rule.RuleMessage,
+) rule.RuleDiagnostic {
+	diagnostic := buildAssignmentDiagnostic(
+		primaryRange,
+		thisRange,
+		receiverRange,
+		thisType,
+		receiverType,
+		message,
+	)
+	diagnostic.LabeledRanges[0].Label = fmt.Sprintf("`this` has type `%s`.", thisType)
+	return diagnostic
+}
+
+func buildDestructureDiagnostic(
+	receiverRange core.TextRange,
+	senderRange core.TextRange,
+	senderType string,
+	unsafeType string,
+	message rule.RuleMessage,
+) rule.RuleDiagnostic {
+	return rule.RuleDiagnostic{
+		Range:   receiverRange,
+		Message: message,
+		LabeledRanges: []rule.RuleLabeledRange{
+			{
+				Label: fmt.Sprintf("Destructured source provides type `%s`.", senderType),
+				Range: senderRange,
+			},
+			{
+				Label: fmt.Sprintf("This binding receives type `%s`.", unsafeType),
+				Range: receiverRange,
+			},
+		},
+	}
+}
+
+func buildArraySpreadDiagnostic(
+	spreadRange core.TextRange,
+	valueRange core.TextRange,
+	valueType string,
+	message rule.RuleMessage,
+) rule.RuleDiagnostic {
+	return rule.RuleDiagnostic{
+		Range:   spreadRange,
+		Message: message,
+		LabeledRanges: []rule.RuleLabeledRange{
+			{
+				Label: fmt.Sprintf("Spread value has type `%s`.", valueType),
+				Range: valueRange,
+			},
+		},
+	}
+}
+
+func diagnosticTypeText(typeChecker *checker.Checker, t *checker.Type) string {
+	if utils.IsIntrinsicErrorType(t) {
+		return "error"
+	}
+	return typeChecker.TypeToString(t)
+}
+
+func assignmentRelationRange(sourceFile *ast.SourceFile, receiverNode, senderNode *ast.Node) core.TextRange {
+	s := scanner.GetScannerForSourceFile(sourceFile, receiverNode.End())
+	var colonRange core.TextRange
+	for s.Token() != ast.KindEndOfFile && s.TokenRange().Pos() < senderNode.End() {
+		switch s.Token() {
+		case ast.KindEqualsToken:
+			return s.TokenRange()
+		case ast.KindColonToken:
+			colonRange = s.TokenRange()
+		}
+		if s.TokenRange().Pos() >= senderNode.Pos() {
+			break
+		}
+		s.Scan()
+	}
+	if colonRange != (core.TextRange{}) {
+		return colonRange
+	}
+	return utils.TrimNodeTextRange(sourceFile, receiverNode)
+}
+
+func localTargetRange(sourceFile *ast.SourceFile, receiverNode, typeAnnotationNode *ast.Node) core.TextRange {
+	if typeAnnotationNode != nil && ast.GetSourceFileOfNode(typeAnnotationNode) == sourceFile {
+		return utils.TrimNodeTextRange(sourceFile, typeAnnotationNode)
+	}
+	return utils.TrimNodeTextRange(sourceFile, receiverNode)
 }
 
 type comparisonType uint8
@@ -102,6 +224,16 @@ var NoUnsafeAssignmentRule = rule.Rule{
 			compilerOptions.NoImplicitThis,
 		)
 
+		reportDestructure := func(receiverNode, senderNode *ast.Node, senderType *checker.Type, unsafeType string, message rule.RuleMessage) {
+			ctx.ReportDiagnostic(buildDestructureDiagnostic(
+				utils.TrimNodeTextRange(ctx.SourceFile, receiverNode),
+				utils.TrimNodeTextRange(ctx.SourceFile, senderNode),
+				diagnosticTypeText(ctx.TypeChecker, senderType),
+				unsafeType,
+				message,
+			))
+		}
+
 		var checkArrayDestructure func(
 			receiverNode *ast.Node,
 			senderType *checker.Type,
@@ -147,7 +279,7 @@ var NoUnsafeAssignmentRule = rule.Rule{
 				// check for the any type first so we can handle {x: {y: z}} = {x: any}
 				if utils.IsTypeAnyType(senderType) {
 					// TODO(port): why object reported with "array" message?
-					ctx.ReportNode(propertyValue, buildUnsafeArrayPatternFromTupleMessage(senderType))
+					reportDestructure(propertyValue, senderNode, senderType, diagnosticTypeText(ctx.TypeChecker, senderType), buildUnsafeArrayPatternFromTupleMessage(senderType))
 					return true
 				} else if ast.IsArrayBindingPattern(propertyValue) || ast.IsArrayLiteralExpression(propertyValue) {
 					return checkArrayDestructure(
@@ -222,7 +354,7 @@ var NoUnsafeAssignmentRule = rule.Rule{
 			// any array
 			// const [x] = ([] as any[]);
 			if utils.IsTypeAnyArrayType(senderType, ctx.TypeChecker) {
-				ctx.ReportNode(receiverNode, buildUnsafeArrayPatternMessage(senderType))
+				reportDestructure(receiverNode, senderNode, senderType, "any", buildUnsafeArrayPatternMessage(senderType))
 				return false
 			}
 
@@ -243,7 +375,7 @@ var NoUnsafeAssignmentRule = rule.Rule{
 
 				// check for the any type first so we can handle [[[x]]] = [any]
 				if utils.IsTypeAnyType(senderType) {
-					ctx.ReportNode(receiverElement, buildUnsafeArrayPatternFromTupleMessage(senderType))
+					reportDestructure(receiverElement, senderNode, senderType, diagnosticTypeText(ctx.TypeChecker, senderType), buildUnsafeArrayPatternFromTupleMessage(senderType))
 					return true
 				} else if ast.IsArrayBindingPattern(receiverElement) || ast.IsArrayLiteralExpression(receiverElement) {
 					return checkArrayDestructure(
@@ -312,7 +444,8 @@ var NoUnsafeAssignmentRule = rule.Rule{
 		checkAssignment := func(
 			receiverNode *ast.Node,
 			senderNode *ast.Node,
-			reportingNode *ast.Node,
+			typeAnnotationNode *ast.Node,
+			primaryRange core.TextRange,
 			compType comparisonType,
 		) bool {
 			// Fast path: return early when we know that the sender definitely cannot have an `any` type,
@@ -325,6 +458,9 @@ var NoUnsafeAssignmentRule = rule.Rule{
 
 			getReceiverType := func() *checker.Type {
 				if compType == comparisonTypeContextual {
+					if receiverType := utils.GetContextualType(ctx.TypeChecker, senderNode); receiverType != nil {
+						return receiverType
+					}
 					if receiverType := utils.GetContextualType(ctx.TypeChecker, receiverNode); receiverType != nil {
 						return receiverType
 					}
@@ -334,6 +470,15 @@ var NoUnsafeAssignmentRule = rule.Rule{
 
 			if utils.IsTypeAnyType(senderType) {
 				receiverType := getReceiverType()
+				receiverRange := localTargetRange(ctx.SourceFile, receiverNode, typeAnnotationNode)
+				setInferredTargetLabel := func(diagnostic *rule.RuleDiagnostic) {
+					if compType == comparisonTypeNone {
+						diagnostic.LabeledRanges[1].Label = fmt.Sprintf(
+							"Target is inferred as `%s`.",
+							diagnosticTypeText(ctx.TypeChecker, receiverType),
+						)
+					}
+				}
 
 				// handle cases when we assign any ==> unknown.
 				if utils.IsTypeUnknownType(receiverType) {
@@ -343,13 +488,34 @@ var NoUnsafeAssignmentRule = rule.Rule{
 				if !isNoImplicitThis {
 					// `var foo = this`
 					thisExpression := utils.GetThisExpression(senderNode)
-					if thisExpression != nil && utils.IsTypeAnyType(utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, thisExpression)) {
-						ctx.ReportNode(reportingNode, buildAnyAssignmentThisMessage(senderType))
-						return true
+					if thisExpression != nil {
+						thisType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, thisExpression)
+						if utils.IsTypeAnyType(thisType) {
+							diagnostic := buildThisAssignmentDiagnostic(
+								primaryRange,
+								utils.TrimNodeTextRange(ctx.SourceFile, thisExpression),
+								receiverRange,
+								diagnosticTypeText(ctx.TypeChecker, thisType),
+								diagnosticTypeText(ctx.TypeChecker, receiverType),
+								buildAnyAssignmentThisMessage(senderType),
+							)
+							setInferredTargetLabel(&diagnostic)
+							ctx.ReportDiagnostic(diagnostic)
+							return true
+						}
 					}
 				}
 
-				ctx.ReportNode(reportingNode, buildAnyAssignmentMessage(senderType))
+				diagnostic := buildAssignmentDiagnostic(
+					primaryRange,
+					utils.TrimNodeTextRange(ctx.SourceFile, senderNode),
+					receiverRange,
+					diagnosticTypeText(ctx.TypeChecker, senderType),
+					diagnosticTypeText(ctx.TypeChecker, receiverType),
+					buildAnyAssignmentMessage(senderType),
+				)
+				setInferredTargetLabel(&diagnostic)
+				ctx.ReportDiagnostic(diagnostic)
 				return true
 			}
 
@@ -372,7 +538,14 @@ var NoUnsafeAssignmentRule = rule.Rule{
 				return false
 			}
 
-			ctx.ReportNode(reportingNode, buildUnsafeAssignmentMessage(ctx.TypeChecker, sender, receiver))
+			ctx.ReportDiagnostic(buildAssignmentDiagnostic(
+				primaryRange,
+				utils.TrimNodeTextRange(ctx.SourceFile, senderNode),
+				localTargetRange(ctx.SourceFile, receiverNode, typeAnnotationNode),
+				diagnosticTypeText(ctx.TypeChecker, sender),
+				diagnosticTypeText(ctx.TypeChecker, receiver),
+				buildUnsafeAssignmentMessage(),
+			))
 			return true
 		}
 
@@ -387,14 +560,15 @@ var NoUnsafeAssignmentRule = rule.Rule{
 			return comparisonTypeNone
 		}
 
-		checkAssignmentFull := func(id *ast.Node, init *ast.Node, node *ast.Node) {
+		checkAssignmentFull := func(id *ast.Node, init *ast.Node, typeAnnotationNode *ast.Node, primaryRange core.TextRange) {
 			if id == nil || init == nil {
 				return
 			}
 			didReport := checkAssignment(
 				id,
 				init,
-				node,
+				typeAnnotationNode,
+				primaryRange,
 				// the variable already has some form of a type to compare against
 				comparisonTypeBasic,
 			)
@@ -414,7 +588,13 @@ var NoUnsafeAssignmentRule = rule.Rule{
 				if initializer == nil {
 					return
 				}
-				checkAssignment(node.Name(), initializer, node, getComparisonType(node))
+				checkAssignment(
+					node.Name(),
+					initializer,
+					node.Type(),
+					assignmentRelationRange(ctx.SourceFile, node.Name(), initializer),
+					getComparisonType(node),
+				)
 			},
 
 			// ESTree AssignmentExpression, AssignmentPattern
@@ -424,21 +604,32 @@ var NoUnsafeAssignmentRule = rule.Rule{
 				}
 
 				expr := node.AsBinaryExpression()
-				checkAssignmentFull(expr.Left, expr.Right, node)
+				checkAssignmentFull(
+					expr.Left,
+					expr.Right,
+					nil,
+					utils.TrimNodeTextRange(ctx.SourceFile, expr.OperatorToken),
+				)
 			},
 
 			// ESTree AssignmentPattern
 			ast.KindBindingElement: func(node *ast.Node) {
-				checkAssignmentFull(node.Name(), node.Initializer(), node)
+				if initializer := node.Initializer(); initializer != nil {
+					checkAssignmentFull(node.Name(), initializer, node.Type(), assignmentRelationRange(ctx.SourceFile, node.Name(), initializer))
+				}
 			},
 			// ESTree AssignmentPattern
 			ast.KindParameter: func(node *ast.Node) {
-				checkAssignmentFull(node.Name(), node.Initializer(), node)
+				if initializer := node.Initializer(); initializer != nil {
+					checkAssignmentFull(node.Name(), initializer, node.Type(), assignmentRelationRange(ctx.SourceFile, node.Name(), initializer))
+				}
 			},
 			// ESTree AssignmentPattern
 			ast.KindShorthandPropertyAssignment: func(node *ast.Node) {
 				assignment := node.AsShorthandPropertyAssignment()
-				checkAssignmentFull(assignment.Name(), assignment.ObjectAssignmentInitializer, node)
+				if initializer := assignment.ObjectAssignmentInitializer; initializer != nil {
+					checkAssignmentFull(assignment.Name(), initializer, nil, assignmentRelationRange(ctx.SourceFile, assignment.Name(), initializer))
+				}
 			},
 
 			ast.KindVariableDeclaration: func(node *ast.Node) {
@@ -451,7 +642,8 @@ var NoUnsafeAssignmentRule = rule.Rule{
 				didReport := checkAssignment(
 					id,
 					init,
-					node,
+					node.Type(),
+					assignmentRelationRange(ctx.SourceFile, id, init),
 					getComparisonType(node),
 				)
 
@@ -486,7 +678,13 @@ var NoUnsafeAssignmentRule = rule.Rule{
 						return
 					}
 
-					checkAssignment(node.Name(), init, node, comparisonTypeContextual)
+					checkAssignment(
+						node.Name(),
+						init,
+						nil,
+						assignmentRelationRange(ctx.SourceFile, node.Name(), init),
+						comparisonTypeContextual,
+					)
 				}
 			},
 
@@ -498,7 +696,13 @@ var NoUnsafeAssignmentRule = rule.Rule{
 
 					restType := ctx.TypeChecker.GetTypeAtLocation(node.Expression())
 					if utils.IsTypeAnyType(restType) || utils.IsTypeAnyArrayType(restType, ctx.TypeChecker) {
-						ctx.ReportNode(node, buildUnsafeArraySpreadMessage(restType))
+						nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+						ctx.ReportDiagnostic(buildArraySpreadDiagnostic(
+							core.NewTextRange(nodeRange.Pos(), nodeRange.Pos()+3),
+							utils.TrimNodeTextRange(ctx.SourceFile, node.Expression()),
+							diagnosticTypeText(ctx.TypeChecker, restType),
+							buildUnsafeArraySpreadMessage(restType),
+						))
 					}
 				}
 			},
@@ -514,7 +718,13 @@ var NoUnsafeAssignmentRule = rule.Rule{
 					return
 				}
 
-				checkAssignment(node.Name(), expr, expr, comparisonTypeContextual)
+				checkAssignment(
+					node.Name(),
+					expr,
+					nil,
+					assignmentRelationRange(ctx.SourceFile, node.Name(), expr),
+					comparisonTypeContextual,
+				)
 			},
 		}
 	},

--- a/internal/rules/no_unsafe_assignment/no_unsafe_assignment_test.go
+++ b/internal/rules/no_unsafe_assignment/no_unsafe_assignment_test.go
@@ -4,9 +4,55 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/typescript-eslint/tsgolint/internal/rule"
 	"github.com/typescript-eslint/tsgolint/internal/rule_tester"
 	"github.com/typescript-eslint/tsgolint/internal/rules/fixtures"
 )
+
+func TestDiagnosticRelationships(t *testing.T) {
+	t.Parallel()
+
+	primaryRange := core.NewTextRange(10, 11)
+	senderRange := core.NewTextRange(20, 30)
+	receiverRange := core.NewTextRange(1, 8)
+	message := rule.RuleMessage{Id: "test", Description: "test"}
+
+	assignment := buildAssignmentDiagnostic(primaryRange, senderRange, receiverRange, "Set<any>", "Set<string>", message)
+	if assignment.Range != primaryRange {
+		t.Fatalf("assignment range = %v, want %v", assignment.Range, primaryRange)
+	}
+	if len(assignment.LabeledRanges) != 2 {
+		t.Fatalf("assignment labels = %d, want 2", len(assignment.LabeledRanges))
+	}
+	if assignment.LabeledRanges[0].Range != senderRange || assignment.LabeledRanges[0].Label != "Assigned value has type `Set<any>`." {
+		t.Fatalf("sender label = %+v", assignment.LabeledRanges[0])
+	}
+	if assignment.LabeledRanges[1].Range != receiverRange || assignment.LabeledRanges[1].Label != "Target expects type `Set<string>`." {
+		t.Fatalf("receiver label = %+v", assignment.LabeledRanges[1])
+	}
+
+	thisAssignment := buildThisAssignmentDiagnostic(primaryRange, senderRange, receiverRange, "any", "number", message)
+	if thisAssignment.LabeledRanges[0].Label != "`this` has type `any`." || thisAssignment.LabeledRanges[0].Range != senderRange {
+		t.Fatalf("this label = %+v", thisAssignment.LabeledRanges[0])
+	}
+
+	destructure := buildDestructureDiagnostic(receiverRange, senderRange, "[any]", "any", message)
+	if destructure.Range != receiverRange || len(destructure.LabeledRanges) != 2 {
+		t.Fatalf("destructure diagnostic = %+v", destructure)
+	}
+	if destructure.LabeledRanges[0].Label != "Destructured source provides type `[any]`." || destructure.LabeledRanges[0].Range != senderRange {
+		t.Fatalf("destructure source label = %+v", destructure.LabeledRanges[0])
+	}
+	if destructure.LabeledRanges[1].Label != "This binding receives type `any`." || destructure.LabeledRanges[1].Range != receiverRange {
+		t.Fatalf("destructure binding label = %+v", destructure.LabeledRanges[1])
+	}
+
+	spread := buildArraySpreadDiagnostic(primaryRange, senderRange, "any[]", message)
+	if spread.Range != primaryRange || len(spread.LabeledRanges) != 1 || spread.LabeledRanges[0].Range != senderRange || spread.LabeledRanges[0].Label != "Spread value has type `any[]`." {
+		t.Fatalf("spread diagnostic = %+v", spread)
+	}
+}
 
 func assignmentTest(
 	tests []struct {
@@ -159,6 +205,8 @@ a+= foo;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "anyAssignment",
+					Column:    9,
+					EndColumn: 10,
 				},
 			},
 		},
@@ -261,6 +309,9 @@ value = spooky;
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "anyAssignment",
+					Line:      4,
+					Column:    7,
+					EndColumn: 8,
 				},
 			},
 		},
@@ -289,6 +340,8 @@ const [x] = [] as any[];
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "unsafeAssignment",
+					Column:    22,
+					EndColumn: 23,
 				},
 			},
 		},
@@ -338,8 +391,8 @@ const [x] = [] as any[];
 					{
 						MessageId: "unsafeAssignment",
 						Line:      1,
-						Column:    1,
-						EndColumn: 23,
+						Column:    11,
+						EndColumn: 12,
 					},
 				},
 			},
@@ -350,6 +403,9 @@ const x = [...(1 as any)];
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "unsafeArraySpread",
+						Line:      2,
+						Column:    12,
+						EndColumn: 15,
 					},
 				},
 			},
@@ -360,6 +416,9 @@ const x = [...([] as any[])];
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "unsafeArraySpread",
+						Line:      2,
+						Column:    12,
+						EndColumn: 15,
 					},
 				},
 			},
@@ -382,8 +441,8 @@ const x = [...([] as any[])];
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "anyAssignment",
-						Column:    13,
-						EndColumn: 24,
+						Column:    14,
+						EndColumn: 15,
 					},
 				},
 			},
@@ -392,8 +451,8 @@ const x = [...([] as any[])];
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "anyAssignment",
-						Column:    18,
-						EndColumn: 29,
+						Column:    19,
+						EndColumn: 20,
 					},
 				},
 			},
@@ -402,8 +461,8 @@ const x = [...([] as any[])];
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "unsafeAssignment",
-						Column:    43,
-						EndColumn: 70,
+						Column:    44,
+						EndColumn: 45,
 					},
 				},
 			},
@@ -412,8 +471,8 @@ const x = [...([] as any[])];
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "anyAssignment",
-						Column:    7,
-						EndColumn: 28,
+						Column:    9,
+						EndColumn: 10,
 					},
 				},
 			},
@@ -428,8 +487,8 @@ declare function Foo(props: Props): never;
 					{
 						MessageId: "anyAssignment",
 						Line:      4,
-						Column:    9,
-						EndColumn: 17,
+						Column:    7,
+						EndColumn: 8,
 					},
 				},
 			},
@@ -443,8 +502,8 @@ function foo() {
 					{
 						MessageId: "anyAssignmentThis",
 						Line:      3,
-						Column:    9,
-						EndColumn: 19,
+						Column:    13,
+						EndColumn: 14,
 					},
 				},
 			},
@@ -457,8 +516,8 @@ const test: T = ['string', []] as any;
 					{
 						MessageId: "anyAssignment",
 						Line:      3,
-						Column:    7,
-						EndColumn: 38,
+						Column:    15,
+						EndColumn: 16,
 					},
 				},
 			},
@@ -495,8 +554,8 @@ class Foo {
 					{
 						MessageId: "anyAssignment",
 						Line:      9,
-						Column:    5,
-						EndColumn: 54,
+						Column:    33,
+						EndColumn: 34,
 					},
 				},
 			},
@@ -510,8 +569,8 @@ foo = { bar: 2 } as any;
 					{
 						MessageId: "anyAssignment",
 						Line:      4,
-						Column:    1,
-						EndColumn: 24,
+						Column:    5,
+						EndColumn: 6,
 					},
 				},
 			},


### PR DESCRIPTION
Part of #677.

Improves no-unsafe-assignment diagnostics by:
- narrowing primary ranges to assignment, annotation, and spread syntax
- labeling sender values and receiver annotations with actual and expected types
- adding specialized labels for destructuring, spreads, and implicit this
- omitting unsafe cross-file ranges
- adding focused range coverage and updating focused/e2e snapshots

Tests:
- go test ./internal/rules/no_unsafe_assignment
- cd e2e and pnpm --ignore-workspace run test --run