### PR TITLE
fix(no-unnecessary-template-expression): preserve expression precedence

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-template-expression.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-template-expression.snap
@@ -1051,3 +1051,26 @@ Message: Template literal expression is unnecessary and can be simplified.
    1 | `${'abc' || 'def'}`[0];
      |  ~~~~~~~~~~~~~~~~~
 ---
+
+[TestNoUnnecessaryTemplateExpressionRule/invalid-121 - 1]
+Diagnostic 1: noUnnecessaryTemplateExpression (1:24 - 1:46)
+Message: Template literal expression is unnecessary and can be simplified.
+   1 | const value = "foo" + `${cond ? "bar" : "baz"}`;
+     |                        ~~~~~~~~~~~~~~~~~~~~~~~
+---
+
+[TestNoUnnecessaryTemplateExpressionRule/invalid-122 - 1]
+Diagnostic 1: noUnnecessaryTemplateExpression (2:2 - 2:12)
+Message: Template literal expression is unnecessary and can be simplified.
+   1 | declare const a: string;
+   2 | `${a || 'b'}` ?? 'c';
+     |  ~~~~~~~~~~~
+---
+
+[TestNoUnnecessaryTemplateExpressionRule/invalid-123 - 1]
+Diagnostic 1: noUnnecessaryTemplateExpression (2:9 - 2:19)
+Message: Template literal expression is unnecessary and can be simplified.
+   1 | declare const b: string;
+   2 | 'a' ?? `${b && 'c'}`;
+     |         ~~~~~~~~~~~
+---

--- a/internal/rules/no_unnecessary_template_expression/no_unnecessary_template_expression.go
+++ b/internal/rules/no_unnecessary_template_expression/no_unnecessary_template_expression.go
@@ -110,9 +110,15 @@ var NoUnnecessaryTemplateExpressionRule = rule.Rule{
 
 		reportSingleInterpolation := func(template *ast.Node, interpolation *ast.Node, spanLiteral *ast.Node) {
 			text := nodeText(interpolation)
-			isMemberReceiver := ast.IsPropertyAccessExpression(template.Parent) && template.Parent.AsPropertyAccessExpression().Expression == template ||
-				ast.IsElementAccessExpression(template.Parent) && template.Parent.AsElementAccessExpression().Expression == template
-			if isMemberReceiver && ast.GetExpressionPrecedence(interpolation) < ast.OperatorPrecedenceMember {
+			parentIsNullishCoalescing := ast.IsBinaryExpression(template.Parent) &&
+				template.Parent.AsBinaryExpression().OperatorToken.Kind == ast.KindQuestionQuestionToken
+			interpolationIsLogical := ast.IsBinaryExpression(interpolation) &&
+				(interpolation.AsBinaryExpression().OperatorToken.Kind == ast.KindBarBarToken ||
+					interpolation.AsBinaryExpression().OperatorToken.Kind == ast.KindAmpersandAmpersandToken)
+			needsParentheses := parentIsNullishCoalescing && interpolationIsLogical ||
+				ast.IsExpression(template.Parent) &&
+					ast.GetExpressionPrecedence(interpolation) <= ast.GetExpressionPrecedence(template.Parent)
+			if needsParentheses {
 				text = "(" + text + ")"
 			}
 

--- a/internal/rules/no_unnecessary_template_expression/no_unnecessary_template_expression_test.go
+++ b/internal/rules/no_unnecessary_template_expression/no_unnecessary_template_expression_test.go
@@ -1666,5 +1666,32 @@ type Bar = Foo;
 				},
 			},
 		},
+		{
+			Code:   `const value = "foo" + ` + "`" + `${cond ? "bar" : "baz"}` + "`" + `;`,
+			Output: []string{`const value = "foo" + (cond ? "bar" : "baz");`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noUnnecessaryTemplateExpression",
+				},
+			},
+		},
+		{
+			Code:   "declare const a: string;\n`${a || 'b'}` ?? 'c';",
+			Output: []string{"declare const a: string;\n(a || 'b') ?? 'c';"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noUnnecessaryTemplateExpression",
+				},
+			},
+		},
+		{
+			Code:   "declare const b: string;\n'a' ?? `${b && 'c'}`;",
+			Output: []string{"declare const b: string;\n'a' ?? (b && 'c');"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noUnnecessaryTemplateExpression",
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
Fixes oxc-project/oxc#24734.

When a template literal consists of a single string-typed interpolation, compare the interpolation precedence with the destination parent before removing the template wrapper. Add parentheses when the moved expression would otherwise bind differently.

Adds a regression for a conditional interpolation used as the right operand of `+`.
