### PR TITLE
feat(no-unsafe-return): improve diagnostics

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -2526,12 +2526,28 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unsafe-return/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Returned expression has type \`any\`.",
+        "range": {
+          "end": 135,
+          "pos": 127,
+        },
+      },
+      {
+        "label": "Function expects return type \`string\`.",
+        "range": {
+          "end": 115,
+          "pos": 109,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe return of a value of type \`any\`.",
       "id": "unsafeReturn",
     },
     "range": {
-      "end": 136,
+      "end": 126,
       "pos": 120,
     },
     "rule": "no-unsafe-return",
@@ -2539,25 +2555,57 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unsafe-return/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Returned expression has type \`any\`.",
+        "range": {
+          "end": 197,
+          "pos": 189,
+        },
+      },
+      {
+        "label": "Function expects return type \`number\`.",
+        "range": {
+          "end": 185,
+          "pos": 179,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe return of a value of type \`any\`.",
       "id": "unsafeReturn",
     },
     "range": {
-      "end": 197,
-      "pos": 189,
+      "end": 188,
+      "pos": 186,
     },
     "rule": "no-unsafe-return",
   },
   {
     "file_path": "fixtures/basic/rules/no-unsafe-return/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Returned expression has type \`any\`.",
+        "range": {
+          "end": 290,
+          "pos": 282,
+        },
+      },
+      {
+        "label": "Function expects return type \`{ name: string; age: number; }\`.",
+        "range": {
+          "end": 270,
+          "pos": 241,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe return of a value of type \`any\`.",
       "id": "unsafeReturn",
     },
     "range": {
-      "end": 291,
+      "end": 281,
       "pos": 275,
     },
     "rule": "no-unsafe-return",
@@ -2636,12 +2684,21 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unsafe-type-assertion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Returned expression has type \`any\`.",
+        "range": {
+          "end": 332,
+          "pos": 310,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe return of a value of type \`any\`.",
       "id": "unsafeReturn",
     },
     "range": {
-      "end": 333,
+      "end": 309,
       "pos": 303,
     },
     "rule": "no-unsafe-return",

--- a/internal/rule_tester/__snapshots__/no-unsafe-return.snap
+++ b/internal/rule_tester/__snapshots__/no-unsafe-return.snap
@@ -1,307 +1,567 @@
 
 [TestNoUnsafeReturnRule/invalid-0 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:18)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `any`.
    2 | function foo() {
    3 |   return 1 as any;
-     |   ~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `any`. (3:10 - 3:17)
+   2 | function foo() {
+   3 |   return 1 as any;
+     |          ^^^^^^^^ Returned expression has type `any`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-1 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:29)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `any`.
    2 | function foo() {
    3 |   return Object.create(null);
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `any`. (3:10 - 3:28)
+   2 | function foo() {
+   3 |   return Object.create(null);
+     |          ^^^^^^^^^^^^^^^^^^^ Returned expression has type `any`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-2 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:18)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `any`.
    2 | const foo = () => {
    3 |   return 1 as any;
-     |   ~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | };
+  Label: Returned expression has type `any`. (3:10 - 3:17)
+   2 | const foo = () => {
+   3 |   return 1 as any;
+     |          ^^^^^^^^ Returned expression has type `any`.
    4 | };
 ---
 
 [TestNoUnsafeReturnRule/invalid-3 - 1]
-Diagnostic 1: unsafeReturn (1:19 - 1:37)
+Diagnostic 1: unsafeReturn (1:16 - 1:17)
 Message: Unsafe return of a value of type `any`.
    1 | const foo = () => Object.create(null);
-     |                   ~~~~~~~~~~~~~~~~~~~
+     |                ~~
+  Label: Returned expression has type `any`. (1:19 - 1:37)
+   1 | const foo = () => Object.create(null);
+     |                   ^^^^^^^^^^^^^^^^^^^ Returned expression has type `any`.
 ---
 
 [TestNoUnsafeReturnRule/invalid-4 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:21)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `any[]`.
    2 | function foo() {
    3 |   return [] as any[];
-     |   ~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `any[]`. (3:10 - 3:20)
+   2 | function foo() {
+   3 |   return [] as any[];
+     |          ^^^^^^^^^^^ Returned expression has type `any[]`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-5 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:26)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `any[]`.
    2 | function foo() {
    3 |   return [] as Array<any>;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `any[]`. (3:10 - 3:25)
+   2 | function foo() {
+   3 |   return [] as Array<any>;
+     |          ^^^^^^^^^^^^^^^^ Returned expression has type `any[]`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-6 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:30)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `any[]`.
    2 | function foo() {
    3 |   return [] as readonly any[];
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `readonly any[]`. (3:10 - 3:29)
+   2 | function foo() {
+   3 |   return [] as readonly any[];
+     |          ^^^^^^^^^^^^^^^^^^^^ Returned expression has type `readonly any[]`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-7 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:31)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `any[]`.
    2 | function foo() {
    3 |   return [] as Readonly<any[]>;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `readonly any[]`. (3:10 - 3:30)
+   2 | function foo() {
+   3 |   return [] as Readonly<any[]>;
+     |          ^^^^^^^^^^^^^^^^^^^^^ Returned expression has type `readonly any[]`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-8 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:21)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `any[]`.
    2 | const foo = () => {
    3 |   return [] as any[];
-     |   ~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | };
+  Label: Returned expression has type `any[]`. (3:10 - 3:20)
+   2 | const foo = () => {
+   3 |   return [] as any[];
+     |          ^^^^^^^^^^^ Returned expression has type `any[]`.
    4 | };
 ---
 
 [TestNoUnsafeReturnRule/invalid-9 - 1]
-Diagnostic 1: unsafeReturn (1:19 - 1:29)
+Diagnostic 1: unsafeReturn (1:16 - 1:17)
 Message: Unsafe return of a value of type `any[]`.
    1 | const foo = () => [] as any[];
-     |                   ~~~~~~~~~~~
+     |                ~~
+  Label: Returned expression has type `any[]`. (1:19 - 1:29)
+   1 | const foo = () => [] as any[];
+     |                   ^^^^^^^^^^^ Returned expression has type `any[]`.
 ---
 
 [TestNoUnsafeReturnRule/invalid-10 - 1]
-Diagnostic 1: unsafeReturnAssignment (3:3 - 3:24)
+Diagnostic 1: unsafeReturnAssignment (3:3 - 3:8)
 Message: Unsafe return of type `Set<any>` from function with return type `Set<string>`.
    2 | function foo(): Set<string> {
    3 |   return new Set<any>();
-     |   ~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    4 | }
+  Label: Returned expression has type `Set<any>`. (3:10 - 3:23)
+   2 | function foo(): Set<string> {
+   3 |   return new Set<any>();
+     |          ^^^^^^^^^^^^^^ Returned expression has type `Set<any>`.
+   4 | }
+  Label: Function expects return type `Set<string>`. (2:17 - 2:27)
+   1 | 
+   2 | function foo(): Set<string> {
+     |                 ^^^^^^^^^^^ Function expects return type `Set<string>`.
+   3 |   return new Set<any>();
 ---
 
 [TestNoUnsafeReturnRule/invalid-11 - 1]
-Diagnostic 1: unsafeReturnAssignment (3:3 - 3:32)
+Diagnostic 1: unsafeReturnAssignment (3:3 - 3:8)
 Message: Unsafe return of type `Map<string, any>` from function with return type `Map<string, string>`.
    2 | function foo(): Map<string, string> {
    3 |   return new Map<string, any>();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    4 | }
+  Label: Returned expression has type `Map<string, any>`. (3:10 - 3:31)
+   2 | function foo(): Map<string, string> {
+   3 |   return new Map<string, any>();
+     |          ^^^^^^^^^^^^^^^^^^^^^^ Returned expression has type `Map<string, any>`.
+   4 | }
+  Label: Function expects return type `Map<string, string>`. (2:17 - 2:35)
+   1 | 
+   2 | function foo(): Map<string, string> {
+     |                 ^^^^^^^^^^^^^^^^^^^ Function expects return type `Map<string, string>`.
+   3 |   return new Map<string, any>();
 ---
 
 [TestNoUnsafeReturnRule/invalid-12 - 1]
-Diagnostic 1: unsafeReturnAssignment (3:3 - 3:26)
+Diagnostic 1: unsafeReturnAssignment (3:3 - 3:8)
 Message: Unsafe return of type `Set<any[]>` from function with return type `Set<string[]>`.
    2 | function foo(): Set<string[]> {
    3 |   return new Set<any[]>();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    4 | }
+  Label: Returned expression has type `Set<any[]>`. (3:10 - 3:25)
+   2 | function foo(): Set<string[]> {
+   3 |   return new Set<any[]>();
+     |          ^^^^^^^^^^^^^^^^ Returned expression has type `Set<any[]>`.
+   4 | }
+  Label: Function expects return type `Set<string[]>`. (2:17 - 2:29)
+   1 | 
+   2 | function foo(): Set<string[]> {
+     |                 ^^^^^^^^^^^^^ Function expects return type `Set<string[]>`.
+   3 |   return new Set<any[]>();
 ---
 
 [TestNoUnsafeReturnRule/invalid-13 - 1]
-Diagnostic 1: unsafeReturnAssignment (3:3 - 3:34)
+Diagnostic 1: unsafeReturnAssignment (3:3 - 3:8)
 Message: Unsafe return of type `Set<Set<Set<any>>>` from function with return type `Set<Set<Set<string>>>`.
    2 | function foo(): Set<Set<Set<string>>> {
    3 |   return new Set<Set<Set<any>>>();
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    4 | }
+  Label: Returned expression has type `Set<Set<Set<any>>>`. (3:10 - 3:33)
+   2 | function foo(): Set<Set<Set<string>>> {
+   3 |   return new Set<Set<Set<any>>>();
+     |          ^^^^^^^^^^^^^^^^^^^^^^^^ Returned expression has type `Set<Set<Set<any>>>`.
+   4 | }
+  Label: Function expects return type `Set<Set<Set<string>>>`. (2:17 - 2:37)
+   1 | 
+   2 | function foo(): Set<Set<Set<string>>> {
+     |                 ^^^^^^^^^^^^^^^^^^^^^ Function expects return type `Set<Set<Set<string>>>`.
+   3 |   return new Set<Set<Set<any>>>();
 ---
 
 [TestNoUnsafeReturnRule/invalid-14 - 1]
-Diagnostic 1: unsafeReturnAssignment (3:24 - 3:37)
+Diagnostic 1: unsafeReturnAssignment (3:21 - 3:22)
 Message: Unsafe return of type `Set<any>` from function with return type `Set<string>`.
    2 | type Fn = () => Set<string>;
    3 | const foo1: Fn = () => new Set<any>();
-     |                        ~~~~~~~~~~~~~~
+     |                     ~~
    4 | const foo2: Fn = function test() {
+  Label: Returned expression has type `Set<any>`. (3:24 - 3:37)
+   2 | type Fn = () => Set<string>;
+   3 | const foo1: Fn = () => new Set<any>();
+     |                        ^^^^^^^^^^^^^^ Returned expression has type `Set<any>`.
+   4 | const foo2: Fn = function test() {
+  Label: Function expects return type `Set<string>`. (2:17 - 2:27)
+   1 | 
+   2 | type Fn = () => Set<string>;
+     |                 ^^^^^^^^^^^ Function expects return type `Set<string>`.
+   3 | const foo1: Fn = () => new Set<any>();
 
-Diagnostic 2: unsafeReturnAssignment (5:3 - 5:24)
+Diagnostic 2: unsafeReturnAssignment (5:3 - 5:8)
 Message: Unsafe return of type `Set<any>` from function with return type `Set<string>`.
    4 | const foo2: Fn = function test() {
    5 |   return new Set<any>();
-     |   ~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    6 | };
+  Label: Returned expression has type `Set<any>`. (5:10 - 5:23)
+   4 | const foo2: Fn = function test() {
+   5 |   return new Set<any>();
+     |          ^^^^^^^^^^^^^^ Returned expression has type `Set<any>`.
+   6 | };
+  Label: Function expects return type `Set<string>`. (2:17 - 2:27)
+   1 | 
+   2 | type Fn = () => Set<string>;
+     |                 ^^^^^^^^^^^ Function expects return type `Set<string>`.
+   3 | const foo1: Fn = () => new Set<any>();
 ---
 
 [TestNoUnsafeReturnRule/invalid-15 - 1]
-Diagnostic 1: unsafeReturnAssignment (4:16 - 4:29)
+Diagnostic 1: unsafeReturnAssignment (4:13 - 4:14)
 Message: Unsafe return of type `Set<any>` from function with return type `Set<string>`.
    3 | function receiver(arg: Fn) {}
    4 | receiver(() => new Set<any>());
-     |                ~~~~~~~~~~~~~~
+     |             ~~
    5 | receiver(function test() {
+  Label: Returned expression has type `Set<any>`. (4:16 - 4:29)
+   3 | function receiver(arg: Fn) {}
+   4 | receiver(() => new Set<any>());
+     |                ^^^^^^^^^^^^^^ Returned expression has type `Set<any>`.
+   5 | receiver(function test() {
+  Label: Function expects return type `Set<string>`. (2:17 - 2:27)
+   1 | 
+   2 | type Fn = () => Set<string>;
+     |                 ^^^^^^^^^^^ Function expects return type `Set<string>`.
+   3 | function receiver(arg: Fn) {}
 
-Diagnostic 2: unsafeReturnAssignment (6:3 - 6:24)
+Diagnostic 2: unsafeReturnAssignment (6:3 - 6:8)
 Message: Unsafe return of type `Set<any>` from function with return type `Set<string>`.
    5 | receiver(function test() {
    6 |   return new Set<any>();
-     |   ~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    7 | });
+  Label: Returned expression has type `Set<any>`. (6:10 - 6:23)
+   5 | receiver(function test() {
+   6 |   return new Set<any>();
+     |          ^^^^^^^^^^^^^^ Returned expression has type `Set<any>`.
+   7 | });
+  Label: Function expects return type `Set<string>`. (2:17 - 2:27)
+   1 | 
+   2 | type Fn = () => Set<string>;
+     |                 ^^^^^^^^^^^ Function expects return type `Set<string>`.
+   3 | function receiver(arg: Fn) {}
 ---
 
 [TestNoUnsafeReturnRule/invalid-16 - 1]
-Diagnostic 1: unsafeReturnThis (3:3 - 3:14)
+Diagnostic 1: unsafeReturnThis (3:3 - 3:8)
 Message: Unsafe return of a value of type ``any``. `this` is typed as `any`.
 Help: You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.
    2 | function foo() {
    3 |   return this;
-     |   ~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `any`. (3:10 - 3:13)
+   2 | function foo() {
+   3 |   return this;
+     |          ^^^^ Returned expression has type `any`.
    4 | }
 
-Diagnostic 2: unsafeReturnThis (7:16 - 7:19)
+Diagnostic 2: unsafeReturnThis (7:13 - 7:14)
 Message: Unsafe return of a value of type ``any``. `this` is typed as `any`.
 Help: You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.
    6 | function bar() {
    7 |   return () => this;
-     |                ~~~~
+     |             ~~
+   8 | }
+  Label: Returned expression has type `any`. (7:16 - 7:19)
+   6 | function bar() {
+   7 |   return () => this;
+     |                ^^^^ Returned expression has type `any`.
    8 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-17 - 1]
-Diagnostic 1: unsafeReturn (3:11 - 3:22)
+Diagnostic 1: unsafeReturn (3:8 - 3:9)
 Message: Unsafe return of a value of type `any`.
    2 | declare function foo(arg: null | (() => any)): void;
    3 | foo(() => 'foo' as any);
-     |           ~~~~~~~~~~~~
+     |        ~~
    4 |       
+  Label: Returned expression has type `any`. (3:11 - 3:22)
+   2 | declare function foo(arg: null | (() => any)): void;
+   3 | foo(() => 'foo' as any);
+     |           ^^^^^^^^^^^^ Returned expression has type `any`.
+   4 |       
+  Label: Function expects return type `any`. (2:41 - 2:43)
+   1 | 
+   2 | declare function foo(arg: null | (() => any)): void;
+     |                                         ^^^ Function expects return type `any`.
+   3 | foo(() => 'foo' as any);
 ---
 
 [TestNoUnsafeReturnRule/invalid-18 - 1]
-Diagnostic 1: unsafeReturn (5:3 - 5:15)
+Diagnostic 1: unsafeReturn (5:3 - 5:8)
 Message: Unsafe return of a value of type error.
    4 | function example() {
    5 |   return value;
-     |   ~~~~~~~~~~~~~
+     |   ~~~~~~
+   6 | }
+  Label: Returned expression has type `error`. (5:10 - 5:14)
+   4 | function example() {
+   5 |   return value;
+     |          ^^^^^ Returned expression has type `error`.
    6 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-19 - 1]
-Diagnostic 1: unsafeReturn (4:3 - 4:15)
+Diagnostic 1: unsafeReturn (4:3 - 4:8)
 Message: Unsafe return of a value of type `any`.
    3 | async function foo() {
    4 |   return value;
-     |   ~~~~~~~~~~~~~
+     |   ~~~~~~
+   5 | }
+  Label: Returned expression has type `any`. (4:10 - 4:14)
+   3 | async function foo() {
+   4 |   return value;
+     |          ^^^^^ Returned expression has type `any`.
    5 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-20 - 1]
-Diagnostic 1: unsafeReturn (4:3 - 4:15)
+Diagnostic 1: unsafeReturn (4:3 - 4:8)
 Message: Unsafe return of a value of type `Promise<any>`.
    3 | async function foo(): Promise<number> {
    4 |   return value;
-     |   ~~~~~~~~~~~~~
+     |   ~~~~~~
    5 | }
+  Label: Returned expression has type `Promise<any>`. (4:10 - 4:14)
+   3 | async function foo(): Promise<number> {
+   4 |   return value;
+     |          ^^^^^ Returned expression has type `Promise<any>`.
+   5 | }
+  Label: Function expects return type `Promise<number>`. (3:23 - 3:37)
+   2 | declare const value: Promise<any>;
+   3 | async function foo(): Promise<number> {
+     |                       ^^^^^^^^^^^^^^^ Function expects return type `Promise<number>`.
+   4 |   return value;
 ---
 
 [TestNoUnsafeReturnRule/invalid-21 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:29)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `Promise<any>`.
    2 | async function foo(arg: number) {
    3 |   return arg as Promise<any>;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `Promise<any>`. (3:10 - 3:28)
+   2 | async function foo(arg: number) {
+   3 |   return arg as Promise<any>;
+     |          ^^^^^^^^^^^^^^^^^^^ Returned expression has type `Promise<any>`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-22 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:19)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `any`.
    2 | function foo(): Promise<any> {
    3 |   return {} as any;
-     |   ~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    4 | }
+  Label: Returned expression has type `any`. (3:10 - 3:18)
+   2 | function foo(): Promise<any> {
+   3 |   return {} as any;
+     |          ^^^^^^^^^ Returned expression has type `any`.
+   4 | }
+  Label: Function expects return type `Promise<any>`. (2:17 - 2:28)
+   1 | 
+   2 | function foo(): Promise<any> {
+     |                 ^^^^^^^^^^^^ Function expects return type `Promise<any>`.
+   3 |   return {} as any;
 ---
 
 [TestNoUnsafeReturnRule/invalid-23 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:19)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `any`.
    2 | function foo(): Promise<object> {
    3 |   return {} as any;
-     |   ~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    4 | }
+  Label: Returned expression has type `any`. (3:10 - 3:18)
+   2 | function foo(): Promise<object> {
+   3 |   return {} as any;
+     |          ^^^^^^^^^ Returned expression has type `any`.
+   4 | }
+  Label: Function expects return type `Promise<object>`. (2:17 - 2:31)
+   1 | 
+   2 | function foo(): Promise<object> {
+     |                 ^^^^^^^^^^^^^^^ Function expects return type `Promise<object>`.
+   3 |   return {} as any;
 ---
 
 [TestNoUnsafeReturnRule/invalid-24 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:34)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `Promise<any>`.
    2 | async function foo(): Promise<object> {
    3 |   return Promise.resolve<any>({});
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    4 | }
+  Label: Returned expression has type `Promise<any>`. (3:10 - 3:33)
+   2 | async function foo(): Promise<object> {
+   3 |   return Promise.resolve<any>({});
+     |          ^^^^^^^^^^^^^^^^^^^^^^^^ Returned expression has type `Promise<any>`.
+   4 | }
+  Label: Function expects return type `Promise<object>`. (2:23 - 2:37)
+   1 | 
+   2 | async function foo(): Promise<object> {
+     |                       ^^^^^^^^^^^^^^^ Function expects return type `Promise<object>`.
+   3 |   return Promise.resolve<any>({});
 ---
 
 [TestNoUnsafeReturnRule/invalid-25 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:68)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `Promise<any>`.
    2 | async function foo(): Promise<object> {
    3 |   return Promise.resolve<Promise<Promise<any>>>({} as Promise<any>);
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    4 | }
+  Label: Returned expression has type `Promise<any>`. (3:10 - 3:67)
+   2 | async function foo(): Promise<object> {
+   3 |   return Promise.resolve<Promise<Promise<any>>>({} as Promise<any>);
+     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Returned expression has type `Promise<any>`.
+   4 | }
+  Label: Function expects return type `Promise<object>`. (2:23 - 2:37)
+   1 | 
+   2 | async function foo(): Promise<object> {
+     |                       ^^^^^^^^^^^^^^^ Function expects return type `Promise<object>`.
+   3 |   return Promise.resolve<Promise<Promise<any>>>({} as Promise<any>);
 ---
 
 [TestNoUnsafeReturnRule/invalid-26 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:55)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `Promise<any>`.
    2 | async function foo(): Promise<object> {
    3 |   return {} as Promise<Promise<Promise<Promise<any>>>>;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
    4 | }
+  Label: Returned expression has type `Promise<Promise<Promise<Promise<any>>>>`. (3:10 - 3:54)
+   2 | async function foo(): Promise<object> {
+   3 |   return {} as Promise<Promise<Promise<Promise<any>>>>;
+     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Returned expression has type `Promise<Promise<Promise<Promise<any>>>>`.
+   4 | }
+  Label: Function expects return type `Promise<object>`. (2:23 - 2:37)
+   1 | 
+   2 | async function foo(): Promise<object> {
+     |                       ^^^^^^^^^^^^^^^ Function expects return type `Promise<object>`.
+   3 |   return {} as Promise<Promise<Promise<Promise<any>>>>;
 ---
 
 [TestNoUnsafeReturnRule/invalid-27 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:55)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `Promise<any>`.
    2 | async function foo() {
    3 |   return {} as Promise<Promise<Promise<Promise<any>>>>;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `Promise<Promise<Promise<Promise<any>>>>`. (3:10 - 3:54)
+   2 | async function foo() {
+   3 |   return {} as Promise<Promise<Promise<Promise<any>>>>;
+     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Returned expression has type `Promise<Promise<Promise<Promise<any>>>>`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-28 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:46)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `Promise<any>`.
    2 | async function foo() {
    3 |   return {} as Promise<any> | Promise<object>;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `Promise<any> | Promise<object>`. (3:10 - 3:45)
+   2 | async function foo() {
+   3 |   return {} as Promise<any> | Promise<object>;
+     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Returned expression has type `Promise<any> | Promise<object>`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-29 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:37)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `Promise<any>`.
    2 | async function foo() {
    3 |   return {} as Promise<any | object>;
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `Promise<any>`. (3:10 - 3:36)
+   2 | async function foo() {
+   3 |   return {} as Promise<any | object>;
+     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Returned expression has type `Promise<any>`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-30 - 1]
-Diagnostic 1: unsafeReturn (3:3 - 3:49)
+Diagnostic 1: unsafeReturn (3:3 - 3:8)
 Message: Unsafe return of a value of type `Promise<any>`.
    2 | async function foo() {
    3 |   return {} as Promise<any> & { __brand: 'any' };
-     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~
+   4 | }
+  Label: Returned expression has type `Promise<any> & { __brand: "any"; }`. (3:10 - 3:48)
+   2 | async function foo() {
+   3 |   return {} as Promise<any> & { __brand: 'any' };
+     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Returned expression has type `Promise<any> & { __brand: "any"; }`.
    4 | }
 ---
 
 [TestNoUnsafeReturnRule/invalid-31 - 1]
-Diagnostic 1: unsafeReturn (8:3 - 8:15)
+Diagnostic 1: unsafeReturn (8:3 - 8:8)
 Message: Unsafe return of a value of type `Promise<any>`.
    7 | async function foo() {
    8 |   return value;
-     |   ~~~~~~~~~~~~~
+     |   ~~~~~~
    9 | }
+  Label: Returned expression has type `Alias<number>`. (8:10 - 8:14)
+   7 | async function foo() {
+   8 |   return value;
+     |          ^^^^^ Returned expression has type `Alias<number>`.
+   9 | }
+---
+
+[TestNoUnsafeReturnRule/invalid-32 - 1]
+Diagnostic 1: unsafeReturnAssignment (3:20 - 3:21)
+Message: Unsafe return of type `Set<any>` from function with return type `Set<string>`.
+   2 | import type { Fn } from 'return-types';
+   3 | const foo: Fn = () => new Set<any>();
+     |                    ~~
+   4 |       
+  Label: Returned expression has type `Set<any>`. (3:23 - 3:36)
+   2 | import type { Fn } from 'return-types';
+   3 | const foo: Fn = () => new Set<any>();
+     |                       ^^^^^^^^^^^^^^ Returned expression has type `Set<any>`.
+   4 |       
 ---

--- a/internal/rules/no_unsafe_return/no_unsafe_return.go
+++ b/internal/rules/no_unsafe_return/no_unsafe_return.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/typescript-eslint/tsgolint/internal/rule"
 	"github.com/typescript-eslint/tsgolint/internal/utils"
 )
@@ -29,6 +31,40 @@ func buildUnsafeReturnThisMessage(t string) rule.RuleMessage {
 	}
 }
 
+func buildUnsafeReturnDiagnostic(
+	message rule.RuleMessage,
+	primaryRange core.TextRange,
+	returnedRange core.TextRange,
+	returnedType string,
+	expectedRange *core.TextRange,
+	expectedType string,
+) rule.RuleDiagnostic {
+	diagnostic := rule.RuleDiagnostic{
+		Range:   primaryRange,
+		Message: message,
+		LabeledRanges: []rule.RuleLabeledRange{
+			{
+				Label: fmt.Sprintf("Returned expression has type `%s`.", returnedType),
+				Range: returnedRange,
+			},
+		},
+	}
+	if expectedRange != nil {
+		diagnostic.LabeledRanges = append(diagnostic.LabeledRanges, rule.RuleLabeledRange{
+			Label: fmt.Sprintf("Function expects return type `%s`.", expectedType),
+			Range: *expectedRange,
+		})
+	}
+	return diagnostic
+}
+
+func renderReturnType(typeChecker *checker.Checker, t *checker.Type) string {
+	if utils.IsIntrinsicErrorType(t) {
+		return "error"
+	}
+	return typeChecker.TypeToString(t)
+}
+
 var NoUnsafeReturnRule = rule.Rule{
 	Name: "no-unsafe-return",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
@@ -40,7 +76,7 @@ var NoUnsafeReturnRule = rule.Rule{
 
 		checkReturn := func(
 			returnNode *ast.Node,
-			reportingNode *ast.Node,
+			primaryRange core.TextRange,
 		) {
 			t := ctx.TypeChecker.GetTypeAtLocation(returnNode)
 
@@ -63,13 +99,43 @@ var NoUnsafeReturnRule = rule.Rule{
 			// const foo1: () => Set<string> = () => new Set<any>();
 			// the return type of the arrow function is Set<any> even though the variable is typed as Set<string>
 			var functionType *checker.Type
+			usesContextualType := false
 			if ast.IsFunctionExpression(functionNode) || ast.IsArrowFunction(functionNode) {
 				functionType = utils.GetContextualType(ctx.TypeChecker, functionNode)
+				usesContextualType = functionType != nil
 			}
 			if functionType == nil {
 				functionType = ctx.TypeChecker.GetTypeAtLocation(functionNode)
 			}
 			callSignatures := utils.CollectAllCallSignatures(ctx.TypeChecker, functionType)
+			var expectedRange *core.TextRange
+			var expectedType string
+			if returnTypeNode := functionNode.Type(); returnTypeNode != nil {
+				r := utils.TrimNodeTextRange(ctx.SourceFile, returnTypeNode)
+				expectedRange = &r
+				expectedType = renderReturnType(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(returnTypeNode))
+			} else if usesContextualType {
+				for _, signature := range callSignatures {
+					declaration := checker.Signature_declaration(signature)
+					if declaration == nil || declaration.Type() == nil || ast.GetSourceFileOfNode(declaration) != ctx.SourceFile {
+						continue
+					}
+					r := utils.TrimNodeTextRange(ctx.SourceFile, declaration.Type())
+					expectedRange = &r
+					expectedType = renderReturnType(ctx.TypeChecker, checker.Checker_getReturnTypeOfSignature(ctx.TypeChecker, signature))
+					break
+				}
+			}
+			report := func(message rule.RuleMessage) {
+				ctx.ReportDiagnostic(buildUnsafeReturnDiagnostic(
+					message,
+					primaryRange,
+					utils.TrimNodeTextRange(ctx.SourceFile, returnNode),
+					renderReturnType(ctx.TypeChecker, returnNodeType),
+					expectedRange,
+					expectedType,
+				))
+			}
 			// If there is an explicit type annotation *and* that type matches the actual
 			// function return type, we shouldn't complain (it's intentional, even if unsafe)
 			if functionNode.Type() != nil {
@@ -133,12 +199,12 @@ var NoUnsafeReturnRule = rule.Rule{
 					// `return this`
 					thisExpression := utils.GetThisExpression(returnNode)
 					if thisExpression != nil && utils.IsTypeAnyType(utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, thisExpression)) {
-						ctx.ReportNode(reportingNode, buildUnsafeReturnThisMessage(typeString))
+						report(buildUnsafeReturnThisMessage(typeString))
 						return
 					}
 				}
 				// If the function return type was not unknown/unknown[], mark usage as unsafeReturn.
-				ctx.ReportNode(reportingNode, buildUnsafeReturnMessage(typeString))
+				report(buildUnsafeReturnMessage(typeString))
 				return
 			}
 
@@ -160,14 +226,14 @@ var NoUnsafeReturnRule = rule.Rule{
 				return
 			}
 
-			ctx.ReportNode(reportingNode, buildUnsafeReturnAssignmentMessage(ctx.TypeChecker.TypeToString(sender), ctx.TypeChecker.TypeToString(receiver)))
+			report(buildUnsafeReturnAssignmentMessage(ctx.TypeChecker.TypeToString(sender), ctx.TypeChecker.TypeToString(receiver)))
 		}
 
 		return rule.RuleListeners{
 			ast.KindArrowFunction: func(node *ast.Node) {
 				body := node.Body()
 				if !ast.IsBlock(body) {
-					checkReturn(body, body)
+					checkReturn(body, utils.TrimNodeTextRange(ctx.SourceFile, node.AsArrowFunction().EqualsGreaterThanToken))
 				}
 			},
 			ast.KindReturnStatement: func(node *ast.Node) {
@@ -176,7 +242,7 @@ var NoUnsafeReturnRule = rule.Rule{
 					return
 				}
 
-				checkReturn(argument, node)
+				checkReturn(argument, scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, node.Pos()))
 			},
 		}
 	},

--- a/internal/rules/no_unsafe_return/no_unsafe_return_test.go
+++ b/internal/rules/no_unsafe_return/no_unsafe_return_test.go
@@ -3,9 +3,44 @@ package no_unsafe_return
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/typescript-eslint/tsgolint/internal/rule_tester"
 	"github.com/typescript-eslint/tsgolint/internal/rules/fixtures"
 )
+
+func TestDiagnosticRangesAndLabels(t *testing.T) {
+	t.Parallel()
+
+	primaryRange := core.NewTextRange(10, 6)
+	returnedRange := core.NewTextRange(17, 12)
+	expectedRange := core.NewTextRange(2, 7)
+	diagnostic := buildUnsafeReturnDiagnostic(
+		buildUnsafeReturnAssignmentMessage("Set<any>", "Set<string>"),
+		primaryRange,
+		returnedRange,
+		"Set<any>",
+		&expectedRange,
+		"Set<string>",
+	)
+
+	if diagnostic.Range != primaryRange {
+		t.Fatalf("primary range = %v, want %v", diagnostic.Range, primaryRange)
+	}
+	if len(diagnostic.LabeledRanges) != 2 {
+		t.Fatalf("labels = %d, want 2", len(diagnostic.LabeledRanges))
+	}
+	if diagnostic.LabeledRanges[0].Label != "Returned expression has type `Set<any>`." || diagnostic.LabeledRanges[0].Range != returnedRange {
+		t.Fatalf("returned expression label = %+v", diagnostic.LabeledRanges[0])
+	}
+	if diagnostic.LabeledRanges[1].Label != "Function expects return type `Set<string>`." || diagnostic.LabeledRanges[1].Range != expectedRange {
+		t.Fatalf("expected return label = %+v", diagnostic.LabeledRanges[1])
+	}
+
+	withoutExpectation := buildUnsafeReturnDiagnostic(buildUnsafeReturnMessage("`any`"), primaryRange, returnedRange, "any", nil, "")
+	if len(withoutExpectation.LabeledRanges) != 1 {
+		t.Fatalf("labels without local expectation = %d, want 1", len(withoutExpectation.LabeledRanges))
+	}
+}
 
 func TestNoUnsafeReturnRule(t *testing.T) {
 	t.Parallel()
@@ -373,13 +408,13 @@ function bar() {
 					MessageId: "unsafeReturnThis",
 					Line:      3,
 					Column:    3,
-					EndColumn: 15,
+					EndColumn: 9,
 				},
 				{
 					MessageId: "unsafeReturnThis",
 					Line:      7,
-					Column:    16,
-					EndColumn: 20,
+					Column:    13,
+					EndColumn: 15,
 				},
 			},
 		},
@@ -392,8 +427,8 @@ foo(() => 'foo' as any);
 				{
 					MessageId: "unsafeReturn",
 					Line:      3,
-					Column:    11,
-					EndColumn: 23,
+					Column:    8,
+					EndColumn: 10,
 				},
 			},
 		},
@@ -410,7 +445,7 @@ function example() {
 					MessageId: "unsafeReturn",
 					Line:      5,
 					Column:    3,
-					EndColumn: 16,
+					EndColumn: 9,
 				},
 			},
 		},
@@ -600,6 +635,28 @@ async function foo() {
 					MessageId: "unsafeReturn",
 					Line:      8,
 					Column:    3,
+				},
+			},
+		},
+		{
+			Code: `
+import type { Fn } from 'return-types';
+const foo: Fn = () => new Set<any>();
+      `,
+			Files: map[string]string{
+				"node_modules/return-types/package.json": `{
+  "name": "return-types",
+  "version": "1.0.0",
+  "types": "index.d.ts"
+}`,
+				"node_modules/return-types/index.d.ts": `export type Fn = () => Set<string>;`,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unsafeReturnAssignment",
+					Line:      3,
+					Column:    20,
+					EndColumn: 22,
 				},
 			},
 		},


### PR DESCRIPTION
Part of #677.

Improves no-unsafe-return diagnostics by:
- narrowing primary ranges to return and concise-arrow syntax
- labeling returned expressions with their actual rendered types
- labeling same-file explicit and contextual return expectations
- omitting unsafe cross-file expectation ranges
- covering any, Promise<any>, any-array, and implicit-this cases
- updating focused and e2e snapshots

Tests:
- go test ./internal/rules/no_unsafe_return
- cd e2e and pnpm --ignore-workspace run test --run