### PR TITLE
feat(no-unsafe-type-assertion): improve diagnostics

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -2034,26 +2034,58 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unnecessary-type-parameters/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Original expression has type \`string\`.",
+        "range": {
+          "end": 127,
+          "pos": 122,
+        },
+      },
+      {
+        "label": "Asserted type is \`any\`.",
+        "range": {
+          "end": 134,
+          "pos": 131,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assertion to \`any\` detected: consider using a more specific type to ensure safety.",
       "id": "unsafeToAnyTypeAssertion",
     },
     "range": {
       "end": 134,
-      "pos": 122,
+      "pos": 128,
     },
     "rule": "no-unsafe-type-assertion",
   },
   {
     "file_path": "fixtures/basic/rules/no-unnecessary-type-parameters/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Original expression has type \`any\`.",
+        "range": {
+          "end": 134,
+          "pos": 122,
+        },
+      },
+      {
+        "label": "Asserted type is \`T\`.",
+        "range": {
+          "end": 139,
+          "pos": 138,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assertion from \`any\` detected: consider using type guards or a safer assertion.",
       "id": "unsafeOfAnyTypeAssertion",
     },
     "range": {
       "end": 139,
-      "pos": 122,
+      "pos": 135,
     },
     "rule": "no-unsafe-type-assertion",
   },
@@ -2706,52 +2738,116 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-unsafe-type-assertion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Original expression has type \`unknown\`.",
+        "range": {
+          "end": 113,
+          "pos": 108,
+        },
+      },
+      {
+        "label": "Asserted type is \`any\`.",
+        "range": {
+          "end": 120,
+          "pos": 117,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assertion to \`any\` detected: consider using a more specific type to ensure safety.",
       "id": "unsafeToAnyTypeAssertion",
     },
     "range": {
       "end": 120,
-      "pos": 108,
+      "pos": 114,
     },
     "rule": "no-unsafe-type-assertion",
   },
   {
     "file_path": "fixtures/basic/rules/no-unsafe-type-assertion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Original expression has type \`unknown\`.",
+        "range": {
+          "end": 165,
+          "pos": 160,
+        },
+      },
+      {
+        "label": "Asserted type is \`any\`.",
+        "range": {
+          "end": 172,
+          "pos": 169,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assertion to \`any\` detected: consider using a more specific type to ensure safety.",
       "id": "unsafeToAnyTypeAssertion",
     },
     "range": {
       "end": 172,
-      "pos": 160,
+      "pos": 166,
     },
     "rule": "no-unsafe-type-assertion",
   },
   {
     "file_path": "fixtures/basic/rules/no-unsafe-type-assertion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Original expression has type \`any\`.",
+        "range": {
+          "end": 172,
+          "pos": 160,
+        },
+      },
+      {
+        "label": "Asserted type is \`string\`.",
+        "range": {
+          "end": 182,
+          "pos": 176,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assertion from \`any\` detected: consider using type guards or a safer assertion.",
       "id": "unsafeOfAnyTypeAssertion",
     },
     "range": {
       "end": 182,
-      "pos": 160,
+      "pos": 173,
     },
     "rule": "no-unsafe-type-assertion",
   },
   {
     "file_path": "fixtures/basic/rules/no-unsafe-type-assertion/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Original expression has type \`unknown\`.",
+        "range": {
+          "end": 282,
+          "pos": 277,
+        },
+      },
+      {
+        "label": "Asserted type is \`any\`.",
+        "range": {
+          "end": 289,
+          "pos": 286,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe assertion to \`any\` detected: consider using a more specific type to ensure safety.",
       "id": "unsafeToAnyTypeAssertion",
     },
     "range": {
       "end": 289,
-      "pos": 277,
+      "pos": 283,
     },
     "rule": "no-unsafe-type-assertion",
   },
@@ -2844,26 +2940,58 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/non-nullable-type-assertion-style/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Original expression has type \`string | null\`.",
+        "range": {
+          "end": 191,
+          "pos": 186,
+        },
+      },
+      {
+        "label": "Asserted type is \`string\`.",
+        "range": {
+          "end": 201,
+          "pos": 195,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe type assertion: type 'string' is more narrow than the original type.",
       "id": "unsafeTypeAssertion",
     },
     "range": {
       "end": 201,
-      "pos": 186,
+      "pos": 192,
     },
     "rule": "no-unsafe-type-assertion",
   },
   {
     "file_path": "fixtures/basic/rules/non-nullable-type-assertion-style/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Original expression has type \`number | undefined\`.",
+        "range": {
+          "end": 266,
+          "pos": 261,
+        },
+      },
+      {
+        "label": "Asserted type is \`number\`.",
+        "range": {
+          "end": 276,
+          "pos": 270,
+        },
+      },
+    ],
     "message": {
       "description": "Unsafe type assertion: type 'number' is more narrow than the original type.",
       "id": "unsafeTypeAssertion",
     },
     "range": {
       "end": 276,
-      "pos": 261,
+      "pos": 267,
     },
     "rule": "no-unsafe-type-assertion",
   },

--- a/internal/rule_tester/__snapshots__/no-unsafe-type-assertion.snap
+++ b/internal/rule_tester/__snapshots__/no-unsafe-type-assertion.snap
@@ -1,404 +1,844 @@
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-0 - 1]
-Diagnostic 1: unsafeOfAnyTypeAssertion (3:1 - 3:15)
+Diagnostic 1: unsafeOfAnyTypeAssertion (3:7 - 3:15)
 Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
    2 | declare const _any_: any;
    3 | _any_ as string;
-     | ~~~~~~~~~~~~~~~
+     |       ~~~~~~~~~
+   4 |         
+  Label: Original expression has type `any`. (3:1 - 3:5)
+   2 | declare const _any_: any;
+   3 | _any_ as string;
+     | ^^^^^ Original expression has type `any`.
+   4 |         
+  Label: Asserted type is `string`. (3:10 - 3:15)
+   2 | declare const _any_: any;
+   3 | _any_ as string;
+     |          ^^^^^^ Asserted type is `string`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-1 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (3:1 - 3:16)
+Diagnostic 1: unsafeToAnyTypeAssertion (3:11 - 3:16)
 Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    2 | declare const _unknown_: unknown;
    3 | _unknown_ as any;
-     | ~~~~~~~~~~~~~~~~
+     |           ~~~~~~
+   4 |         
+  Label: Original expression has type `unknown`. (3:1 - 3:9)
+   2 | declare const _unknown_: unknown;
+   3 | _unknown_ as any;
+     | ^^^^^^^^^ Original expression has type `unknown`.
+   4 |         
+  Label: Asserted type is `any`. (3:14 - 3:16)
+   2 | declare const _unknown_: unknown;
+   3 | _unknown_ as any;
+     |              ^^^ Asserted type is `any`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-2 - 1]
-Diagnostic 1: unsafeOfAnyTypeAssertion (3:1 - 3:17)
+Diagnostic 1: unsafeOfAnyTypeAssertion (3:7 - 3:17)
 Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
    2 | declare const _any_: any;
    3 | _any_ as Function;
-     | ~~~~~~~~~~~~~~~~~
+     |       ~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `any`. (3:1 - 3:5)
+   2 | declare const _any_: any;
+   3 | _any_ as Function;
+     | ^^^^^ Original expression has type `any`.
+   4 |         
+  Label: Asserted type is `Function`. (3:10 - 3:17)
+   2 | declare const _any_: any;
+   3 | _any_ as Function;
+     |          ^^^^^^^^ Asserted type is `Function`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-3 - 1]
-Diagnostic 1: unsafeOfAnyTypeAssertion (3:1 - 3:14)
+Diagnostic 1: unsafeOfAnyTypeAssertion (3:7 - 3:14)
 Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
    2 | declare const _any_: any;
    3 | _any_ as never;
-     | ~~~~~~~~~~~~~~
+     |       ~~~~~~~~
+   4 |         
+  Label: Original expression has type `any`. (3:1 - 3:5)
+   2 | declare const _any_: any;
+   3 | _any_ as never;
+     | ^^^^^ Original expression has type `any`.
+   4 |         
+  Label: Asserted type is `never`. (3:10 - 3:14)
+   2 | declare const _any_: any;
+   3 | _any_ as never;
+     |          ^^^^^ Asserted type is `never`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-4 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (2:1 - 2:12)
+Diagnostic 1: unsafeToAnyTypeAssertion (2:7 - 2:12)
 Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    1 | 
    2 | 'foo' as any;
-     | ~~~~~~~~~~~~
+     |       ~~~~~~
+   3 |         
+  Label: Original expression has type `"foo"`. (2:1 - 2:5)
+   1 | 
+   2 | 'foo' as any;
+     | ^^^^^ Original expression has type `"foo"`.
+   3 |         
+  Label: Asserted type is `any`. (2:10 - 2:12)
+   1 | 
+   2 | 'foo' as any;
+     |          ^^^ Asserted type is `any`.
    3 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-5 - 1]
-Diagnostic 1: unsafeOfAnyTypeAssertion (2:13 - 2:25)
+Diagnostic 1: unsafeOfAnyTypeAssertion (2:17 - 2:25)
 Message: Unsafe assertion from error typed detected: consider using type guards or a safer assertion.
    1 | 
    2 | const bar = foo as number;
-     |             ~~~~~~~~~~~~~
+     |                 ~~~~~~~~~
+   3 |         
+  Label: Original expression has type `error`. (2:13 - 2:15)
+   1 | 
+   2 | const bar = foo as number;
+     |             ^^^ Original expression has type `error`.
+   3 |         
+  Label: Asserted type is `number`. (2:20 - 2:25)
+   1 | 
+   2 | const bar = foo as number;
+     |                    ^^^^^^ Asserted type is `number`.
    3 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-6 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (2:13 - 2:30)
+Diagnostic 1: unsafeToAnyTypeAssertion (2:19 - 2:30)
 Message: Unsafe assertion to error typed detected: consider using a more specific type to ensure safety.
    1 | 
    2 | const bar = 'foo' as errorType;
-     |             ~~~~~~~~~~~~~~~~~~
+     |                   ~~~~~~~~~~~~
+   3 |         
+  Label: Original expression has type `"foo"`. (2:13 - 2:17)
+   1 | 
+   2 | const bar = 'foo' as errorType;
+     |             ^^^^^ Original expression has type `"foo"`.
+   3 |         
+  Label: Asserted type is `error`. (2:22 - 2:30)
+   1 | 
+   2 | const bar = 'foo' as errorType;
+     |                      ^^^^^^^^^ Asserted type is `error`.
    3 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_ArrayAssertions/invalid-0 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:13)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:13)
 Message: Unsafe type assertion: type 'string[]' is more narrow than the original type.
    2 | declare const a: (string | number)[];
    3 | a as string[];
-     | ~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `(string | number)[]`. (3:1 - 3:1)
+   2 | declare const a: (string | number)[];
+   3 | a as string[];
+     | ^ Original expression has type `(string | number)[]`.
+   4 |         
+  Label: Asserted type is `string[]`. (3:6 - 3:13)
+   2 | declare const a: (string | number)[];
+   3 | a as string[];
+     |      ^^^^^^^^ Asserted type is `string[]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_ArrayAssertions/invalid-1 - 1]
-Diagnostic 1: unsafeOfAnyTypeAssertion (3:1 - 3:13)
+Diagnostic 1: unsafeOfAnyTypeAssertion (3:3 - 3:13)
 Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
    2 | declare const a: any[];
    3 | a as number[];
-     | ~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `any[]`. (3:1 - 3:1)
+   2 | declare const a: any[];
+   3 | a as number[];
+     | ^ Original expression has type `any[]`.
+   4 |         
+  Label: Asserted type is `number[]`. (3:6 - 3:13)
+   2 | declare const a: any[];
+   3 | a as number[];
+     |      ^^^^^^^^ Asserted type is `number[]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_ArrayAssertions/invalid-2 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (3:1 - 3:10)
+Diagnostic 1: unsafeToAnyTypeAssertion (3:3 - 3:10)
 Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    2 | declare const a: number[];
    3 | a as any[];
-     | ~~~~~~~~~~
+     |   ~~~~~~~~
+   4 |         
+  Label: Original expression has type `number[]`. (3:1 - 3:1)
+   2 | declare const a: number[];
+   3 | a as any[];
+     | ^ Original expression has type `number[]`.
+   4 |         
+  Label: Asserted type is `any[]`. (3:6 - 3:10)
+   2 | declare const a: number[];
+   3 | a as any[];
+     |      ^^^^^ Asserted type is `any[]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_ArrayAssertions/invalid-3 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:13)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:13)
 Message: Unsafe type assertion: type 'number[]' is more narrow than the original type.
    2 | declare const a: unknown[];
    3 | a as number[];
-     | ~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `unknown[]`. (3:1 - 3:1)
+   2 | declare const a: unknown[];
+   3 | a as number[];
+     | ^ Original expression has type `unknown[]`.
+   4 |         
+  Label: Asserted type is `number[]`. (3:6 - 3:13)
+   2 | declare const a: unknown[];
+   3 | a as number[];
+     |      ^^^^^^^^ Asserted type is `number[]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_ArrayAssertions/invalid-4 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:12)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:12)
 Message: Unsafe type assertion: type 'never[]' is more narrow than the original type.
    2 | declare const a: number[];
    3 | a as never[];
-     | ~~~~~~~~~~~~
+     |   ~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `number[]`. (3:1 - 3:1)
+   2 | declare const a: number[];
+   3 | a as never[];
+     | ^ Original expression has type `number[]`.
+   4 |         
+  Label: Asserted type is `never[]`. (3:6 - 3:12)
+   2 | declare const a: number[];
+   3 | a as never[];
+     |      ^^^^^^^ Asserted type is `never[]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_BasicAssertions/invalid-0 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:11)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:11)
 Message: Unsafe type assertion: type 'string' is more narrow than the original type.
    2 | declare const a: string | number;
    3 | a as string;
-     | ~~~~~~~~~~~
+     |   ~~~~~~~~~
+   4 |         
+  Label: Original expression has type `string | number`. (3:1 - 3:1)
+   2 | declare const a: string | number;
+   3 | a as string;
+     | ^ Original expression has type `string | number`.
+   4 |         
+  Label: Asserted type is `string`. (3:6 - 3:11)
+   2 | declare const a: string | number;
+   3 | a as string;
+     |      ^^^^^^ Asserted type is `string`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_BasicAssertions/invalid-1 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:28)
+Diagnostic 1: unsafeTypeAssertion (3:20 - 3:28)
 Message: Unsafe type assertion: type 'string' is more narrow than the original type.
    2 | declare const a: string | number;
    3 | a satisfies string as string;
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                    ~~~~~~~~~
+   4 |         
+  Label: Original expression has type `string | number`. (3:1 - 3:18)
+   2 | declare const a: string | number;
+   3 | a satisfies string as string;
+     | ^^^^^^^^^^^^^^^^^^ Original expression has type `string | number`.
+   4 |         
+  Label: Asserted type is `string`. (3:23 - 3:28)
+   2 | declare const a: string | number;
+   3 | a satisfies string as string;
+     |                       ^^^^^^ Asserted type is `string`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_BasicAssertions/invalid-2 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:9)
+Diagnostic 1: unsafeTypeAssertion (3:1 - 3:8)
 Message: Unsafe type assertion: type 'string' is more narrow than the original type.
    2 | declare const a: string | number;
    3 | <string>a;
-     | ~~~~~~~~~
+     | ~~~~~~~~
+   4 |         
+  Label: Original expression has type `string | number`. (3:9 - 3:9)
+   2 | declare const a: string | number;
+   3 | <string>a;
+     |         ^ Original expression has type `string | number`.
+   4 |         
+  Label: Asserted type is `string`. (3:2 - 3:7)
+   2 | declare const a: string | number;
+   3 | <string>a;
+     |  ^^^^^^ Asserted type is `string`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_BasicAssertions/invalid-3 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:21)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:21)
 Message: Unsafe type assertion: type 'string | boolean' is more narrow than the original type.
    2 | declare const a: string | undefined;
    3 | a as string | boolean;
-     | ~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `string | undefined`. (3:1 - 3:1)
+   2 | declare const a: string | undefined;
+   3 | a as string | boolean;
+     | ^ Original expression has type `string | undefined`.
+   4 |         
+  Label: Asserted type is `string | boolean`. (3:6 - 3:21)
+   2 | declare const a: string | undefined;
+   3 | a as string | boolean;
+     |      ^^^^^^^^^^^^^^^^ Asserted type is `string | boolean`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_BasicAssertions/invalid-4 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:19)
+Diagnostic 1: unsafeTypeAssertion (3:12 - 3:19)
 Message: Unsafe type assertion: type '"bar"' is more narrow than the original type.
    2 | declare const a: string;
    3 | a as 'foo' as 'bar';
-     | ~~~~~~~~~~~~~~~~~~~
+     |            ~~~~~~~~
+   4 |         
+  Label: Original expression has type `"foo"`. (3:1 - 3:10)
+   2 | declare const a: string;
+   3 | a as 'foo' as 'bar';
+     | ^^^^^^^^^^ Original expression has type `"foo"`.
+   4 |         
+  Label: Asserted type is `"bar"`. (3:15 - 3:19)
+   2 | declare const a: string;
+   3 | a as 'foo' as 'bar';
+     |               ^^^^^ Asserted type is `"bar"`.
    4 |         
 
-Diagnostic 2: unsafeTypeAssertion (3:1 - 3:10)
+Diagnostic 2: unsafeTypeAssertion (3:3 - 3:10)
 Message: Unsafe type assertion: type '"foo"' is more narrow than the original type.
    2 | declare const a: string;
    3 | a as 'foo' as 'bar';
-     | ~~~~~~~~~~
+     |   ~~~~~~~~
+   4 |         
+  Label: Original expression has type `string`. (3:1 - 3:1)
+   2 | declare const a: string;
+   3 | a as 'foo' as 'bar';
+     | ^ Original expression has type `string`.
+   4 |         
+  Label: Asserted type is `"foo"`. (3:6 - 3:10)
+   2 | declare const a: string;
+   3 | a as 'foo' as 'bar';
+     |      ^^^^^ Asserted type is `"foo"`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_BasicAssertions/invalid-5 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:10 - 3:18)
+Diagnostic 1: unsafeTypeAssertion (3:12 - 3:18)
 Message: Unsafe type assertion: type 'true' is more narrow than the original type.
    2 | function foo<T extends boolean>(a: T) {
    3 |   return a as true;
-     |          ~~~~~~~~~
+     |            ~~~~~~~
+   4 | }
+  Label: Original expression has type `boolean`. (3:10 - 3:10)
+   2 | function foo<T extends boolean>(a: T) {
+   3 |   return a as true;
+     |          ^ Original expression has type `boolean`.
+   4 | }
+  Label: Asserted type is `true`. (3:15 - 3:18)
+   2 | function foo<T extends boolean>(a: T) {
+   3 |   return a as true;
+     |               ^^^^ Asserted type is `true`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_BasicAssertions/invalid-6 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:68)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:68)
 Message: Unsafe type assertion: type 'Omit<Required<Readonly<{ hello: "world"; foo: "bar"; }>>, "foo">' is more narrow than the original type.
    2 | declare const a: string;
    3 | a as Omit<Required<Readonly<{ hello: 'world'; foo: 'bar' }>>, 'foo'>;
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `string`. (3:1 - 3:1)
+   2 | declare const a: string;
+   3 | a as Omit<Required<Readonly<{ hello: 'world'; foo: 'bar' }>>, 'foo'>;
+     | ^ Original expression has type `string`.
+   4 |         
+  Label: Asserted type is `Omit<Required<Readonly<{ hello: "world"; foo: "bar"; }>>, "foo">`. (3:6 - 3:68)
+   2 | declare const a: string;
+   3 | a as Omit<Required<Readonly<{ hello: 'world'; foo: 'bar' }>>, 'foo'>;
+     |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Asserted type is `Omit<Required<Readonly<{ hello: "world"; foo: "bar"; }>>, "foo">`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_BasicAssertions/invalid-7 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:13 - 3:27)
+Diagnostic 1: unsafeTypeAssertion (3:17 - 3:27)
 Message: Unsafe type assertion: type 'number[]' is more narrow than the original type.
    2 | declare const foo: readonly number[];
    3 | const bar = foo as number[];
-     |             ~~~~~~~~~~~~~~~
+     |                 ~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `readonly number[]`. (3:13 - 3:15)
+   2 | declare const foo: readonly number[];
+   3 | const bar = foo as number[];
+     |             ^^^ Original expression has type `readonly number[]`.
+   4 |         
+  Label: Asserted type is `number[]`. (3:20 - 3:27)
+   2 | declare const foo: readonly number[];
+   3 | const bar = foo as number[];
+     |                    ^^^^^^^^ Asserted type is `number[]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_ClassAssertions/invalid-0 - 1]
-Diagnostic 1: unsafeTypeAssertion (9:1 - 9:8)
+Diagnostic 1: unsafeTypeAssertion (9:3 - 9:8)
 Message: Unsafe type assertion: type 'Bar' is more narrow than the original type.
    8 | declare const a: Foo;
    9 | a as Bar;
-     | ~~~~~~~~
+     |   ~~~~~~
+  10 |         
+  Label: Original expression has type `Foo`. (9:1 - 9:1)
+   8 | declare const a: Foo;
+   9 | a as Bar;
+     | ^ Original expression has type `Foo`.
+  10 |         
+  Label: Asserted type is `Bar`. (9:6 - 9:8)
+   8 | declare const a: Foo;
+   9 | a as Bar;
+     |      ^^^ Asserted type is `Bar`.
   10 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_FunctionAssertions/invalid-0 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:24)
+Diagnostic 1: unsafeTypeAssertion (3:12 - 3:24)
 Message: Unsafe type assertion: type '() => void' is more narrow than the original type.
    2 | declare const _function_: Function;
    3 | _function_ as () => void;
-     | ~~~~~~~~~~~~~~~~~~~~~~~~
+     |            ~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `Function`. (3:1 - 3:10)
+   2 | declare const _function_: Function;
+   3 | _function_ as () => void;
+     | ^^^^^^^^^^ Original expression has type `Function`.
+   4 |         
+  Label: Asserted type is `() => void`. (3:15 - 3:24)
+   2 | declare const _function_: Function;
+   3 | _function_ as () => void;
+     |               ^^^^^^^^^^ Asserted type is `() => void`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_FunctionAssertions/invalid-1 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (3:1 - 3:17)
+Diagnostic 1: unsafeToAnyTypeAssertion (3:12 - 3:17)
 Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    2 | declare const _function_: Function;
    3 | _function_ as any;
-     | ~~~~~~~~~~~~~~~~~
+     |            ~~~~~~
+   4 |         
+  Label: Original expression has type `Function`. (3:1 - 3:10)
+   2 | declare const _function_: Function;
+   3 | _function_ as any;
+     | ^^^^^^^^^^ Original expression has type `Function`.
+   4 |         
+  Label: Asserted type is `any`. (3:15 - 3:17)
+   2 | declare const _function_: Function;
+   3 | _function_ as any;
+     |               ^^^ Asserted type is `any`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_FunctionAssertions/invalid-2 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:19)
+Diagnostic 1: unsafeTypeAssertion (3:12 - 3:19)
 Message: Unsafe type assertion: type 'never' is more narrow than the original type.
    2 | declare const _function_: Function;
    3 | _function_ as never;
-     | ~~~~~~~~~~~~~~~~~~~
+     |            ~~~~~~~~
+   4 |         
+  Label: Original expression has type `Function`. (3:1 - 3:10)
+   2 | declare const _function_: Function;
+   3 | _function_ as never;
+     | ^^^^^^^^^^ Original expression has type `Function`.
+   4 |         
+  Label: Asserted type is `never`. (3:15 - 3:19)
+   2 | declare const _function_: Function;
+   3 | _function_ as never;
+     |               ^^^^^ Asserted type is `never`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-0 - 1]
-Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (4:17 - 4:34)
+Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (4:31 - 4:34)
 Message: Unsafe type assertion: the original type is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of its constraint.
    3 | function func<T extends Obj>() {
    4 |   const myObj = { foo: 'hi' } as T;
-     |                 ~~~~~~~~~~~~~~~~~~
+     |                               ~~~~
+   5 | }
+  Label: Original expression has type `{ foo: string; }`. (4:17 - 4:29)
+   3 | function func<T extends Obj>() {
+   4 |   const myObj = { foo: 'hi' } as T;
+     |                 ^^^^^^^^^^^^^ Original expression has type `{ foo: string; }`.
+   5 | }
+  Label: Asserted type is `T`. (4:34 - 4:34)
+   3 | function func<T extends Obj>() {
+   4 |   const myObj = { foo: 'hi' } as T;
+     |                                  ^ Asserted type is `T`.
    5 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-1 - 1]
-Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (5:17 - 5:22)
+Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (5:19 - 5:22)
 Message: Unsafe type assertion: the original type is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of its constraint.
    4 |   const o: Obj = { foo: 'hi' };
    5 |   const myObj = o as T;
-     |                 ~~~~~~
+     |                   ~~~~
+   6 | }
+  Label: Original expression has type `Obj`. (5:17 - 5:17)
+   4 |   const o: Obj = { foo: 'hi' };
+   5 |   const myObj = o as T;
+     |                 ^ Original expression has type `Obj`.
+   6 | }
+  Label: Asserted type is `T`. (5:22 - 5:22)
+   4 |   const o: Obj = { foo: 'hi' };
+   5 |   const myObj = o as T;
+     |                      ^ Asserted type is `T`.
    6 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-2 - 1]
-Diagnostic 1: unsafeTypeAssertion (5:27 - 5:48)
+Diagnostic 1: unsafeTypeAssertion (5:33 - 5:48)
 Message: Unsafe type assertion: type 'CustomObjectT' is more narrow than the original type.
    4 | ): CustomObjectT {
    5 |   const newCustomObject = input as CustomObjectT;
-     |                           ~~~~~~~~~~~~~~~~~~~~~~
+     |                                 ~~~~~~~~~~~~~~~~
+   6 |   return newCustomObject;
+  Label: Original expression has type `number`. (5:27 - 5:31)
+   4 | ): CustomObjectT {
+   5 |   const newCustomObject = input as CustomObjectT;
+     |                           ^^^^^ Original expression has type `number`.
+   6 |   return newCustomObject;
+  Label: Asserted type is `CustomObjectT`. (5:36 - 5:48)
+   4 | ): CustomObjectT {
+   5 |   const newCustomObject = input as CustomObjectT;
+     |                                    ^^^^^^^^^^^^^ Asserted type is `CustomObjectT`.
    6 |   return newCustomObject;
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-3 - 1]
-Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (3:3 - 3:8)
+Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (3:5 - 3:8)
 Message: Unsafe type assertion: the original type is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of its constraint.
    2 | function unknownConstraint<T extends unknown>(x: T, y: string) {
    3 |   y as T; // banned; generic arbitrary subtype
-     |   ~~~~~~
+     |     ~~~~
+   4 | }
+  Label: Original expression has type `string`. (3:3 - 3:3)
+   2 | function unknownConstraint<T extends unknown>(x: T, y: string) {
+   3 |   y as T; // banned; generic arbitrary subtype
+     |   ^ Original expression has type `string`.
+   4 | }
+  Label: Asserted type is `T`. (3:8 - 3:8)
+   2 | function unknownConstraint<T extends unknown>(x: T, y: string) {
+   3 |   y as T; // banned; generic arbitrary subtype
+     |        ^ Asserted type is `T`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-4 - 1]
-Diagnostic 1: unsafeToUnconstrainedTypeAssertion (3:3 - 3:8)
+Diagnostic 1: unsafeToUnconstrainedTypeAssertion (3:5 - 3:8)
 Message: Unsafe type assertion: 'T' could be instantiated with an arbitrary type which could be unrelated to the original type.
    2 | function unconstrained<T>(x: T, y: string) {
    3 |   y as T;
-     |   ~~~~~~
+     |     ~~~~
+   4 | }
+  Label: Original expression has type `string`. (3:3 - 3:3)
+   2 | function unconstrained<T>(x: T, y: string) {
+   3 |   y as T;
+     |   ^ Original expression has type `string`.
+   4 | }
+  Label: Asserted type is `T`. (3:8 - 3:8)
+   2 | function unconstrained<T>(x: T, y: string) {
+   3 |   y as T;
+     |        ^ Asserted type is `T`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-5 - 1]
-Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (5:3 - 5:8)
+Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (5:5 - 5:8)
 Message: Unsafe type assertion: the original type is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of its constraint.
    4 | function anyConstraint<T extends any>(x: T, y: string) {
    5 |   y as T; // banned; generic arbitrary subtype
-     |   ~~~~~~
+     |     ~~~~
+   6 | }
+  Label: Original expression has type `string`. (5:3 - 5:3)
+   4 | function anyConstraint<T extends any>(x: T, y: string) {
+   5 |   y as T; // banned; generic arbitrary subtype
+     |   ^ Original expression has type `string`.
+   6 | }
+  Label: Asserted type is `T`. (5:8 - 5:8)
+   4 | function anyConstraint<T extends any>(x: T, y: string) {
+   5 |   y as T; // banned; generic arbitrary subtype
+     |        ^ Asserted type is `T`.
    6 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-6 - 1]
-Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (6:3 - 6:8)
+Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (6:5 - 6:8)
 Message: Unsafe type assertion: the original type is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of its constraint.
    5 | ) {
    6 |   y as T; // banned; assignable to constraint
-     |   ~~~~~~
+     |     ~~~~
+   7 | }
+  Label: Original expression has type `string`. (6:3 - 6:3)
+   5 | ) {
+   6 |   y as T; // banned; assignable to constraint
+     |   ^ Original expression has type `string`.
+   7 | }
+  Label: Asserted type is `T`. (6:8 - 6:8)
+   5 | ) {
+   6 |   y as T; // banned; assignable to constraint
+     |        ^ Asserted type is `T`.
    7 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-7 - 1]
-Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (3:3 - 3:8)
+Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (3:5 - 3:8)
 Message: Unsafe type assertion: the original type is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of its constraint.
    2 | function constraintEqualUncastType<T extends string>(x: T, y: string) {
    3 |   y as T; // banned; assignable to constraint
-     |   ~~~~~~
+     |     ~~~~
+   4 | }
+  Label: Original expression has type `string`. (3:3 - 3:3)
+   2 | function constraintEqualUncastType<T extends string>(x: T, y: string) {
+   3 |   y as T; // banned; assignable to constraint
+     |   ^ Original expression has type `string`.
+   4 | }
+  Label: Asserted type is `T`. (3:8 - 3:8)
+   2 | function constraintEqualUncastType<T extends string>(x: T, y: string) {
+   3 |   y as T; // banned; assignable to constraint
+     |        ^ Asserted type is `T`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-8 - 1]
-Diagnostic 1: unsafeTypeAssertion (6:3 - 6:8)
+Diagnostic 1: unsafeTypeAssertion (6:5 - 6:8)
 Message: Unsafe type assertion: type 'T' is more narrow than the original type.
    5 | ) {
    6 |   y as T; // banned; *not* assignable to constraint
-     |   ~~~~~~
+     |     ~~~~
+   7 | }
+  Label: Original expression has type `string | number`. (6:3 - 6:3)
+   5 | ) {
+   6 |   y as T; // banned; *not* assignable to constraint
+     |   ^ Original expression has type `string | number`.
+   7 | }
+  Label: Asserted type is `T`. (6:8 - 6:8)
+   5 | ) {
+   6 |   y as T; // banned; *not* assignable to constraint
+     |        ^ Asserted type is `T`.
    7 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-9 - 1]
-Diagnostic 1: unsafeOfAnyTypeAssertion (3:3 - 3:8)
+Diagnostic 1: unsafeOfAnyTypeAssertion (3:5 - 3:8)
 Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
    2 | function assertFromAny<T extends string | number>(x: T, y: any) {
    3 |   y as T; // banned; just an `any` complaint. Not a generic subtype.
-     |   ~~~~~~
+     |     ~~~~
+   4 | }
+  Label: Original expression has type `any`. (3:3 - 3:3)
+   2 | function assertFromAny<T extends string | number>(x: T, y: any) {
+   3 |   y as T; // banned; just an `any` complaint. Not a generic subtype.
+     |   ^ Original expression has type `any`.
+   4 | }
+  Label: Asserted type is `T`. (3:8 - 3:8)
+   2 | function assertFromAny<T extends string | number>(x: T, y: any) {
+   3 |   y as T; // banned; just an `any` complaint. Not a generic subtype.
+     |        ^ Asserted type is `T`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-10 - 1]
-Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (6:3 - 6:8)
+Diagnostic 1: unsafeTypeAssertionAssignableToConstraint (6:5 - 6:8)
 Message: Unsafe type assertion: the original type is assignable to the constraint of type 'V', but 'V' could be instantiated with a different subtype of its constraint.
    5 | ) {
    6 |   x as V; // banned; assignable to constraint
-     |   ~~~~~~
+     |     ~~~~
+   7 | }
+  Label: Original expression has type `T`. (6:3 - 6:3)
+   5 | ) {
+   6 |   x as V; // banned; assignable to constraint
+     |   ^ Original expression has type `T`.
+   7 | }
+  Label: Asserted type is `V`. (6:8 - 6:8)
+   5 | ) {
+   6 |   x as V; // banned; assignable to constraint
+     |        ^ Asserted type is `V`.
    7 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-11 - 1]
-Diagnostic 1: unsafeToUnconstrainedTypeAssertion (3:3 - 3:8)
+Diagnostic 1: unsafeToUnconstrainedTypeAssertion (3:5 - 3:8)
 Message: Unsafe type assertion: 'V' could be instantiated with an arbitrary type which could be unrelated to the original type.
    2 | function parameterExtendsUnconstrainedParameter<T, V extends T>(x: T, y: V) {
    3 |   x as V; // banned; unconstrained arbitrary type
-     |   ~~~~~~
+     |     ~~~~
+   4 | }
+  Label: Original expression has type `T`. (3:3 - 3:3)
+   2 | function parameterExtendsUnconstrainedParameter<T, V extends T>(x: T, y: V) {
+   3 |   x as V; // banned; unconstrained arbitrary type
+     |   ^ Original expression has type `T`.
+   4 | }
+  Label: Asserted type is `V`. (3:8 - 3:8)
+   2 | function parameterExtendsUnconstrainedParameter<T, V extends T>(x: T, y: V) {
+   3 |   x as V; // banned; unconstrained arbitrary type
+     |        ^ Asserted type is `V`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-12 - 1]
-Diagnostic 1: unsafeToUnconstrainedTypeAssertion (3:3 - 3:8)
+Diagnostic 1: unsafeToUnconstrainedTypeAssertion (3:5 - 3:8)
 Message: Unsafe type assertion: 'T' could be instantiated with an arbitrary type which could be unrelated to the original type.
    2 | function twoUnconstrained<T, V>(x: T, y: V) {
    3 |   y as T;
-     |   ~~~~~~
+     |     ~~~~
+   4 | }
+  Label: Original expression has type `V`. (3:3 - 3:3)
+   2 | function twoUnconstrained<T, V>(x: T, y: V) {
+   3 |   y as T;
+     |   ^ Original expression has type `V`.
+   4 | }
+  Label: Asserted type is `T`. (3:8 - 3:8)
+   2 | function twoUnconstrained<T, V>(x: T, y: V) {
+   3 |   y as T;
+     |        ^ Asserted type is `T`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-13 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:3 - 3:13)
+Diagnostic 1: unsafeTypeAssertion (3:5 - 3:13)
 Message: Unsafe type assertion: type 'string' is more narrow than the original type.
    2 | function toNarrower<T>(x: T, y: string) {
    3 |   x as string; // banned; ordinary 'string' narrower than 'T'.
-     |   ~~~~~~~~~~~
+     |     ~~~~~~~~~
+   4 | }
+  Label: Original expression has type `T`. (3:3 - 3:3)
+   2 | function toNarrower<T>(x: T, y: string) {
+   3 |   x as string; // banned; ordinary 'string' narrower than 'T'.
+     |   ^ Original expression has type `T`.
+   4 | }
+  Label: Asserted type is `string`. (3:8 - 3:13)
+   2 | function toNarrower<T>(x: T, y: string) {
+   3 |   x as string; // banned; ordinary 'string' narrower than 'T'.
+     |        ^^^^^^ Asserted type is `string`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-14 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (3:3 - 3:10)
+Diagnostic 1: unsafeToAnyTypeAssertion (3:5 - 3:10)
 Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    2 | function unconstrainedToAny<T>(x: T) {
    3 |   x as any;
-     |   ~~~~~~~~
+     |     ~~~~~~
+   4 | }
+  Label: Original expression has type `T`. (3:3 - 3:3)
+   2 | function unconstrainedToAny<T>(x: T) {
+   3 |   x as any;
+     |   ^ Original expression has type `T`.
+   4 | }
+  Label: Asserted type is `any`. (3:8 - 3:10)
+   2 | function unconstrainedToAny<T>(x: T) {
+   3 |   x as any;
+     |        ^^^ Asserted type is `any`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-15 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (3:3 - 3:10)
+Diagnostic 1: unsafeToAnyTypeAssertion (3:5 - 3:10)
 Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    2 | function stringToAny<T extends string>(x: T) {
    3 |   x as any;
-     |   ~~~~~~~~
+     |     ~~~~~~
+   4 | }
+  Label: Original expression has type `T`. (3:3 - 3:3)
+   2 | function stringToAny<T extends string>(x: T) {
+   3 |   x as any;
+     |   ^ Original expression has type `T`.
+   4 | }
+  Label: Asserted type is `any`. (3:8 - 3:10)
+   2 | function stringToAny<T extends string>(x: T) {
+   3 |   x as any;
+     |        ^^^ Asserted type is `any`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-16 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:3 - 3:16)
+Diagnostic 1: unsafeTypeAssertion (3:5 - 3:16)
 Message: Unsafe type assertion: type '"a" | "b"' is more narrow than the original type.
    2 | function stringToNarrower<T extends string>(x: T) {
    3 |   x as 'a' | 'b';
-     |   ~~~~~~~~~~~~~~
+     |     ~~~~~~~~~~~~
+   4 | }
+  Label: Original expression has type `T`. (3:3 - 3:3)
+   2 | function stringToNarrower<T extends string>(x: T) {
+   3 |   x as 'a' | 'b';
+     |   ^ Original expression has type `T`.
+   4 | }
+  Label: Asserted type is `"a" | "b"`. (3:8 - 3:16)
+   2 | function stringToNarrower<T extends string>(x: T) {
+   3 |   x as 'a' | 'b';
+     |        ^^^^^^^^^ Asserted type is `"a" | "b"`.
    4 | }
 ---
 
 [TestNoUnsafeTypeAssertionRule_NeverAssertions/invalid-0 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (3:1 - 3:14)
+Diagnostic 1: unsafeToAnyTypeAssertion (3:9 - 3:14)
 Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    2 | declare const _never_: never;
    3 | _never_ as any;
-     | ~~~~~~~~~~~~~~
+     |         ~~~~~~
+   4 |         
+  Label: Original expression has type `never`. (3:1 - 3:7)
+   2 | declare const _never_: never;
+   3 | _never_ as any;
+     | ^^^^^^^ Original expression has type `never`.
+   4 |         
+  Label: Asserted type is `any`. (3:12 - 3:14)
+   2 | declare const _never_: never;
+   3 | _never_ as any;
+     |            ^^^ Asserted type is `any`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_NeverAssertions/invalid-1 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:17)
+Diagnostic 1: unsafeTypeAssertion (3:10 - 3:17)
 Message: Unsafe type assertion: type 'never' is more narrow than the original type.
    2 | declare const _string_: string;
    3 | _string_ as never;
-     | ~~~~~~~~~~~~~~~~~
+     |          ~~~~~~~~
+   4 |         
+  Label: Original expression has type `string`. (3:1 - 3:8)
+   2 | declare const _string_: string;
+   3 | _string_ as never;
+     | ^^^^^^^^ Original expression has type `string`.
+   4 |         
+  Label: Asserted type is `never`. (3:13 - 3:17)
+   2 | declare const _string_: string;
+   3 | _string_ as never;
+     |             ^^^^^ Asserted type is `never`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_ObjectAssertions/invalid-0 - 1]
-Diagnostic 1: unsafeTypeAssertion (2:11 - 5:1)
+Diagnostic 1: unsafeTypeAssertion (2:14 - 5:1)
 Message: Unsafe type assertion: type '{ bar: number; bas: string; }' is more narrow than the original type.
    1 | 
    2 | var foo = {} as {
-     |           ~~~~~~~
+     |              ~~~~
    3 |   bar: number;
      | ~~~~~~~~~~~~~~
    4 |   bas: string;
@@ -406,166 +846,362 @@ Message: Unsafe type assertion: type '{ bar: number; bas: string; }' is more nar
    5 | };
      | ~
    6 |         
+  Label: Original expression has type `{}`. (2:11 - 2:12)
+   1 | 
+   2 | var foo = {} as {
+     |           ^^ Original expression has type `{}`.
+   3 |   bar: number;
+  Label: Asserted type is `{ bar: number; bas: string; }`. (2:17 - 5:1)
+   1 | 
+   2 | var foo = {} as {
+     |                 ^ Asserted type is `{ bar: number; bas: string; }`.
+   3 |   bar: number;
+     | ^^^^^^^^^^^^^^ Asserted type is `{ bar: number; bas: string; }`.
+   4 |   bas: string;
+     | ^^^^^^^^^^^^^^ Asserted type is `{ bar: number; bas: string; }`.
+   5 | };
+     | ^ Asserted type is `{ bar: number; bas: string; }`.
+   6 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_ObjectAssertions/invalid-1 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:70)
+Diagnostic 1: unsafeTypeAssertion (3:36 - 3:70)
 Message: Unsafe type assertion: type '{ hello: string; world: string; }' is more narrow than the original type.
    2 | declare const a: { hello: string };
    3 | a satisfies Record<string, string> as { hello: string; world: string };
-     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `{ hello: string; }`. (3:1 - 3:34)
+   2 | declare const a: { hello: string };
+   3 | a satisfies Record<string, string> as { hello: string; world: string };
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Original expression has type `{ hello: string; }`.
+   4 |         
+  Label: Asserted type is `{ hello: string; world: string; }`. (3:39 - 3:70)
+   2 | declare const a: { hello: string };
+   3 | a satisfies Record<string, string> as { hello: string; world: string };
+     |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Asserted type is `{ hello: string; world: string; }`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_ObjectAssertions/invalid-2 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:22)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:22)
 Message: Unsafe type assertion: type '{ hello: string; }' is more narrow than the original type.
    2 | declare const a: { hello?: string };
    3 | a as { hello: string };
-     | ~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `{ hello?: string | undefined; }`. (3:1 - 3:1)
+   2 | declare const a: { hello?: string };
+   3 | a as { hello: string };
+     | ^ Original expression has type `{ hello?: string | undefined; }`.
+   4 |         
+  Label: Asserted type is `{ hello: string; }`. (3:6 - 3:22)
+   2 | declare const a: { hello?: string };
+   3 | a as { hello: string };
+     |      ^^^^^^^^^^^^^^^^^ Asserted type is `{ hello: string; }`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_PromiseAssertions/invalid-0 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:20)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:20)
 Message: Unsafe type assertion: type 'Promise<string>' is more narrow than the original type.
    2 | declare const a: Promise<string | number>;
    3 | a as Promise<string>;
-     | ~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `Promise<string | number>`. (3:1 - 3:1)
+   2 | declare const a: Promise<string | number>;
+   3 | a as Promise<string>;
+     | ^ Original expression has type `Promise<string | number>`.
+   4 |         
+  Label: Asserted type is `Promise<string>`. (3:6 - 3:20)
+   2 | declare const a: Promise<string | number>;
+   3 | a as Promise<string>;
+     |      ^^^^^^^^^^^^^^^ Asserted type is `Promise<string>`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_PromiseAssertions/invalid-1 - 1]
-Diagnostic 1: unsafeOfAnyTypeAssertion (3:1 - 3:20)
+Diagnostic 1: unsafeOfAnyTypeAssertion (3:3 - 3:20)
 Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
    2 | declare const a: Promise<any>;
    3 | a as Promise<number>;
-     | ~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `Promise<any>`. (3:1 - 3:1)
+   2 | declare const a: Promise<any>;
+   3 | a as Promise<number>;
+     | ^ Original expression has type `Promise<any>`.
+   4 |         
+  Label: Asserted type is `Promise<number>`. (3:6 - 3:20)
+   2 | declare const a: Promise<any>;
+   3 | a as Promise<number>;
+     |      ^^^^^^^^^^^^^^^ Asserted type is `Promise<number>`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_PromiseAssertions/invalid-2 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (3:1 - 3:17)
+Diagnostic 1: unsafeToAnyTypeAssertion (3:3 - 3:17)
 Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    2 | declare const a: Promise<number>;
    3 | a as Promise<any>;
-     | ~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `Promise<number>`. (3:1 - 3:1)
+   2 | declare const a: Promise<number>;
+   3 | a as Promise<any>;
+     | ^ Original expression has type `Promise<number>`.
+   4 |         
+  Label: Asserted type is `Promise<any>`. (3:6 - 3:17)
+   2 | declare const a: Promise<number>;
+   3 | a as Promise<any>;
+     |      ^^^^^^^^^^^^ Asserted type is `Promise<any>`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_PromiseAssertions/invalid-3 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (3:1 - 3:19)
+Diagnostic 1: unsafeToAnyTypeAssertion (3:3 - 3:19)
 Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    2 | declare const a: Promise<number[]>;
    3 | a as Promise<any[]>;
-     | ~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `Promise<number[]>`. (3:1 - 3:1)
+   2 | declare const a: Promise<number[]>;
+   3 | a as Promise<any[]>;
+     | ^ Original expression has type `Promise<number[]>`.
+   4 |         
+  Label: Asserted type is `Promise<any[]>`. (3:6 - 3:19)
+   2 | declare const a: Promise<number[]>;
+   3 | a as Promise<any[]>;
+     |      ^^^^^^^^^^^^^^ Asserted type is `Promise<any[]>`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_PromiseAssertions/invalid-4 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:20)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:20)
 Message: Unsafe type assertion: type 'Promise<number>' is more narrow than the original type.
    2 | declare const a: Promise<unknown>;
    3 | a as Promise<number>;
-     | ~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `Promise<unknown>`. (3:1 - 3:1)
+   2 | declare const a: Promise<unknown>;
+   3 | a as Promise<number>;
+     | ^ Original expression has type `Promise<unknown>`.
+   4 |         
+  Label: Asserted type is `Promise<number>`. (3:6 - 3:20)
+   2 | declare const a: Promise<unknown>;
+   3 | a as Promise<number>;
+     |      ^^^^^^^^^^^^^^^ Asserted type is `Promise<number>`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_PromiseAssertions/invalid-5 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:19)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:19)
 Message: Unsafe type assertion: type 'Promise<never>' is more narrow than the original type.
    2 | declare const a: Promise<number>;
    3 | a as Promise<never>;
-     | ~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `Promise<number>`. (3:1 - 3:1)
+   2 | declare const a: Promise<number>;
+   3 | a as Promise<never>;
+     | ^ Original expression has type `Promise<number>`.
+   4 |         
+  Label: Asserted type is `Promise<never>`. (3:6 - 3:19)
+   2 | declare const a: Promise<number>;
+   3 | a as Promise<never>;
+     |      ^^^^^^^^^^^^^^ Asserted type is `Promise<never>`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-0 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:13)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:13)
 Message: Unsafe type assertion: type '[string]' is more narrow than the original type.
    2 | declare const a: [string | number];
    3 | a as [string];
-     | ~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `[string | number]`. (3:1 - 3:1)
+   2 | declare const a: [string | number];
+   3 | a as [string];
+     | ^ Original expression has type `[string | number]`.
+   4 |         
+  Label: Asserted type is `[string]`. (3:6 - 3:13)
+   2 | declare const a: [string | number];
+   3 | a as [string];
+     |      ^^^^^^^^ Asserted type is `[string]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-1 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:21)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:21)
 Message: Unsafe type assertion: type '[string, string]' is more narrow than the original type.
    2 | declare const a: [string, number];
    3 | a as [string, string];
-     | ~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `[string, number]`. (3:1 - 3:1)
+   2 | declare const a: [string, number];
+   3 | a as [string, string];
+     | ^ Original expression has type `[string, number]`.
+   4 |         
+  Label: Asserted type is `[string, string]`. (3:6 - 3:21)
+   2 | declare const a: [string, number];
+   3 | a as [string, string];
+     |      ^^^^^^^^^^^^^^^^ Asserted type is `[string, string]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-2 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:21)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:21)
 Message: Unsafe type assertion: type '[string, number]' is more narrow than the original type.
    2 | declare const a: [string];
    3 | a as [string, number];
-     | ~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `[string]`. (3:1 - 3:1)
+   2 | declare const a: [string];
+   3 | a as [string, number];
+     | ^ Original expression has type `[string]`.
+   4 |         
+  Label: Asserted type is `[string, number]`. (3:6 - 3:21)
+   2 | declare const a: [string];
+   3 | a as [string, number];
+     |      ^^^^^^^^^^^^^^^^ Asserted type is `[string, number]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-3 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:13)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:13)
 Message: Unsafe type assertion: type '[string]' is more narrow than the original type.
    2 | declare const a: [string, number];
    3 | a as [string];
-     | ~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `[string, number]`. (3:1 - 3:1)
+   2 | declare const a: [string, number];
+   3 | a as [string];
+     | ^ Original expression has type `[string, number]`.
+   4 |         
+  Label: Asserted type is `[string]`. (3:6 - 3:13)
+   2 | declare const a: [string, number];
+   3 | a as [string];
+     |      ^^^^^^^^ Asserted type is `[string]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-4 - 1]
-Diagnostic 1: unsafeOfAnyTypeAssertion (3:1 - 3:13)
+Diagnostic 1: unsafeOfAnyTypeAssertion (3:3 - 3:13)
 Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
    2 | declare const a: [any];
    3 | a as [number];
-     | ~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `[any]`. (3:1 - 3:1)
+   2 | declare const a: [any];
+   3 | a as [number];
+     | ^ Original expression has type `[any]`.
+   4 |         
+  Label: Asserted type is `[number]`. (3:6 - 3:13)
+   2 | declare const a: [any];
+   3 | a as [number];
+     |      ^^^^^^^^ Asserted type is `[number]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-5 - 1]
-Diagnostic 1: unsafeOfAnyTypeAssertion (3:1 - 3:21)
+Diagnostic 1: unsafeOfAnyTypeAssertion (3:3 - 3:21)
 Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
    2 | declare const a: [number, any];
    3 | a as [number, number];
-     | ~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `[number, any]`. (3:1 - 3:1)
+   2 | declare const a: [number, any];
+   3 | a as [number, number];
+     | ^ Original expression has type `[number, any]`.
+   4 |         
+  Label: Asserted type is `[number, number]`. (3:6 - 3:21)
+   2 | declare const a: [number, any];
+   3 | a as [number, number];
+     |      ^^^^^^^^^^^^^^^^ Asserted type is `[number, number]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-6 - 1]
-Diagnostic 1: unsafeToAnyTypeAssertion (3:1 - 3:10)
+Diagnostic 1: unsafeToAnyTypeAssertion (3:3 - 3:10)
 Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
    2 | declare const a: [number];
    3 | a as [any];
-     | ~~~~~~~~~~
+     |   ~~~~~~~~
+   4 |         
+  Label: Original expression has type `[number]`. (3:1 - 3:1)
+   2 | declare const a: [number];
+   3 | a as [any];
+     | ^ Original expression has type `[number]`.
+   4 |         
+  Label: Asserted type is `[any]`. (3:6 - 3:10)
+   2 | declare const a: [number];
+   3 | a as [any];
+     |      ^^^^^ Asserted type is `[any]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-7 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:13)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:13)
 Message: Unsafe type assertion: type '[number]' is more narrow than the original type.
    2 | declare const a: [unknown];
    3 | a as [number];
-     | ~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `[unknown]`. (3:1 - 3:1)
+   2 | declare const a: [unknown];
+   3 | a as [number];
+     | ^ Original expression has type `[unknown]`.
+   4 |         
+  Label: Asserted type is `[number]`. (3:6 - 3:13)
+   2 | declare const a: [unknown];
+   3 | a as [number];
+     |      ^^^^^^^^ Asserted type is `[number]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-8 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:12)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:12)
 Message: Unsafe type assertion: type '[never]' is more narrow than the original type.
    2 | declare const a: [number];
    3 | a as [never];
-     | ~~~~~~~~~~~~
+     |   ~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `[number]`. (3:1 - 3:1)
+   2 | declare const a: [number];
+   3 | a as [never];
+     | ^ Original expression has type `[number]`.
+   4 |         
+  Label: Asserted type is `[never]`. (3:6 - 3:12)
+   2 | declare const a: [number];
+   3 | a as [never];
+     |      ^^^^^^^ Asserted type is `[never]`.
    4 |         
 ---
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-9 - 1]
-Diagnostic 1: unsafeTypeAssertion (3:1 - 3:22)
+Diagnostic 1: unsafeTypeAssertion (3:3 - 3:22)
 Message: Unsafe type assertion: type '[Promise<string>]' is more narrow than the original type.
    2 | declare const a: [Promise<string | number>];
    3 | a as [Promise<string>];
-     | ~~~~~~~~~~~~~~~~~~~~~~
+     |   ~~~~~~~~~~~~~~~~~~~~
+   4 |         
+  Label: Original expression has type `[Promise<string | number>]`. (3:1 - 3:1)
+   2 | declare const a: [Promise<string | number>];
+   3 | a as [Promise<string>];
+     | ^ Original expression has type `[Promise<string | number>]`.
+   4 |         
+  Label: Asserted type is `[Promise<string>]`. (3:6 - 3:22)
+   2 | declare const a: [Promise<string | number>];
+   3 | a as [Promise<string>];
+     |      ^^^^^^^^^^^^^^^^^ Asserted type is `[Promise<string>]`.
    4 |         
 ---

--- a/internal/rules/no_unsafe_type_assertion/no_unsafe_type_assertion.go
+++ b/internal/rules/no_unsafe_type_assertion/no_unsafe_type_assertion.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/typescript-eslint/tsgolint/internal/rule"
 	"github.com/typescript-eslint/tsgolint/internal/utils"
 )
@@ -51,6 +53,51 @@ func isObjectLiteralType(t *checker.Type) bool {
 	return utils.IsObjectType(t) && checker.Type_objectFlags(t)&checker.ObjectFlagsObjectLiteral != 0
 }
 
+func getAssertionRange(sourceFile *ast.SourceFile, node, expression, typeAnnotation *ast.Node) core.TextRange {
+	if ast.IsAsExpression(node) {
+		asKeywordRange := scanner.GetScannerForSourceFile(sourceFile, expression.End()).TokenRange()
+		return asKeywordRange.WithEnd(typeAnnotation.End())
+	}
+
+	s := scanner.GetScannerForSourceFile(sourceFile, node.Pos())
+	openingAngleBracket := s.TokenRange()
+	s.ResetPos(typeAnnotation.End())
+	s.Scan()
+	closingAngleBracket := s.TokenRange()
+	return openingAngleBracket.WithEnd(closingAngleBracket.End())
+}
+
+func typeLabel(typeChecker *checker.Checker, t *checker.Type) string {
+	if utils.IsIntrinsicErrorType(t) {
+		return "error"
+	}
+	return typeChecker.TypeToString(t)
+}
+
+func buildUnsafeTypeAssertionDiagnostic(
+	assertionRange core.TextRange,
+	expressionRange core.TextRange,
+	typeAnnotationRange core.TextRange,
+	originalType string,
+	assertedType string,
+	message rule.RuleMessage,
+) rule.RuleDiagnostic {
+	return rule.RuleDiagnostic{
+		Range:   assertionRange,
+		Message: message,
+		LabeledRanges: []rule.RuleLabeledRange{
+			{
+				Label: fmt.Sprintf("Original expression has type `%s`.", originalType),
+				Range: expressionRange,
+			},
+			{
+				Label: fmt.Sprintf("Asserted type is `%s`.", assertedType),
+				Range: typeAnnotationRange,
+			},
+		},
+	}
+}
+
 var NoUnsafeTypeAssertionRule = rule.Rule{
 	Name: "no-unsafe-type-assertion",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
@@ -59,6 +106,16 @@ var NoUnsafeTypeAssertionRule = rule.Rule{
 			typeAnnotation := node.Type()
 			expressionType := ctx.TypeChecker.GetTypeAtLocation(expression)
 			assertedType := ctx.TypeChecker.GetTypeAtLocation(typeAnnotation)
+			report := func(message rule.RuleMessage) {
+				ctx.ReportDiagnostic(buildUnsafeTypeAssertionDiagnostic(
+					getAssertionRange(ctx.SourceFile, node, expression, typeAnnotation),
+					utils.TrimNodeTextRange(ctx.SourceFile, expression),
+					utils.TrimNodeTextRange(ctx.SourceFile, typeAnnotation),
+					typeLabel(ctx.TypeChecker, expressionType),
+					typeLabel(ctx.TypeChecker, assertedType),
+					message,
+				))
+			}
 
 			if expressionType == assertedType {
 				return
@@ -66,19 +123,19 @@ var NoUnsafeTypeAssertionRule = rule.Rule{
 
 			// handle cases when asserting unknown ==> any.
 			if utils.IsTypeAnyType(assertedType) && utils.IsTypeUnknownType(expressionType) {
-				ctx.ReportNode(node, buildUnsafeToAnyTypeAssertionMessage("`any`"))
+				report(buildUnsafeToAnyTypeAssertionMessage("`any`"))
 				return
 			}
 
 			_, sender, isUnsafeExpressionAny := utils.IsUnsafeAssignment(expressionType, assertedType, ctx.TypeChecker, expression)
 			if isUnsafeExpressionAny {
-				ctx.ReportNode(node, buildUnsafeOfAnyTypeAssertionMessage(getAnyTypeName(sender)))
+				report(buildUnsafeOfAnyTypeAssertionMessage(getAnyTypeName(sender)))
 				return
 			}
 
 			_, sender, isUnsafeAssertedAny := utils.IsUnsafeAssignment(assertedType, expressionType, ctx.TypeChecker, typeAnnotation)
 			if isUnsafeAssertedAny {
-				ctx.ReportNode(node, buildUnsafeToAnyTypeAssertionMessage(getAnyTypeName(sender)))
+				report(buildUnsafeToAnyTypeAssertionMessage(getAnyTypeName(sender)))
 				return
 			}
 
@@ -98,19 +155,19 @@ var NoUnsafeTypeAssertionRule = rule.Rule{
 				assertedTypeConstraint := checker.Checker_getBaseConstraintOfType(ctx.TypeChecker, assertedType)
 				if assertedTypeConstraint == nil {
 					// asserting to an unconstrained type parameter is unsafe
-					ctx.ReportNode(node, buildUnsafeToUnconstrainedTypeAssertionMessage(ctx.TypeChecker.TypeToString(assertedType)))
+					report(buildUnsafeToUnconstrainedTypeAssertionMessage(ctx.TypeChecker.TypeToString(assertedType)))
 					return
 				}
 
 				// special case message if the original type is assignable to the
 				// constraint of the target type parameter
 				if checker.Checker_isTypeAssignableTo(ctx.TypeChecker, expressionWidenedType, assertedTypeConstraint) {
-					ctx.ReportNode(node, buildUnsafeTypeAssertionAssignableToConstraintMessage(ctx.TypeChecker.TypeToString(assertedType)))
+					report(buildUnsafeTypeAssertionAssignableToConstraintMessage(ctx.TypeChecker.TypeToString(assertedType)))
 					return
 				}
 			}
 
-			ctx.ReportNode(node, buildUnsafeTypeAssertionMessage(ctx.TypeChecker.TypeToString(assertedType)))
+			report(buildUnsafeTypeAssertionMessage(ctx.TypeChecker.TypeToString(assertedType)))
 		}
 
 		return rule.RuleListeners{

--- a/internal/rules/no_unsafe_type_assertion/no_unsafe_type_assertion_test.go
+++ b/internal/rules/no_unsafe_type_assertion/no_unsafe_type_assertion_test.go
@@ -48,7 +48,7 @@ a as string;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 12,
 				},
@@ -63,7 +63,7 @@ a satisfies string as string;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    20,
 					EndLine:   3,
 					EndColumn: 29,
 				},
@@ -80,7 +80,7 @@ declare const a: string | number;
 					Line:      3,
 					Column:    1,
 					EndLine:   3,
-					EndColumn: 10,
+					EndColumn: 9,
 				},
 			},
 		},
@@ -93,7 +93,7 @@ a as string | boolean;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 22,
 				},
@@ -108,14 +108,14 @@ a as 'foo' as 'bar';
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    12,
 					EndLine:   3,
 					EndColumn: 20,
 				},
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 11,
 				},
@@ -131,7 +131,7 @@ function foo<T extends boolean>(a: T) {
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    10,
+					Column:    12,
 					EndLine:   3,
 					EndColumn: 19,
 				},
@@ -146,7 +146,7 @@ a as Omit<Required<Readonly<{ hello: 'world'; foo: 'bar' }>>, 'foo'>;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 69,
 				},
@@ -161,7 +161,7 @@ const bar = foo as number[];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    13,
+					Column:    17,
 					EndLine:   3,
 					EndColumn: 28,
 				},
@@ -190,7 +190,7 @@ _any_ as string;
 				{
 					MessageId: "unsafeOfAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    7,
 					EndLine:   3,
 					EndColumn: 16,
 				},
@@ -205,7 +205,7 @@ _unknown_ as any;
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    11,
 					EndLine:   3,
 					EndColumn: 17,
 				},
@@ -220,7 +220,7 @@ _any_ as Function;
 				{
 					MessageId: "unsafeOfAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    7,
 					EndLine:   3,
 					EndColumn: 18,
 				},
@@ -235,7 +235,7 @@ _any_ as never;
 				{
 					MessageId: "unsafeOfAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    7,
 					EndLine:   3,
 					EndColumn: 15,
 				},
@@ -249,7 +249,7 @@ _any_ as never;
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      2,
-					Column:    1,
+					Column:    7,
 					EndLine:   2,
 					EndColumn: 13,
 				},
@@ -263,7 +263,7 @@ const bar = foo as number;
 				{
 					MessageId: "unsafeOfAnyTypeAssertion",
 					Line:      2,
-					Column:    13,
+					Column:    17,
 					EndLine:   2,
 					EndColumn: 26,
 				},
@@ -277,7 +277,7 @@ const bar = 'foo' as errorType;
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      2,
-					Column:    13,
+					Column:    19,
 					EndLine:   2,
 					EndColumn: 31,
 				},
@@ -306,7 +306,7 @@ _never_ as any;
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    9,
 					EndLine:   3,
 					EndColumn: 15,
 				},
@@ -321,7 +321,7 @@ _string_ as never;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    10,
 					EndLine:   3,
 					EndColumn: 18,
 				},
@@ -350,7 +350,7 @@ _function_ as () => void;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    12,
 					EndLine:   3,
 					EndColumn: 25,
 				},
@@ -365,7 +365,7 @@ _function_ as any;
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    12,
 					EndLine:   3,
 					EndColumn: 18,
 				},
@@ -380,7 +380,7 @@ _function_ as never;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    12,
 					EndLine:   3,
 					EndColumn: 20,
 				},
@@ -425,7 +425,7 @@ var foo = {} as {
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      2,
-					Column:    11,
+					Column:    14,
 					EndLine:   5,
 					EndColumn: 2,
 				},
@@ -440,7 +440,7 @@ a satisfies Record<string, string> as { hello: string; world: string };
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    36,
 					EndLine:   3,
 					EndColumn: 71,
 				},
@@ -455,7 +455,7 @@ a as { hello: string };
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 23,
 				},
@@ -488,7 +488,7 @@ a as string[];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 14,
 				},
@@ -503,7 +503,7 @@ a as number[];
 				{
 					MessageId: "unsafeOfAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 14,
 				},
@@ -518,7 +518,7 @@ a as any[];
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 11,
 				},
@@ -533,7 +533,7 @@ a as number[];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 14,
 				},
@@ -548,7 +548,7 @@ a as never[];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 13,
 				},
@@ -585,7 +585,7 @@ a as [string];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 14,
 				},
@@ -600,7 +600,7 @@ a as [string, string];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 22,
 				},
@@ -615,7 +615,7 @@ a as [string, number];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 22,
 				},
@@ -630,7 +630,7 @@ a as [string];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 14,
 				},
@@ -645,7 +645,7 @@ a as [number];
 				{
 					MessageId: "unsafeOfAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 14,
 				},
@@ -660,7 +660,7 @@ a as [number, number];
 				{
 					MessageId: "unsafeOfAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 22,
 				},
@@ -675,7 +675,7 @@ a as [any];
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 11,
 				},
@@ -690,7 +690,7 @@ a as [number];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 14,
 				},
@@ -705,7 +705,7 @@ a as [never];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 13,
 				},
@@ -720,7 +720,7 @@ a as [Promise<string>];
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 23,
 				},
@@ -757,7 +757,7 @@ a as Promise<string>;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 21,
 				},
@@ -772,7 +772,7 @@ a as Promise<number>;
 				{
 					MessageId: "unsafeOfAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 21,
 				},
@@ -787,7 +787,7 @@ a as Promise<any>;
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 18,
 				},
@@ -802,7 +802,7 @@ a as Promise<any[]>;
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 20,
 				},
@@ -817,7 +817,7 @@ a as Promise<number>;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 21,
 				},
@@ -832,7 +832,7 @@ a as Promise<never>;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    1,
+					Column:    3,
 					EndLine:   3,
 					EndColumn: 20,
 				},
@@ -894,7 +894,7 @@ a as Bar;
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      9,
-					Column:    1,
+					Column:    3,
 					EndLine:   9,
 					EndColumn: 9,
 				},
@@ -946,7 +946,7 @@ function func<T extends Obj>() {
 				{
 					MessageId: "unsafeTypeAssertionAssignableToConstraint",
 					Line:      4,
-					Column:    17,
+					Column:    31,
 					EndLine:   4,
 					EndColumn: 35,
 				},
@@ -964,7 +964,7 @@ function func<T extends Obj>() {
 				{
 					MessageId: "unsafeTypeAssertionAssignableToConstraint",
 					Line:      5,
-					Column:    17,
+					Column:    19,
 					EndLine:   5,
 					EndColumn: 23,
 				},
@@ -983,7 +983,7 @@ export function myfunc<CustomObjectT extends string>(
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      5,
-					Column:    27,
+					Column:    33,
 					EndLine:   5,
 					EndColumn: 49,
 				},
@@ -999,7 +999,7 @@ function unknownConstraint<T extends unknown>(x: T, y: string) {
 				{
 					MessageId: "unsafeTypeAssertionAssignableToConstraint",
 					Line:      3,
-					Column:    3,
+					Column:    5,
 					EndLine:   3,
 					EndColumn: 9,
 				},
@@ -1015,7 +1015,7 @@ function unconstrained<T>(x: T, y: string) {
 				{
 					MessageId: "unsafeToUnconstrainedTypeAssertion",
 					Line:      3,
-					Column:    3,
+					Column:    5,
 					EndLine:   3,
 					EndColumn: 9,
 				},
@@ -1033,7 +1033,7 @@ function anyConstraint<T extends any>(x: T, y: string) {
 				{
 					MessageId: "unsafeTypeAssertionAssignableToConstraint",
 					Line:      5,
-					Column:    3,
+					Column:    5,
 					EndLine:   5,
 					EndColumn: 9,
 				},
@@ -1052,7 +1052,7 @@ function constraintWiderThanUncastType<T extends string | number>(
 				{
 					MessageId: "unsafeTypeAssertionAssignableToConstraint",
 					Line:      6,
-					Column:    3,
+					Column:    5,
 					EndLine:   6,
 					EndColumn: 9,
 				},
@@ -1068,7 +1068,7 @@ function constraintEqualUncastType<T extends string>(x: T, y: string) {
 				{
 					MessageId: "unsafeTypeAssertionAssignableToConstraint",
 					Line:      3,
-					Column:    3,
+					Column:    5,
 					EndLine:   3,
 					EndColumn: 9,
 				},
@@ -1087,7 +1087,7 @@ function constraintNarrowerThanUncastType<T extends string>(
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      6,
-					Column:    3,
+					Column:    5,
 					EndLine:   6,
 					EndColumn: 9,
 				},
@@ -1103,7 +1103,7 @@ function assertFromAny<T extends string | number>(x: T, y: any) {
 				{
 					MessageId: "unsafeOfAnyTypeAssertion",
 					Line:      3,
-					Column:    3,
+					Column:    5,
 					EndLine:   3,
 					EndColumn: 9,
 				},
@@ -1122,7 +1122,7 @@ function parameterExtendsOtherParameter<T extends string | number, V extends T>(
 				{
 					MessageId: "unsafeTypeAssertionAssignableToConstraint",
 					Line:      6,
-					Column:    3,
+					Column:    5,
 					EndLine:   6,
 					EndColumn: 9,
 				},
@@ -1138,7 +1138,7 @@ function parameterExtendsUnconstrainedParameter<T, V extends T>(x: T, y: V) {
 				{
 					MessageId: "unsafeToUnconstrainedTypeAssertion",
 					Line:      3,
-					Column:    3,
+					Column:    5,
 					EndLine:   3,
 					EndColumn: 9,
 				},
@@ -1154,7 +1154,7 @@ function twoUnconstrained<T, V>(x: T, y: V) {
 				{
 					MessageId: "unsafeToUnconstrainedTypeAssertion",
 					Line:      3,
-					Column:    3,
+					Column:    5,
 					EndLine:   3,
 					EndColumn: 9,
 				},
@@ -1170,7 +1170,7 @@ function toNarrower<T>(x: T, y: string) {
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    3,
+					Column:    5,
 					EndLine:   3,
 					EndColumn: 14,
 				},
@@ -1186,7 +1186,7 @@ function unconstrainedToAny<T>(x: T) {
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      3,
-					Column:    3,
+					Column:    5,
 					EndLine:   3,
 					EndColumn: 11,
 				},
@@ -1202,7 +1202,7 @@ function stringToAny<T extends string>(x: T) {
 				{
 					MessageId: "unsafeToAnyTypeAssertion",
 					Line:      3,
-					Column:    3,
+					Column:    5,
 					EndLine:   3,
 					EndColumn: 11,
 				},
@@ -1218,7 +1218,7 @@ function stringToNarrower<T extends string>(x: T) {
 				{
 					MessageId: "unsafeTypeAssertion",
 					Line:      3,
-					Column:    3,
+					Column:    5,
 					EndLine:   3,
 					EndColumn: 17,
 				},


### PR DESCRIPTION
Part of #677.

Improves no-unsafe-type-assertion diagnostics by:
- narrowing primary ranges to the assertion syntax
- labeling original expressions with their rendered source types
- labeling asserted annotations with their rendered target types
- handling any, intrinsic error, and generic-constraint cases consistently
- adding focused range coverage and updating focused/e2e snapshots

Tests:
- go test ./internal/rules/no_unsafe_type_assertion
- cd e2e and pnpm --ignore-workspace run test --run