### PR TITLE
fix(headless): resolve relative payload paths against the working directory

### DIFF
--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -253,7 +253,11 @@ func runHeadless(args []string) int {
 
 	baseFS := osvfs.FS()
 	if len(payload.SourceOverrides) > 0 {
-		baseFS = newOverlayFS(baseFS, payload.SourceOverrides)
+		overrides := make(map[string]string, len(payload.SourceOverrides))
+		for path, content := range payload.SourceOverrides {
+			overrides[tspath.ResolvePath(cwd, path)] = content
+		}
+		baseFS = newOverlayFS(baseFS, overrides)
 	}
 	fs := bundled.WrapFS(cachedvfs.From(baseFS))
 
@@ -276,10 +280,12 @@ func runHeadless(args []string) int {
 	fileConfigs := make(map[string][]headlessRule, totalFileCount)
 	for _, config := range payload.Configs {
 		for _, filePath := range config.FilePaths {
-			normalized := tspath.NormalizeSlashes(filePath)
-			normalizedFiles = append(normalizedFiles, normalized)
+			// Payload paths may be relative (e.g. `oxlint --no-ignore src`);
+			// the VFS panics on non-absolute paths, so resolve against cwd.
+			resolved := tspath.ResolvePath(cwd, filePath)
+			normalizedFiles = append(normalizedFiles, resolved)
 
-			fileConfigs[normalized] = config.Rules
+			fileConfigs[resolved] = config.Rules
 		}
 	}
 

--- a/e2e/snapshot.test.ts
+++ b/e2e/snapshot.test.ts
@@ -347,6 +347,28 @@ describe('TSGoLint E2E Snapshot Tests', () => {
     },
   );
 
+  it('should not panic when file paths are relative to the working directory (issue #1114)', async () => {
+    // Regression test for https://github.com/oxc-project/tsgolint/issues/1114
+    // `oxlint --type-aware --no-ignore src` passes relative paths through to
+    // tsgolint, which crashed with:
+    // "panic: vfs: path \"src/tsconfig.json\" is not absolute"
+    const relativePath = 'basic/rules/no-floating-promises/index.ts';
+
+    const output = execFileSync(TSGOLINT_BIN, ['headless'], {
+      input: generateConfig([relativePath], ['no-floating-promises']),
+      cwd: FIXTURES_DIR,
+      env: { ...process.env, GOMAXPROCS: '1' },
+    });
+
+    const diagnostics = parseHeadlessOutput(output);
+
+    expect(diagnostics.length).toBeGreaterThan(0);
+    for (const diagnostic of diagnostics) {
+      expect((diagnostic as RuleDiagnostic).rule).toBe('no-floating-promises');
+      expect(diagnostic.file_path).toBe('fixtures/basic/rules/no-floating-promises/index.ts');
+    }
+  });
+
   it('should correctly evaluate project references', async () => {
     const testFiles = await getTestFiles('project-references');
     expect(testFiles.length).toBeGreaterThan(0);


### PR DESCRIPTION
Fixes #1114.

Headless payload file paths were only slash-normalized, so a relative path such as `src/index.ts` (what oxlint sends for `oxlint --type-aware --no-ignore src`) reached tsconfig discovery unchanged, and typescript-go's VFS panicked with `vfs: path "src/tsconfig.json" is not absolute`.

File paths are now resolved against the process working directory before files are assigned to programs. Source override keys come from the same payload, so they get the same treatment; a relative key there would never match the absolute paths the VFS is queried with.

For absolute inputs `tspath.ResolvePath` behaves like the previous normalization (slashes, plus collapsing any `.`/`..` segments), so the normal oxlint integration is unchanged.

Verified with the repro from the issue: the panic is gone and `no-floating-promises` fires. The new e2e test fails on `main` and passes with this change.