### PR TITLE
fix(no-misused-promises): guard nil contextual type in return statements

### DIFF
--- a/internal/rule_tester/__snapshots__/no-misused-promises.snap
+++ b/internal/rule_tester/__snapshots__/no-misused-promises.snap
@@ -1845,3 +1845,17 @@ Message: Promise returned in function argument where a void return was expected.
      |                                               ^^^^^^^^^^^^^^^^^ This context accepts a `void`-returning callback through type `() => void`.
    3 | on(async () => {}, async () => {});
 ---
+
+[TestNoMisusedPromisesRule/invalid-91 - 1]
+Diagnostic 1: voidReturnReturnValue (10:12 - 10:24)
+Message: Promise-returning function provided to return value where a void return was expected.
+   9 |   get handler() {
+  10 |     return this._handler;
+     |            ~~~~~~~~~~~~~
+  11 |   }
+  Label: This expression has type `((x: number) => Promise<void>) | undefined`. (10:12 - 10:24)
+   9 |   get handler() {
+  10 |     return this._handler;
+     |            ^^^^^^^^^^^^^ This expression has type `((x: number) => Promise<void>) | undefined`.
+  11 |   }
+---

--- a/internal/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/rules/no_misused_promises/no_misused_promises.go
@@ -834,12 +834,13 @@ var NoMisusedPromisesRule = rule.Rule{
 				if functionNode != nil && functionNode.Type() != nil {
 					expectation = &voidExpectation{declaration: functionNode, t: contextualType}
 				} else if functionNode != nil {
-					functionType := checker.Checker_getContextualType(ctx.TypeChecker, functionNode, checker.ContextFlagsNone)
-					for _, signature := range utils.GetCallSignatures(ctx.TypeChecker, functionType) {
-						declaration := checker.Signature_declaration(signature)
-						if declaration != nil && ast.GetSourceFileOfNode(declaration) == ctx.SourceFile {
-							expectation = &voidExpectation{declaration: declaration, t: contextualType}
-							break
+					// The enclosing function may have no contextual type of its own, e.g. a
+					// getter whose type comes from its paired setter's parameter.
+					if functionType := checker.Checker_getContextualType(ctx.TypeChecker, functionNode, checker.ContextFlagsNone); functionType != nil {
+						for _, signature := range utils.GetCallSignatures(ctx.TypeChecker, functionType) {
+							if expectation = localExpectationForDeclaration(checker.Signature_declaration(signature), contextualType); expectation != nil {
+								break
+							}
 						}
 					}
 				}

--- a/internal/rules/no_misused_promises/no_misused_promises_test.go
+++ b/internal/rules/no_misused_promises/no_misused_promises_test.go
@@ -2707,5 +2707,25 @@ on(async () => {}, async () => {});
 				{MessageId: "voidReturnArgument", Line: 3},
 			},
 		},
+		// A getter whose type comes from its paired setter has no contextual type
+		// of its own; the void expectation must not be resolved from it.
+		{
+			Code: `
+class C {
+  private _handler: ((x: number) => Promise<void>) | undefined;
+
+  set handler(handler: undefined | ((x: number) => void)) {
+    this._handler = handler as ((x: number) => Promise<void>) | undefined;
+  }
+
+  get handler() {
+    return this._handler;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "voidReturnReturnValue", Line: 10},
+			},
+		},
 	})
 }


### PR DESCRIPTION
## Summary

`no-misused-promises` segfaults on real code. In `checkReturnStatement`, the enclosing function's contextual type was passed straight to `utils.GetCallSignatures`, which nil-derefs inside `getReducedType` when the function has no contextual type of its own:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0]

checker.(*Checker).getReducedType(...)
checker.(*Checker).getReducedApparentType(...)
checker.(*Checker).getSignaturesOfType(...)
utils.GetCallSignatures(...)          internal/utils/ts_api_utils.go:85
no_misused_promises.init.func1.27(...) internal/rules/no_misused_promises/no_misused_promises.go:838
```

A getter with no return-type annotation is the common trigger: its type comes from its paired setter, so `getContextualType` on the getter itself returns nil while the contextual type of the *returned expression* is a `void`-returning function type.

Introduced in #1101 (`af5d740`) and live on `main` — linting the vscode repo (`src/tsconfig.json`) crashes on `src/vs/workbench/contrib/testing/common/testItemCollection.ts`.

## Repro

```ts
class C {
  private _handler: ((x: number) => Promise<void>) | undefined;

  set handler(handler: undefined | ((x: number) => void)) {
    this._handler = handler as ((x: number) => Promise<void>) | undefined;
  }

  get handler() {
    return this._handler;
  }
}
```

## Fix

Guard the nil, and resolve the expectation through the existing `localExpectationForDeclaration` helper, which already does the same nil-declaration + same-source-file check the inlined loop was doing.

## Testing

- Regression test appended to `invalidCases` (still reports `voidReturnReturnValue`, so the diagnostic is unchanged — only the crash is gone); snapshot diff is purely additive.
- `go test ./internal/rules/no_misused_promises/ ./internal/linter/` passes.
- A full CLI run over vscode `src/tsconfig.json` (7,325 files, 59 rules) completes instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)