### PR TITLE
feat(no-redundant-type-constituents): add diagnostic labels

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -662,6 +662,13 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
         },
       },
       {
+        "label": "Redundant type: \`B\`",
+        "range": {
+          "end": 112,
+          "pos": 111,
+        },
+      },
+      {
         "label": "Overriding type: \`A\`",
         "range": {
           "end": 108,
@@ -691,6 +698,13 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
         },
       },
       {
+        "label": "Redundant type: \`A\`",
+        "range": {
+          "end": 108,
+          "pos": 107,
+        },
+      },
+      {
         "label": "Overriding type: \`B\`",
         "range": {
           "end": 112,
@@ -717,6 +731,13 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
         "range": {
           "end": 108,
           "pos": 107,
+        },
+      },
+      {
+        "label": "Redundant type: \`B\`",
+        "range": {
+          "end": 112,
+          "pos": 111,
         },
       },
       {

--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -653,6 +653,22 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-duplicate-type-constituents/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Redundant type: \`A\`",
+        "range": {
+          "end": 104,
+          "pos": 103,
+        },
+      },
+      {
+        "label": "Overriding type: \`A\`",
+        "range": {
+          "end": 108,
+          "pos": 107,
+        },
+      },
+    ],
     "message": {
       "description": "'A' is an 'error' type that acts as 'any' and overrides all other types in this union type.",
       "id": "errorTypeOverrides",
@@ -666,6 +682,51 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-duplicate-type-constituents/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Redundant type: \`A\`",
+        "range": {
+          "end": 104,
+          "pos": 103,
+        },
+      },
+      {
+        "label": "Overriding type: \`B\`",
+        "range": {
+          "end": 112,
+          "pos": 111,
+        },
+      },
+    ],
+    "message": {
+      "description": "'B' is an 'error' type that acts as 'any' and overrides all other types in this union type.",
+      "id": "errorTypeOverrides",
+    },
+    "range": {
+      "end": 104,
+      "pos": 103,
+    },
+    "rule": "no-redundant-type-constituents",
+  },
+  {
+    "file_path": "fixtures/basic/rules/no-duplicate-type-constituents/index.ts",
+    "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Redundant type: \`A\`",
+        "range": {
+          "end": 108,
+          "pos": 107,
+        },
+      },
+      {
+        "label": "Overriding type: \`A\`",
+        "range": {
+          "end": 104,
+          "pos": 103,
+        },
+      },
+    ],
     "message": {
       "description": "'A' is an 'error' type that acts as 'any' and overrides all other types in this union type.",
       "id": "errorTypeOverrides",
@@ -673,19 +734,6 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "range": {
       "end": 108,
       "pos": 107,
-    },
-    "rule": "no-redundant-type-constituents",
-  },
-  {
-    "file_path": "fixtures/basic/rules/no-duplicate-type-constituents/index.ts",
-    "kind": 0,
-    "message": {
-      "description": "'B' is an 'error' type that acts as 'any' and overrides all other types in this union type.",
-      "id": "errorTypeOverrides",
-    },
-    "range": {
-      "end": 112,
-      "pos": 111,
     },
     "rule": "no-redundant-type-constituents",
   },
@@ -1391,32 +1439,80 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
   {
     "file_path": "fixtures/basic/rules/no-redundant-type-constituents/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Redundant type: \`string\`",
+        "range": {
+          "end": 121,
+          "pos": 115,
+        },
+      },
+      {
+        "label": "Overriding type: \`unknown\`",
+        "range": {
+          "end": 131,
+          "pos": 124,
+        },
+      },
+    ],
     "message": {
       "description": "'unknown' overrides all other types in this union type.",
       "id": "overrides",
     },
     "range": {
-      "end": 131,
-      "pos": 124,
+      "end": 121,
+      "pos": 115,
     },
     "rule": "no-redundant-type-constituents",
   },
   {
     "file_path": "fixtures/basic/rules/no-redundant-type-constituents/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Redundant type: \`string\`",
+        "range": {
+          "end": 180,
+          "pos": 174,
+        },
+      },
+      {
+        "label": "Overriding type: \`any\`",
+        "range": {
+          "end": 186,
+          "pos": 183,
+        },
+      },
+    ],
     "message": {
       "description": "'any' overrides all other types in this union type.",
       "id": "overrides",
     },
     "range": {
-      "end": 186,
-      "pos": 183,
+      "end": 180,
+      "pos": 174,
     },
     "rule": "no-redundant-type-constituents",
   },
   {
     "file_path": "fixtures/basic/rules/no-redundant-type-constituents/index.ts",
     "kind": 0,
+    "labeled_ranges": [
+      {
+        "label": "Redundant type: \`never\`",
+        "range": {
+          "end": 245,
+          "pos": 240,
+        },
+      },
+      {
+        "label": "Overriding type: \`string\`",
+        "range": {
+          "end": 237,
+          "pos": 231,
+        },
+      },
+    ],
     "message": {
       "description": "'never' is overridden by other types in this union type.",
       "id": "overridden",

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -418,9 +418,9 @@ Diagnostic 1: literalOverridden (1:10 - 1:19)
 Message: -1n | 1n is overridden by bigint in this union type.
    1 | type T = (-1n | 1n) | bigint;
      |          ~~~~~~~~~~
-  Label: Redundant type: `-1n` (1:10 - 1:19)
+  Label: Redundant type: `-1n` (1:11 - 1:13)
    1 | type T = (-1n | 1n) | bigint;
-     |          ^^^^^^^^^^ Redundant type: `-1n`
+     |           ^^^ Redundant type: `-1n`
   Label: Redundant type: `1n` (1:17 - 1:18)
    1 | type T = (-1n | 1n) | bigint;
      |                 ^^ Redundant type: `1n`
@@ -889,4 +889,17 @@ Message: 'any' overrides all other types in this union type.
   Label: Overriding type: `any` (1:20 - 1:22)
    1 | type T = (number | any) | string;
      |                    ^^^ Overriding type: `any`
+---
+
+[TestNoRedundantTypeConstituentsRule/invalid-56 - 1]
+Diagnostic 1: literalOverridden (1:10 - 1:23)
+Message: -1 is overridden by number in this union type.
+   1 | type T = (-1 | 'other') | number;
+     |          ~~~~~~~~~~~~~~
+  Label: Redundant type: `-1` (1:11 - 1:12)
+   1 | type T = (-1 | 'other') | number;
+     |           ^^ Redundant type: `-1`
+  Label: Overriding type: `number` (1:27 - 1:32)
+   1 | type T = (-1 | 'other') | number;
+     |                           ^^^^^^ Overriding type: `number`
 ---

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -223,15 +223,15 @@ Message: 2 | 0 | 1 is overridden by number in this union type.
    3 |         type T = (2 | B) | number;
      |                   ^ Redundant type: `2`
    4 |       
-  Label: Redundant type: `0` (3:18 - 3:24)
+  Label: Redundant type: `0` (3:23 - 3:23)
    2 |         type B = 0 | 1;
    3 |         type T = (2 | B) | number;
-     |                  ^^^^^^^ Redundant type: `0`
+     |                       ^ Redundant type: `0`
    4 |       
-  Label: Redundant type: `1` (3:18 - 3:24)
+  Label: Redundant type: `1` (3:23 - 3:23)
    2 |         type B = 0 | 1;
    3 |         type T = (2 | B) | number;
-     |                  ^^^^^^^ Redundant type: `1`
+     |                       ^ Redundant type: `1`
    4 |       
   Label: Overriding type: `number` (3:28 - 3:33)
    2 |         type B = 0 | 1;
@@ -902,4 +902,28 @@ Message: -1 is overridden by number in this union type.
   Label: Overriding type: `number` (1:27 - 1:32)
    1 | type T = (-1 | 'other') | number;
      |                           ^^^^^^ Overriding type: `number`
+---
+
+[TestNoRedundantTypeConstituentsRule/invalid-57 - 1]
+Diagnostic 1: literalOverridden (3:18 - 3:24)
+Message: 2 | 0 is overridden by number in this union type.
+   2 |         type B = 0 | 'other';
+   3 |         type T = (2 | B) | number;
+     |                  ~~~~~~~
+   4 |       
+  Label: Redundant type: `2` (3:19 - 3:19)
+   2 |         type B = 0 | 'other';
+   3 |         type T = (2 | B) | number;
+     |                   ^ Redundant type: `2`
+   4 |       
+  Label: Redundant type: `0` (3:23 - 3:23)
+   2 |         type B = 0 | 'other';
+   3 |         type T = (2 | B) | number;
+     |                       ^ Redundant type: `0`
+   4 |       
+  Label: Overriding type: `number` (3:28 - 3:33)
+   2 |         type B = 0 | 'other';
+   3 |         type T = (2 | B) | number;
+     |                            ^^^^^^ Overriding type: `number`
+   4 |       
 ---

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -964,3 +964,39 @@ Message: 0 is overridden by number in this union type.
    1 | type T = 0 | (number | string);
      |               ^^^^^^ Overriding type: `number`
 ---
+
+[TestNoRedundantTypeConstituentsRule/invalid-60 - 1]
+Diagnostic 1: overrides (3:33 - 3:38)
+Message: 'any' overrides all other types in this union type.
+   2 |         type A = any;
+   3 |         type T = (number | A) | string;
+     |                                 ~~~~~~
+   4 |       
+  Label: Redundant type: `string` (3:33 - 3:38)
+   2 |         type A = any;
+   3 |         type T = (number | A) | string;
+     |                                 ^^^^^^ Redundant type: `string`
+   4 |       
+  Label: Overriding type: `any` (3:28 - 3:28)
+   2 |         type A = any;
+   3 |         type T = (number | A) | string;
+     |                            ^ Overriding type: `any`
+   4 |       
+
+Diagnostic 2: overrides (3:19 - 3:24)
+Message: 'any' overrides all other types in this union type.
+   2 |         type A = any;
+   3 |         type T = (number | A) | string;
+     |                   ~~~~~~
+   4 |       
+  Label: Redundant type: `number` (3:19 - 3:24)
+   2 |         type A = any;
+   3 |         type T = (number | A) | string;
+     |                   ^^^^^^ Redundant type: `number`
+   4 |       
+  Label: Overriding type: `any` (3:28 - 3:28)
+   2 |         type A = any;
+   3 |         type T = (number | A) | string;
+     |                            ^ Overriding type: `any`
+   4 |       
+---

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -1,33 +1,65 @@
 
 [TestNoRedundantTypeConstituentsRule/invalid-0 - 1]
-Diagnostic 1: overrides (1:19 - 1:21)
+Diagnostic 1: overrides (1:10 - 1:15)
 Message: 'any' overrides all other types in this union type.
    1 | type T = number | any;
-     |                   ~~~
+     |          ~~~~~~
+  Label: Redundant type: `number` (1:10 - 1:15)
+   1 | type T = number | any;
+     |          ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `any` (1:19 - 1:21)
+   1 | type T = number | any;
+     |                   ^^^ Overriding type: `any`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-1 - 1]
-Diagnostic 1: overrides (3:22 - 3:24)
+Diagnostic 1: overrides (3:18 - 3:18)
 Message: 'any' overrides all other types in this union type.
    2 |         type B = number;
    3 |         type T = B | any;
-     |                      ~~~
+     |                  ~
+   4 |       
+  Label: Redundant type: `number` (3:18 - 3:18)
+   2 |         type B = number;
+   3 |         type T = B | any;
+     |                  ^ Redundant type: `number`
+   4 |       
+  Label: Overriding type: `any` (3:22 - 3:24)
+   2 |         type B = number;
+   3 |         type T = B | any;
+     |                      ^^^ Overriding type: `any`
    4 |       
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-2 - 1]
-Diagnostic 1: overrides (1:10 - 1:12)
+Diagnostic 1: overrides (1:16 - 1:21)
 Message: 'any' overrides all other types in this union type.
    1 | type T = any | number;
-     |          ~~~
+     |                ~~~~~~
+  Label: Redundant type: `number` (1:16 - 1:21)
+   1 | type T = any | number;
+     |                ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `any` (1:10 - 1:12)
+   1 | type T = any | number;
+     |          ^^^ Overriding type: `any`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-3 - 1]
-Diagnostic 1: overrides (3:18 - 3:18)
+Diagnostic 1: overrides (3:22 - 3:27)
 Message: 'any' overrides all other types in this union type.
    2 |         type B = any;
    3 |         type T = B | number;
-     |                  ~
+     |                      ~~~~~~
+   4 |       
+  Label: Redundant type: `number` (3:22 - 3:27)
+   2 |         type B = any;
+   3 |         type T = B | number;
+     |                      ^^^^^^ Redundant type: `number`
+   4 |       
+  Label: Overriding type: `any` (3:18 - 3:18)
+   2 |         type B = any;
+   3 |         type T = B | number;
+     |                  ^ Overriding type: `any`
    4 |       
 ---
 
@@ -36,6 +68,12 @@ Diagnostic 1: overridden (1:19 - 1:23)
 Message: 'never' is overridden by other types in this union type.
    1 | type T = number | never;
      |                   ~~~~~
+  Label: Redundant type: `never` (1:19 - 1:23)
+   1 | type T = number | never;
+     |                   ^^^^^ Redundant type: `never`
+  Label: Overriding type: `number` (1:10 - 1:15)
+   1 | type T = number | never;
+     |          ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-5 - 1]
@@ -44,6 +82,16 @@ Message: 'never' is overridden by other types in this union type.
    2 |         type B = number;
    3 |         type T = B | never;
      |                      ~~~~~
+   4 |       
+  Label: Redundant type: `never` (3:22 - 3:26)
+   2 |         type B = number;
+   3 |         type T = B | never;
+     |                      ^^^^^ Redundant type: `never`
+   4 |       
+  Label: Overriding type: `number` (3:18 - 3:18)
+   2 |         type B = number;
+   3 |         type T = B | never;
+     |                  ^ Overriding type: `number`
    4 |       
 ---
 
@@ -54,6 +102,16 @@ Message: 'never' is overridden by other types in this union type.
    3 |         type T = B | number;
      |                  ~
    4 |       
+  Label: Redundant type: `never` (3:18 - 3:18)
+   2 |         type B = never;
+   3 |         type T = B | number;
+     |                  ^ Redundant type: `never`
+   4 |       
+  Label: Overriding type: `number` (3:22 - 3:27)
+   2 |         type B = never;
+   3 |         type T = B | number;
+     |                      ^^^^^^ Overriding type: `number`
+   4 |       
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-7 - 1]
@@ -61,27 +119,51 @@ Diagnostic 1: overridden (1:10 - 1:14)
 Message: 'never' is overridden by other types in this union type.
    1 | type T = never | number;
      |          ~~~~~
+  Label: Redundant type: `never` (1:10 - 1:14)
+   1 | type T = never | number;
+     |          ^^^^^ Redundant type: `never`
+  Label: Overriding type: `number` (1:18 - 1:23)
+   1 | type T = never | number;
+     |                  ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-8 - 1]
-Diagnostic 1: overrides (1:19 - 1:25)
+Diagnostic 1: overrides (1:10 - 1:15)
 Message: 'unknown' overrides all other types in this union type.
    1 | type T = number | unknown;
-     |                   ~~~~~~~
+     |          ~~~~~~
+  Label: Redundant type: `number` (1:10 - 1:15)
+   1 | type T = number | unknown;
+     |          ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `unknown` (1:19 - 1:25)
+   1 | type T = number | unknown;
+     |                   ^^^^^^^ Overriding type: `unknown`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-9 - 1]
-Diagnostic 1: overrides (1:10 - 1:16)
+Diagnostic 1: overrides (1:20 - 1:25)
 Message: 'unknown' overrides all other types in this union type.
    1 | type T = unknown | number;
-     |          ~~~~~~~
+     |                    ~~~~~~
+  Label: Redundant type: `number` (1:20 - 1:25)
+   1 | type T = unknown | number;
+     |                    ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `unknown` (1:10 - 1:16)
+   1 | type T = unknown | number;
+     |          ^^^^^^^ Overriding type: `unknown`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-10 - 1]
-Diagnostic 1: errorTypeOverrides (1:19 - 1:26)
+Diagnostic 1: errorTypeOverrides (1:30 - 1:30)
 Message: 'NotKnown' is an 'error' type that acts as 'any' and overrides all other types in this union type.
    1 | type ErrorTypes = NotKnown | 0;
-     |                   ~~~~~~~~
+     |                              ~
+  Label: Redundant type: `0` (1:30 - 1:30)
+   1 | type ErrorTypes = NotKnown | 0;
+     |                              ^ Redundant type: `0`
+  Label: Overriding type: `NotKnown` (1:19 - 1:26)
+   1 | type ErrorTypes = NotKnown | 0;
+     |                   ^^^^^^^^ Overriding type: `NotKnown`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-11 - 1]
@@ -89,6 +171,12 @@ Diagnostic 1: literalOverridden (1:19 - 1:19)
 Message: 0 is overridden by number in this union type.
    1 | type T = number | 0;
      |                   ~
+  Label: Redundant type: `0` (1:19 - 1:19)
+   1 | type T = number | 0;
+     |                   ^ Redundant type: `0`
+  Label: Overriding type: `number` (1:10 - 1:15)
+   1 | type T = number | 0;
+     |          ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-12 - 1]
@@ -96,6 +184,12 @@ Diagnostic 1: literalOverridden (1:19 - 1:25)
 Message: 0 | 1 is overridden by number in this union type.
    1 | type T = number | (0 | 1);
      |                   ~~~~~~~
+  Label: Redundant type: `0 | 1` (1:19 - 1:25)
+   1 | type T = number | (0 | 1);
+     |                   ^^^^^^^ Redundant type: `0 | 1`
+  Label: Overriding type: `number` (1:10 - 1:15)
+   1 | type T = number | (0 | 1);
+     |          ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-13 - 1]
@@ -103,6 +197,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:16)
 Message: 0 is overridden by number in this union type.
    1 | type T = (0 | 0) | number;
      |          ~~~~~~~
+  Label: Redundant type: `0` (1:10 - 1:16)
+   1 | type T = (0 | 0) | number;
+     |          ^^^^^^^ Redundant type: `0`
+  Label: Overriding type: `number` (1:20 - 1:25)
+   1 | type T = (0 | 0) | number;
+     |                    ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-14 - 1]
@@ -112,6 +212,16 @@ Message: 0 | 1 | 2 is overridden by number in this union type.
    3 |         type T = (2 | B) | number;
      |                  ~~~~~~~
    4 |       
+  Label: Redundant type: `0 | 1 | 2` (3:18 - 3:24)
+   2 |         type B = 0 | 1;
+   3 |         type T = (2 | B) | number;
+     |                  ^^^^^^^ Redundant type: `0 | 1 | 2`
+   4 |       
+  Label: Overriding type: `number` (3:28 - 3:33)
+   2 |         type B = 0 | 1;
+   3 |         type T = (2 | B) | number;
+     |                            ^^^^^^ Overriding type: `number`
+   4 |       
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-15 - 1]
@@ -119,6 +229,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:22)
 Message: 0 | 1 | 2 is overridden by number in this union type.
    1 | type T = (0 | (1 | 2)) | number;
      |          ~~~~~~~~~~~~~
+  Label: Redundant type: `0 | 1 | 2` (1:10 - 1:22)
+   1 | type T = (0 | (1 | 2)) | number;
+     |          ^^^^^^^^^^^^^ Redundant type: `0 | 1 | 2`
+  Label: Overriding type: `number` (1:26 - 1:31)
+   1 | type T = (0 | (1 | 2)) | number;
+     |                          ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-16 - 1]
@@ -126,6 +242,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:16)
 Message: 0 | 1 is overridden by number in this union type.
    1 | type T = (0 | 1) | number;
      |          ~~~~~~~
+  Label: Redundant type: `0 | 1` (1:10 - 1:16)
+   1 | type T = (0 | 1) | number;
+     |          ^^^^^^^ Redundant type: `0 | 1`
+  Label: Overriding type: `number` (1:20 - 1:25)
+   1 | type T = (0 | 1) | number;
+     |                    ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-17 - 1]
@@ -133,6 +255,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:22)
 Message: 0 | 1 is overridden by number in this union type.
    1 | type T = (0 | (0 | 1)) | number;
      |          ~~~~~~~~~~~~~
+  Label: Redundant type: `0 | 1` (1:10 - 1:22)
+   1 | type T = (0 | (0 | 1)) | number;
+     |          ^^^^^^^^^^^^^ Redundant type: `0 | 1`
+  Label: Overriding type: `number` (1:26 - 1:31)
+   1 | type T = (0 | (0 | 1)) | number;
+     |                          ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-18 - 1]
@@ -140,6 +268,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:26)
 Message: 2 | 3 is overridden by number in this union type.
    1 | type T = (2 | 'other' | 3) | number;
      |          ~~~~~~~~~~~~~~~~~
+  Label: Redundant type: `2 | 3` (1:10 - 1:26)
+   1 | type T = (2 | 'other' | 3) | number;
+     |          ^^^^^^^^^^^^^^^^^ Redundant type: `2 | 3`
+  Label: Overriding type: `number` (1:30 - 1:35)
+   1 | type T = (2 | 'other' | 3) | number;
+     |                              ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-19 - 1]
@@ -147,6 +281,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:11)
 Message:  is overridden by string in this union type.
    1 | type T = '' | string;
      |          ~~
+  Label: Redundant type: `""` (1:10 - 1:11)
+   1 | type T = '' | string;
+     |          ^^ Redundant type: `""`
+  Label: Overriding type: `string` (1:15 - 1:20)
+   1 | type T = '' | string;
+     |               ^^^^^^ Overriding type: `string`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-20 - 1]
@@ -156,6 +296,16 @@ Message: "\"b\"" is overridden by string in this union type.
    3 |         type T = B | string;
      |                  ~
    4 |       
+  Label: Redundant type: `"b"` (3:18 - 3:18)
+   2 |         type B = 'b';
+   3 |         type T = B | string;
+     |                  ^ Redundant type: `"b"`
+   4 |       
+  Label: Overriding type: `string` (3:22 - 3:27)
+   2 |         type B = 'b';
+   3 |         type T = B | string;
+     |                      ^^^^^^ Overriding type: `string`
+   4 |       
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-21 - 1]
@@ -163,6 +313,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:22)
 Message: `a${number}c` is overridden by string in this union type.
    1 | type T = `a${number}c` | string;
      |          ~~~~~~~~~~~~~
+  Label: Redundant type: ``a${number}c`` (1:10 - 1:22)
+   1 | type T = `a${number}c` | string;
+     |          ^^^^^^^^^^^^^ Redundant type: ``a${number}c``
+  Label: Overriding type: `string` (1:26 - 1:31)
+   1 | type T = `a${number}c` | string;
+     |                          ^^^^^^ Overriding type: `string`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-22 - 1]
@@ -172,6 +328,16 @@ Message: `a${number}c` is overridden by string in this union type.
    3 |         type T = B | string;
      |                  ~
    4 |       
+  Label: Redundant type: ``a${number}c`` (3:18 - 3:18)
+   2 |         type B = `a${number}c`;
+   3 |         type T = B | string;
+     |                  ^ Redundant type: ``a${number}c``
+   4 |       
+  Label: Overriding type: `string` (3:22 - 3:27)
+   2 |         type B = `a${number}c`;
+   3 |         type T = B | string;
+     |                      ^^^^^^ Overriding type: `string`
+   4 |       
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-23 - 1]
@@ -179,6 +345,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:20)
 Message: `${number}` is overridden by string in this union type.
    1 | type T = `${number}` | string;
      |          ~~~~~~~~~~~
+  Label: Redundant type: ``${number}`` (1:10 - 1:20)
+   1 | type T = `${number}` | string;
+     |          ^^^^^^^^^^^ Redundant type: ``${number}``
+  Label: Overriding type: `string` (1:24 - 1:29)
+   1 | type T = `${number}` | string;
+     |                        ^^^^^^ Overriding type: `string`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-24 - 1]
@@ -186,6 +358,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:11)
 Message: 0n is overridden by bigint in this union type.
    1 | type T = 0n | bigint;
      |          ~~
+  Label: Redundant type: `0n` (1:10 - 1:11)
+   1 | type T = 0n | bigint;
+     |          ^^ Redundant type: `0n`
+  Label: Overriding type: `bigint` (1:15 - 1:20)
+   1 | type T = 0n | bigint;
+     |               ^^^^^^ Overriding type: `bigint`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-25 - 1]
@@ -193,6 +371,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:12)
 Message: -1n is overridden by bigint in this union type.
    1 | type T = -1n | bigint;
      |          ~~~
+  Label: Redundant type: `-1n` (1:10 - 1:12)
+   1 | type T = -1n | bigint;
+     |          ^^^ Redundant type: `-1n`
+  Label: Overriding type: `bigint` (1:16 - 1:21)
+   1 | type T = -1n | bigint;
+     |                ^^^^^^ Overriding type: `bigint`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-26 - 1]
@@ -200,6 +384,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:19)
 Message: 1n | -1n is overridden by bigint in this union type.
    1 | type T = (-1n | 1n) | bigint;
      |          ~~~~~~~~~~
+  Label: Redundant type: `1n | -1n` (1:10 - 1:19)
+   1 | type T = (-1n | 1n) | bigint;
+     |          ^^^^^^^^^^ Redundant type: `1n | -1n`
+  Label: Overriding type: `bigint` (1:23 - 1:28)
+   1 | type T = (-1n | 1n) | bigint;
+     |                       ^^^^^^ Overriding type: `bigint`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-27 - 1]
@@ -209,6 +399,16 @@ Message: literal type is overridden by boolean in this union type.
    3 |         type T = B | false;
      |                      ~~~~~
    4 |       
+  Label: Redundant type: `false` (3:22 - 3:26)
+   2 |         type B = boolean;
+   3 |         type T = B | false;
+     |                      ^^^^^ Redundant type: `false`
+   4 |       
+  Label: Overriding type: `boolean` (3:18 - 3:18)
+   2 |         type B = boolean;
+   3 |         type T = B | false;
+     |                  ^ Overriding type: `boolean`
+   4 |       
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-28 - 1]
@@ -216,6 +416,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:14)
 Message: literal type is overridden by boolean in this union type.
    1 | type T = false | boolean;
      |          ~~~~~
+  Label: Redundant type: `false` (1:10 - 1:14)
+   1 | type T = false | boolean;
+     |          ^^^^^ Redundant type: `false`
+  Label: Overriding type: `boolean` (1:18 - 1:24)
+   1 | type T = false | boolean;
+     |                  ^^^^^^^ Overriding type: `boolean`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-29 - 1]
@@ -223,6 +429,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:13)
 Message: literal type is overridden by boolean in this union type.
    1 | type T = true | boolean;
      |          ~~~~
+  Label: Redundant type: `true` (1:10 - 1:13)
+   1 | type T = true | boolean;
+     |          ^^^^ Redundant type: `true`
+  Label: Overriding type: `boolean` (1:17 - 1:23)
+   1 | type T = true | boolean;
+     |                 ^^^^^^^ Overriding type: `boolean`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-30 - 1]
@@ -230,6 +442,12 @@ Diagnostic 1: primitiveOverridden (1:18 - 1:24)
 Message: boolean is overridden by the literal type in this intersection type.
    1 | type T = false & boolean;
      |                  ~~~~~~~
+  Label: Redundant type: `boolean` (1:18 - 1:24)
+   1 | type T = false & boolean;
+     |                  ^^^^^^^ Redundant type: `boolean`
+  Label: Overriding type: `false` (1:10 - 1:14)
+   1 | type T = false & boolean;
+     |          ^^^^^ Overriding type: `false`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-31 - 1]
@@ -238,6 +456,16 @@ Message: boolean is overridden by the false in this intersection type.
    2 |         type B = false;
    3 |         type T = B & boolean;
      |                      ~~~~~~~
+   4 |       
+  Label: Redundant type: `boolean` (3:22 - 3:28)
+   2 |         type B = false;
+   3 |         type T = B & boolean;
+     |                      ^^^^^^^ Redundant type: `boolean`
+   4 |       
+  Label: Overriding type: `false` (3:18 - 3:18)
+   2 |         type B = false;
+   3 |         type T = B & boolean;
+     |                  ^ Overriding type: `false`
    4 |       
 ---
 
@@ -248,6 +476,16 @@ Message: boolean is overridden by the true in this intersection type.
    3 |         type T = B & boolean;
      |                      ~~~~~~~
    4 |       
+  Label: Redundant type: `boolean` (3:22 - 3:28)
+   2 |         type B = true;
+   3 |         type T = B & boolean;
+     |                      ^^^^^^^ Redundant type: `boolean`
+   4 |       
+  Label: Overriding type: `true` (3:18 - 3:18)
+   2 |         type B = true;
+   3 |         type T = B & boolean;
+     |                  ^ Overriding type: `true`
+   4 |       
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-33 - 1]
@@ -255,50 +493,96 @@ Diagnostic 1: primitiveOverridden (1:17 - 1:23)
 Message: boolean is overridden by the literal type in this intersection type.
    1 | type T = true & boolean;
      |                 ~~~~~~~
+  Label: Redundant type: `boolean` (1:17 - 1:23)
+   1 | type T = true & boolean;
+     |                 ^^^^^^^ Redundant type: `boolean`
+  Label: Overriding type: `true` (1:10 - 1:13)
+   1 | type T = true & boolean;
+     |          ^^^^ Overriding type: `true`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-34 - 1]
-Diagnostic 1: overrides (1:19 - 1:21)
+Diagnostic 1: overrides (1:10 - 1:15)
 Message: 'any' overrides all other types in this intersection type.
    1 | type T = number & any;
-     |                   ~~~
+     |          ~~~~~~
+  Label: Redundant type: `number` (1:10 - 1:15)
+   1 | type T = number & any;
+     |          ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `any` (1:19 - 1:21)
+   1 | type T = number & any;
+     |                   ^^^ Overriding type: `any`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-35 - 1]
-Diagnostic 1: overrides (1:10 - 1:12)
+Diagnostic 1: overrides (1:16 - 1:21)
 Message: 'any' overrides all other types in this intersection type.
    1 | type T = any & number;
-     |          ~~~
+     |                ~~~~~~
+  Label: Redundant type: `number` (1:16 - 1:21)
+   1 | type T = any & number;
+     |                ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `any` (1:10 - 1:12)
+   1 | type T = any & number;
+     |          ^^^ Overriding type: `any`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-36 - 1]
-Diagnostic 1: errorTypeOverrides (1:19 - 1:26)
+Diagnostic 1: errorTypeOverrides (1:30 - 1:30)
 Message: 'NotKnown' is an 'error' type that acts as 'any' and overrides all other types in this intersection type.
    1 | type ErrorTypes = NotKnown & 0;
-     |                   ~~~~~~~~
+     |                              ~
+  Label: Redundant type: `0` (1:30 - 1:30)
+   1 | type ErrorTypes = NotKnown & 0;
+     |                              ^ Redundant type: `0`
+  Label: Overriding type: `NotKnown` (1:19 - 1:26)
+   1 | type ErrorTypes = NotKnown & 0;
+     |                   ^^^^^^^^ Overriding type: `NotKnown`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-37 - 1]
-Diagnostic 1: overrides (1:19 - 1:23)
+Diagnostic 1: overrides (1:10 - 1:15)
 Message: 'never' overrides all other types in this intersection type.
    1 | type T = number & never;
-     |                   ~~~~~
+     |          ~~~~~~
+  Label: Redundant type: `number` (1:10 - 1:15)
+   1 | type T = number & never;
+     |          ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `never` (1:19 - 1:23)
+   1 | type T = number & never;
+     |                   ^^^^^ Overriding type: `never`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-38 - 1]
-Diagnostic 1: overrides (3:18 - 3:18)
+Diagnostic 1: overrides (3:22 - 3:27)
 Message: 'never' overrides all other types in this intersection type.
    2 |         type B = never;
    3 |         type T = B & number;
-     |                  ~
+     |                      ~~~~~~
+   4 |       
+  Label: Redundant type: `number` (3:22 - 3:27)
+   2 |         type B = never;
+   3 |         type T = B & number;
+     |                      ^^^^^^ Redundant type: `number`
+   4 |       
+  Label: Overriding type: `never` (3:18 - 3:18)
+   2 |         type B = never;
+   3 |         type T = B & number;
+     |                  ^ Overriding type: `never`
    4 |       
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-39 - 1]
-Diagnostic 1: overrides (1:10 - 1:14)
+Diagnostic 1: overrides (1:18 - 1:23)
 Message: 'never' overrides all other types in this intersection type.
    1 | type T = never & number;
-     |          ~~~~~
+     |                  ~~~~~~
+  Label: Redundant type: `number` (1:18 - 1:23)
+   1 | type T = never & number;
+     |                  ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `never` (1:10 - 1:14)
+   1 | type T = never & number;
+     |          ^^^^^ Overriding type: `never`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-40 - 1]
@@ -306,6 +590,12 @@ Diagnostic 1: overridden (1:19 - 1:25)
 Message: 'unknown' is overridden by other types in this intersection type.
    1 | type T = number & unknown;
      |                   ~~~~~~~
+  Label: Redundant type: `unknown` (1:19 - 1:25)
+   1 | type T = number & unknown;
+     |                   ^^^^^^^ Redundant type: `unknown`
+  Label: Overriding type: `number` (1:10 - 1:15)
+   1 | type T = number & unknown;
+     |          ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-41 - 1]
@@ -313,6 +603,12 @@ Diagnostic 1: overridden (1:10 - 1:16)
 Message: 'unknown' is overridden by other types in this intersection type.
    1 | type T = unknown & number;
      |          ~~~~~~~
+  Label: Redundant type: `unknown` (1:10 - 1:16)
+   1 | type T = unknown & number;
+     |          ^^^^^^^ Redundant type: `unknown`
+  Label: Overriding type: `number` (1:20 - 1:25)
+   1 | type T = unknown & number;
+     |                    ^^^^^^ Overriding type: `number`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-42 - 1]
@@ -320,6 +616,12 @@ Diagnostic 1: primitiveOverridden (1:10 - 1:15)
 Message: number is overridden by the 0 in this intersection type.
    1 | type T = number & 0;
      |          ~~~~~~
+  Label: Redundant type: `number` (1:10 - 1:15)
+   1 | type T = number & 0;
+     |          ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `0` (1:19 - 1:19)
+   1 | type T = number & 0;
+     |                   ^ Overriding type: `0`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-43 - 1]
@@ -327,6 +629,12 @@ Diagnostic 1: primitiveOverridden (1:15 - 1:20)
 Message: string is overridden by the  in this intersection type.
    1 | type T = '' & string;
      |               ~~~~~~
+  Label: Redundant type: `string` (1:15 - 1:20)
+   1 | type T = '' & string;
+     |               ^^^^^^ Redundant type: `string`
+  Label: Overriding type: `""` (1:10 - 1:11)
+   1 | type T = '' & string;
+     |          ^^ Overriding type: `""`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-44 - 1]
@@ -336,6 +644,16 @@ Message: bigint is overridden by the 0n in this intersection type.
    3 |         type T = B & bigint;
      |                      ~~~~~~
    4 |       
+  Label: Redundant type: `bigint` (3:22 - 3:27)
+   2 |         type B = 0n;
+   3 |         type T = B & bigint;
+     |                      ^^^^^^ Redundant type: `bigint`
+   4 |       
+  Label: Overriding type: `0n` (3:18 - 3:18)
+   2 |         type B = 0n;
+   3 |         type T = B & bigint;
+     |                  ^ Overriding type: `0n`
+   4 |       
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-45 - 1]
@@ -343,6 +661,12 @@ Diagnostic 1: primitiveOverridden (1:15 - 1:20)
 Message: bigint is overridden by the 0n in this intersection type.
    1 | type T = 0n & bigint;
      |               ~~~~~~
+  Label: Redundant type: `bigint` (1:15 - 1:20)
+   1 | type T = 0n & bigint;
+     |               ^^^^^^ Redundant type: `bigint`
+  Label: Overriding type: `0n` (1:10 - 1:11)
+   1 | type T = 0n & bigint;
+     |          ^^ Overriding type: `0n`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-46 - 1]
@@ -350,29 +674,78 @@ Diagnostic 1: primitiveOverridden (1:16 - 1:21)
 Message: bigint is overridden by the -1n in this intersection type.
    1 | type T = -1n & bigint;
      |                ~~~~~~
+  Label: Redundant type: `bigint` (1:16 - 1:21)
+   1 | type T = -1n & bigint;
+     |                ^^^^^^ Redundant type: `bigint`
+  Label: Overriding type: `-1n` (1:10 - 1:12)
+   1 | type T = -1n & bigint;
+     |          ^^^ Overriding type: `-1n`
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-47 - 1]
-Diagnostic 1: primitiveOverridden (3:18 - 3:18)
-Message: "\"a\"" | "\"b\"" is overridden by the string in this intersection type.
+Diagnostic 1: primitiveOverridden (3:22 - 3:27)
+Message: string is overridden by the "\"a\"" | "\"b\"" in this intersection type.
    2 |         type T = 'a' | 'b';
    3 |         type U = T & string;
-     |                  ~
+     |                      ~~~~~~
+   4 |       
+  Label: Redundant type: `string` (3:22 - 3:27)
+   2 |         type T = 'a' | 'b';
+   3 |         type U = T & string;
+     |                      ^^^^^^ Redundant type: `string`
+   4 |       
+  Label: Overriding type: `"a" | "b"` (3:18 - 3:18)
+   2 |         type T = 'a' | 'b';
+   3 |         type U = T & string;
+     |                  ^ Overriding type: `"a" | "b"`
    4 |       
 ---
 
 [TestNoRedundantTypeConstituentsRule/invalid-48 - 1]
-Diagnostic 1: primitiveOverridden (4:18 - 4:18)
-Message: 1 | 2 is overridden by the number in this intersection type.
+Diagnostic 1: primitiveOverridden (4:35 - 4:40)
+Message: number is overridden by the 1 | 2 in this intersection type.
    3 |         type T = 'a' | 'b';
    4 |         type U = S & T & string & number;
-     |                  ~
+     |                                   ~~~~~~
+   5 |       
+  Label: Redundant type: `number` (4:35 - 4:40)
+   3 |         type T = 'a' | 'b';
+   4 |         type U = S & T & string & number;
+     |                                   ^^^^^^ Redundant type: `number`
+   5 |       
+  Label: Overriding type: `1 | 2` (4:18 - 4:18)
+   3 |         type T = 'a' | 'b';
+   4 |         type U = S & T & string & number;
+     |                  ^ Overriding type: `1 | 2`
    5 |       
 
-Diagnostic 2: primitiveOverridden (4:22 - 4:22)
-Message: 1 | 2 is overridden by the string in this intersection type.
+Diagnostic 2: primitiveOverridden (4:26 - 4:31)
+Message: string is overridden by the "\"a\"" | "\"b\"" in this intersection type.
    3 |         type T = 'a' | 'b';
    4 |         type U = S & T & string & number;
-     |                      ~
+     |                          ~~~~~~
    5 |       
+  Label: Redundant type: `string` (4:26 - 4:31)
+   3 |         type T = 'a' | 'b';
+   4 |         type U = S & T & string & number;
+     |                          ^^^^^^ Redundant type: `string`
+   5 |       
+  Label: Overriding type: `"a" | "b"` (4:22 - 4:22)
+   3 |         type T = 'a' | 'b';
+   4 |         type U = S & T & string & number;
+     |                      ^ Overriding type: `"a" | "b"`
+   5 |       
+---
+
+[TestNoRedundantTypeConstituentsRule/invalid-49 - 1]
+Diagnostic 1: literalOverridden (1:10 - 1:22)
+Message: 2 is overridden by number in this union type.
+   1 | type T = (2 | 'other') | number;
+     |          ~~~~~~~~~~~~~
+  Label: Redundant type: `2` (1:10 - 1:22)
+   1 | type T = (2 | 'other') | number;
+     |          ^^^^^^^^^^^^^ Redundant type: `2`
+  Label: Overriding type: `number` (1:26 - 1:31)
+   1 | type T = (2 | 'other') | number;
+     |                          ^^^^^^ Overriding type: `number`
 ---

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -1013,3 +1013,27 @@ Message: number is overridden by the 0 | 1 in this intersection type.
    1 | type T = (number | string) & (0 | 1);
      |                              ^^^^^^^ Overriding type: `0 | 1`
 ---
+
+[TestNoRedundantTypeConstituentsRule/invalid-62 - 1]
+Diagnostic 1: literalOverridden (3:18 - 3:18)
+Message: 0 is overridden by number in this union type.
+   2 |         type N = number;
+   3 |         type T = 0 | number | N;
+     |                  ~
+   4 |       
+  Label: Redundant type: `0` (3:18 - 3:18)
+   2 |         type N = number;
+   3 |         type T = 0 | number | N;
+     |                  ^ Redundant type: `0`
+   4 |       
+  Label: Overriding type: `number` (3:22 - 3:27)
+   2 |         type N = number;
+   3 |         type T = 0 | number | N;
+     |                      ^^^^^^ Overriding type: `number`
+   4 |       
+  Label: Overriding type: `number` (3:31 - 3:31)
+   2 |         type N = number;
+   3 |         type T = 0 | number | N;
+     |                               ^ Overriding type: `number`
+   4 |       
+---

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -866,3 +866,27 @@ Message: 'unknown' is overridden by other types in this intersection type.
    1 | type T = number & string & unknown;
      |                   ^^^^^^ Overriding type: `string`
 ---
+
+[TestNoRedundantTypeConstituentsRule/invalid-55 - 1]
+Diagnostic 1: overrides (1:27 - 1:32)
+Message: 'any' overrides all other types in this union type.
+   1 | type T = (number | any) | string;
+     |                           ~~~~~~
+  Label: Redundant type: `string` (1:27 - 1:32)
+   1 | type T = (number | any) | string;
+     |                           ^^^^^^ Redundant type: `string`
+  Label: Overriding type: `any` (1:20 - 1:22)
+   1 | type T = (number | any) | string;
+     |                    ^^^ Overriding type: `any`
+
+Diagnostic 2: overrides (1:11 - 1:16)
+Message: 'any' overrides all other types in this union type.
+   1 | type T = (number | any) | string;
+     |           ~~~~~~
+  Label: Redundant type: `number` (1:11 - 1:16)
+   1 | type T = (number | any) | string;
+     |           ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `any` (1:20 - 1:22)
+   1 | type T = (number | any) | string;
+     |                    ^^^ Overriding type: `any`
+---

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -184,9 +184,12 @@ Diagnostic 1: literalOverridden (1:19 - 1:25)
 Message: 0 | 1 is overridden by number in this union type.
    1 | type T = number | (0 | 1);
      |                   ~~~~~~~
-  Label: Redundant type: `0 | 1` (1:19 - 1:25)
+  Label: Redundant type: `0` (1:20 - 1:20)
    1 | type T = number | (0 | 1);
-     |                   ^^^^^^^ Redundant type: `0 | 1`
+     |                    ^ Redundant type: `0`
+  Label: Redundant type: `1` (1:24 - 1:24)
+   1 | type T = number | (0 | 1);
+     |                        ^ Redundant type: `1`
   Label: Overriding type: `number` (1:10 - 1:15)
    1 | type T = number | (0 | 1);
      |          ^^^^^^ Overriding type: `number`
@@ -194,12 +197,15 @@ Message: 0 | 1 is overridden by number in this union type.
 
 [TestNoRedundantTypeConstituentsRule/invalid-13 - 1]
 Diagnostic 1: literalOverridden (1:10 - 1:16)
-Message: 0 is overridden by number in this union type.
+Message: 0 | 0 is overridden by number in this union type.
    1 | type T = (0 | 0) | number;
      |          ~~~~~~~
-  Label: Redundant type: `0` (1:10 - 1:16)
+  Label: Redundant type: `0` (1:11 - 1:11)
    1 | type T = (0 | 0) | number;
-     |          ^^^^^^^ Redundant type: `0`
+     |           ^ Redundant type: `0`
+  Label: Redundant type: `0` (1:15 - 1:15)
+   1 | type T = (0 | 0) | number;
+     |               ^ Redundant type: `0`
   Label: Overriding type: `number` (1:20 - 1:25)
    1 | type T = (0 | 0) | number;
      |                    ^^^^^^ Overriding type: `number`
@@ -207,15 +213,25 @@ Message: 0 is overridden by number in this union type.
 
 [TestNoRedundantTypeConstituentsRule/invalid-14 - 1]
 Diagnostic 1: literalOverridden (3:18 - 3:24)
-Message: 0 | 1 | 2 is overridden by number in this union type.
+Message: 2 | 0 | 1 is overridden by number in this union type.
    2 |         type B = 0 | 1;
    3 |         type T = (2 | B) | number;
      |                  ~~~~~~~
    4 |       
-  Label: Redundant type: `0 | 1 | 2` (3:18 - 3:24)
+  Label: Redundant type: `2` (3:19 - 3:19)
    2 |         type B = 0 | 1;
    3 |         type T = (2 | B) | number;
-     |                  ^^^^^^^ Redundant type: `0 | 1 | 2`
+     |                   ^ Redundant type: `2`
+   4 |       
+  Label: Redundant type: `0` (3:18 - 3:24)
+   2 |         type B = 0 | 1;
+   3 |         type T = (2 | B) | number;
+     |                  ^^^^^^^ Redundant type: `0`
+   4 |       
+  Label: Redundant type: `1` (3:18 - 3:24)
+   2 |         type B = 0 | 1;
+   3 |         type T = (2 | B) | number;
+     |                  ^^^^^^^ Redundant type: `1`
    4 |       
   Label: Overriding type: `number` (3:28 - 3:33)
    2 |         type B = 0 | 1;
@@ -229,9 +245,15 @@ Diagnostic 1: literalOverridden (1:10 - 1:22)
 Message: 0 | 1 | 2 is overridden by number in this union type.
    1 | type T = (0 | (1 | 2)) | number;
      |          ~~~~~~~~~~~~~
-  Label: Redundant type: `0 | 1 | 2` (1:10 - 1:22)
+  Label: Redundant type: `0` (1:11 - 1:11)
    1 | type T = (0 | (1 | 2)) | number;
-     |          ^^^^^^^^^^^^^ Redundant type: `0 | 1 | 2`
+     |           ^ Redundant type: `0`
+  Label: Redundant type: `1` (1:16 - 1:16)
+   1 | type T = (0 | (1 | 2)) | number;
+     |                ^ Redundant type: `1`
+  Label: Redundant type: `2` (1:20 - 1:20)
+   1 | type T = (0 | (1 | 2)) | number;
+     |                    ^ Redundant type: `2`
   Label: Overriding type: `number` (1:26 - 1:31)
    1 | type T = (0 | (1 | 2)) | number;
      |                          ^^^^^^ Overriding type: `number`
@@ -242,9 +264,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:16)
 Message: 0 | 1 is overridden by number in this union type.
    1 | type T = (0 | 1) | number;
      |          ~~~~~~~
-  Label: Redundant type: `0 | 1` (1:10 - 1:16)
+  Label: Redundant type: `0` (1:11 - 1:11)
    1 | type T = (0 | 1) | number;
-     |          ^^^^^^^ Redundant type: `0 | 1`
+     |           ^ Redundant type: `0`
+  Label: Redundant type: `1` (1:15 - 1:15)
+   1 | type T = (0 | 1) | number;
+     |               ^ Redundant type: `1`
   Label: Overriding type: `number` (1:20 - 1:25)
    1 | type T = (0 | 1) | number;
      |                    ^^^^^^ Overriding type: `number`
@@ -252,12 +277,18 @@ Message: 0 | 1 is overridden by number in this union type.
 
 [TestNoRedundantTypeConstituentsRule/invalid-17 - 1]
 Diagnostic 1: literalOverridden (1:10 - 1:22)
-Message: 0 | 1 is overridden by number in this union type.
+Message: 0 | 0 | 1 is overridden by number in this union type.
    1 | type T = (0 | (0 | 1)) | number;
      |          ~~~~~~~~~~~~~
-  Label: Redundant type: `0 | 1` (1:10 - 1:22)
+  Label: Redundant type: `0` (1:11 - 1:11)
    1 | type T = (0 | (0 | 1)) | number;
-     |          ^^^^^^^^^^^^^ Redundant type: `0 | 1`
+     |           ^ Redundant type: `0`
+  Label: Redundant type: `0` (1:16 - 1:16)
+   1 | type T = (0 | (0 | 1)) | number;
+     |                ^ Redundant type: `0`
+  Label: Redundant type: `1` (1:20 - 1:20)
+   1 | type T = (0 | (0 | 1)) | number;
+     |                    ^ Redundant type: `1`
   Label: Overriding type: `number` (1:26 - 1:31)
    1 | type T = (0 | (0 | 1)) | number;
      |                          ^^^^^^ Overriding type: `number`
@@ -268,9 +299,12 @@ Diagnostic 1: literalOverridden (1:10 - 1:26)
 Message: 2 | 3 is overridden by number in this union type.
    1 | type T = (2 | 'other' | 3) | number;
      |          ~~~~~~~~~~~~~~~~~
-  Label: Redundant type: `2 | 3` (1:10 - 1:26)
+  Label: Redundant type: `2` (1:11 - 1:11)
    1 | type T = (2 | 'other' | 3) | number;
-     |          ^^^^^^^^^^^^^^^^^ Redundant type: `2 | 3`
+     |           ^ Redundant type: `2`
+  Label: Redundant type: `3` (1:25 - 1:25)
+   1 | type T = (2 | 'other' | 3) | number;
+     |                         ^ Redundant type: `3`
   Label: Overriding type: `number` (1:30 - 1:35)
    1 | type T = (2 | 'other' | 3) | number;
      |                              ^^^^^^ Overriding type: `number`
@@ -381,12 +415,15 @@ Message: -1n is overridden by bigint in this union type.
 
 [TestNoRedundantTypeConstituentsRule/invalid-26 - 1]
 Diagnostic 1: literalOverridden (1:10 - 1:19)
-Message: 1n | -1n is overridden by bigint in this union type.
+Message: -1n | 1n is overridden by bigint in this union type.
    1 | type T = (-1n | 1n) | bigint;
      |          ~~~~~~~~~~
-  Label: Redundant type: `1n | -1n` (1:10 - 1:19)
+  Label: Redundant type: `-1n` (1:10 - 1:19)
    1 | type T = (-1n | 1n) | bigint;
-     |          ^^^^^^^^^^ Redundant type: `1n | -1n`
+     |          ^^^^^^^^^^ Redundant type: `-1n`
+  Label: Redundant type: `1n` (1:17 - 1:18)
+   1 | type T = (-1n | 1n) | bigint;
+     |                 ^^ Redundant type: `1n`
   Label: Overriding type: `bigint` (1:23 - 1:28)
    1 | type T = (-1n | 1n) | bigint;
      |                       ^^^^^^ Overriding type: `bigint`
@@ -742,10 +779,26 @@ Diagnostic 1: literalOverridden (1:10 - 1:22)
 Message: 2 is overridden by number in this union type.
    1 | type T = (2 | 'other') | number;
      |          ~~~~~~~~~~~~~
-  Label: Redundant type: `2` (1:10 - 1:22)
+  Label: Redundant type: `2` (1:11 - 1:11)
    1 | type T = (2 | 'other') | number;
-     |          ^^^^^^^^^^^^^ Redundant type: `2`
+     |           ^ Redundant type: `2`
   Label: Overriding type: `number` (1:26 - 1:31)
    1 | type T = (2 | 'other') | number;
      |                          ^^^^^^ Overriding type: `number`
+---
+
+[TestNoRedundantTypeConstituentsRule/invalid-50 - 1]
+Diagnostic 1: primitiveOverridden (1:18 - 1:23)
+Message: number is overridden by the 0 | 1 in this intersection type.
+   1 | type T = 0 & 1 & number;
+     |                  ~~~~~~
+  Label: Redundant type: `number` (1:18 - 1:23)
+   1 | type T = 0 & 1 & number;
+     |                  ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `0` (1:10 - 1:10)
+   1 | type T = 0 & 1 & number;
+     |          ^ Overriding type: `0`
+  Label: Overriding type: `1` (1:14 - 1:14)
+   1 | type T = 0 & 1 & number;
+     |              ^ Overriding type: `1`
 ---

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -802,3 +802,67 @@ Message: number is overridden by the 0 | 1 in this intersection type.
    1 | type T = 0 & 1 & number;
      |              ^ Overriding type: `1`
 ---
+
+[TestNoRedundantTypeConstituentsRule/invalid-51 - 1]
+Diagnostic 1: overrides (1:10 - 1:15)
+Message: 'any' overrides all other types in this union type.
+   1 | type T = number | string | any;
+     |          ~~~~~~
+  Label: Redundant type: `number` (1:10 - 1:15)
+   1 | type T = number | string | any;
+     |          ^^^^^^ Redundant type: `number`
+  Label: Redundant type: `string` (1:19 - 1:24)
+   1 | type T = number | string | any;
+     |                   ^^^^^^ Redundant type: `string`
+  Label: Overriding type: `any` (1:28 - 1:30)
+   1 | type T = number | string | any;
+     |                            ^^^ Overriding type: `any`
+---
+
+[TestNoRedundantTypeConstituentsRule/invalid-52 - 1]
+Diagnostic 1: overridden (1:28 - 1:32)
+Message: 'never' is overridden by other types in this union type.
+   1 | type T = number | string | never;
+     |                            ~~~~~
+  Label: Redundant type: `never` (1:28 - 1:32)
+   1 | type T = number | string | never;
+     |                            ^^^^^ Redundant type: `never`
+  Label: Overriding type: `number` (1:10 - 1:15)
+   1 | type T = number | string | never;
+     |          ^^^^^^ Overriding type: `number`
+  Label: Overriding type: `string` (1:19 - 1:24)
+   1 | type T = number | string | never;
+     |                   ^^^^^^ Overriding type: `string`
+---
+
+[TestNoRedundantTypeConstituentsRule/invalid-53 - 1]
+Diagnostic 1: overrides (1:10 - 1:15)
+Message: 'never' overrides all other types in this intersection type.
+   1 | type T = number & string & never;
+     |          ~~~~~~
+  Label: Redundant type: `number` (1:10 - 1:15)
+   1 | type T = number & string & never;
+     |          ^^^^^^ Redundant type: `number`
+  Label: Redundant type: `string` (1:19 - 1:24)
+   1 | type T = number & string & never;
+     |                   ^^^^^^ Redundant type: `string`
+  Label: Overriding type: `never` (1:28 - 1:32)
+   1 | type T = number & string & never;
+     |                            ^^^^^ Overriding type: `never`
+---
+
+[TestNoRedundantTypeConstituentsRule/invalid-54 - 1]
+Diagnostic 1: overridden (1:28 - 1:34)
+Message: 'unknown' is overridden by other types in this intersection type.
+   1 | type T = number & string & unknown;
+     |                            ~~~~~~~
+  Label: Redundant type: `unknown` (1:28 - 1:34)
+   1 | type T = number & string & unknown;
+     |                            ^^^^^^^ Redundant type: `unknown`
+  Label: Overriding type: `number` (1:10 - 1:15)
+   1 | type T = number & string & unknown;
+     |          ^^^^^^ Overriding type: `number`
+  Label: Overriding type: `string` (1:19 - 1:24)
+   1 | type T = number & string & unknown;
+     |                   ^^^^^^ Overriding type: `string`
+---

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -1000,3 +1000,16 @@ Message: 'any' overrides all other types in this union type.
      |                            ^ Overriding type: `any`
    4 |       
 ---
+
+[TestNoRedundantTypeConstituentsRule/invalid-61 - 1]
+Diagnostic 1: primitiveOverridden (1:11 - 1:16)
+Message: number is overridden by the 0 | 1 in this intersection type.
+   1 | type T = (number | string) & (0 | 1);
+     |           ~~~~~~
+  Label: Redundant type: `number` (1:11 - 1:16)
+   1 | type T = (number | string) & (0 | 1);
+     |           ^^^^^^ Redundant type: `number`
+  Label: Overriding type: `0 | 1` (1:30 - 1:36)
+   1 | type T = (number | string) & (0 | 1);
+     |                              ^^^^^^^ Overriding type: `0 | 1`
+---

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -927,3 +927,27 @@ Message: 2 | 0 is overridden by number in this union type.
      |                            ^^^^^^ Overriding type: `number`
    4 |       
 ---
+
+[TestNoRedundantTypeConstituentsRule/invalid-58 - 1]
+Diagnostic 1: primitiveOverridden (3:28 - 3:33)
+Message: number is overridden by the 0 | 1 in this intersection type.
+   2 |         type N = number;
+   3 |         type T = (0 | 1) & number & N;
+     |                            ~~~~~~
+   4 |       
+  Label: Redundant type: `number` (3:28 - 3:33)
+   2 |         type N = number;
+   3 |         type T = (0 | 1) & number & N;
+     |                            ^^^^^^ Redundant type: `number`
+   4 |       
+  Label: Redundant type: `number` (3:37 - 3:37)
+   2 |         type N = number;
+   3 |         type T = (0 | 1) & number & N;
+     |                                     ^ Redundant type: `number`
+   4 |       
+  Label: Overriding type: `0 | 1` (3:18 - 3:24)
+   2 |         type N = number;
+   3 |         type T = (0 | 1) & number & N;
+     |                  ^^^^^^^ Overriding type: `0 | 1`
+   4 |       
+---

--- a/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
+++ b/internal/rule_tester/__snapshots__/no-redundant-type-constituents.snap
@@ -951,3 +951,16 @@ Message: number is overridden by the 0 | 1 in this intersection type.
      |                  ^^^^^^^ Overriding type: `0 | 1`
    4 |       
 ---
+
+[TestNoRedundantTypeConstituentsRule/invalid-59 - 1]
+Diagnostic 1: literalOverridden (1:10 - 1:10)
+Message: 0 is overridden by number in this union type.
+   1 | type T = 0 | (number | string);
+     |          ~
+  Label: Redundant type: `0` (1:10 - 1:10)
+   1 | type T = 0 | (number | string);
+     |          ^ Redundant type: `0`
+  Label: Overriding type: `number` (1:15 - 1:20)
+   1 | type T = 0 | (number | string);
+     |               ^^^^^^ Overriding type: `number`
+---

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -296,6 +296,10 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 		checkIntersectionBottomAndTopTypes := func(typePart typeFlagsWithNodeOrType, typeNode *ast.Node, typeNodes []*ast.Node) bool {
 			var message rule.RuleMessage
 			var redundantParts, overridingParts []labeledTypePart
+			matchedNode := typePart.node
+			if matchedNode == nil {
+				matchedNode = typeNode
+			}
 
 			switch typePart.flags {
 			case checker.TypeFlagsAny:
@@ -306,15 +310,15 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 					message = buildErrorTypeOverridesMessage(typeName, "intersection")
 				}
 				redundantParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
-				overridingParts = []labeledTypePart{{node: typeNode, typeName: renderTypeNode(typeNode, typeName)}}
+				overridingParts = []labeledTypePart{{node: matchedNode, typeName: renderTypeNode(matchedNode, typeName)}}
 			case checker.TypeFlagsNever:
 				typeName := typePart.ToString(ctx.TypeChecker)
 				message = buildOverridesMessage(typeName, "intersection")
 				redundantParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
-				overridingParts = []labeledTypePart{{node: typeNode, typeName: renderTypeNode(typeNode, typeName)}}
+				overridingParts = []labeledTypePart{{node: matchedNode, typeName: renderTypeNode(matchedNode, typeName)}}
 			case checker.TypeFlagsUnknown:
-				redundantType := renderTypeNode(typeNode, typePart.ToString(ctx.TypeChecker))
-				redundantParts = []labeledTypePart{{node: typeNode, typeName: redundantType}}
+				redundantType := renderTypeNode(matchedNode, typePart.ToString(ctx.TypeChecker))
+				redundantParts = []labeledTypePart{{node: matchedNode, typeName: redundantType}}
 				overridingParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
 				message = buildOverriddenMessage(redundantType, "intersection")
 			default:
@@ -484,6 +488,10 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				checkUnionBottomAndTopTypes := func(typePart typeFlagsWithNodeOrType, typeNode *ast.Node) bool {
 					var message rule.RuleMessage
 					var redundantParts, overridingParts []labeledTypePart
+					matchedNode := typePart.node
+					if matchedNode == nil {
+						matchedNode = typeNode
+					}
 
 					switch typePart.flags {
 					case checker.TypeFlagsAny:
@@ -494,17 +502,17 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 							message = buildErrorTypeOverridesMessage(typeName, "union")
 						}
 						redundantParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
-						overridingParts = []labeledTypePart{{node: typeNode, typeName: renderTypeNode(typeNode, typeName)}}
+						overridingParts = []labeledTypePart{{node: matchedNode, typeName: renderTypeNode(matchedNode, typeName)}}
 					case checker.TypeFlagsUnknown:
 						typeName := typePart.ToString(ctx.TypeChecker)
 						message = buildOverridesMessage(typeName, "union")
 						redundantParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
-						overridingParts = []labeledTypePart{{node: typeNode, typeName: renderTypeNode(typeNode, typeName)}}
+						overridingParts = []labeledTypePart{{node: matchedNode, typeName: renderTypeNode(matchedNode, typeName)}}
 					case checker.TypeFlagsNever:
 						if isNodeInsideReturnType(node) {
 							return false
 						}
-						redundantParts = []labeledTypePart{{node: typeNode, typeName: renderTypeNode(typeNode, "never")}}
+						redundantParts = []labeledTypePart{{node: matchedNode, typeName: renderTypeNode(matchedNode, "never")}}
 						overridingParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
 						message = buildOverriddenMessage("never", "union")
 					default:

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -379,15 +379,22 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 							}
 						}
 
+						matchedPrimitiveNode := typePart.node
+						if matchedPrimitiveNode == nil {
+							matchedPrimitiveNode = typePart.sourceNode
+						}
+						if matchedPrimitiveNode == nil {
+							matchedPrimitiveNode = typeNode
+						}
 						switch typePart.flags {
 						case checker.TypeFlagsBigInt:
-							seenBigIntPrimitiveTypes = append(seenBigIntPrimitiveTypes, typeNode)
+							seenBigIntPrimitiveTypes = append(seenBigIntPrimitiveTypes, matchedPrimitiveNode)
 						case checker.TypeFlagsBoolean:
-							seenBooleanPrimitiveTypes = append(seenBooleanPrimitiveTypes, typeNode)
+							seenBooleanPrimitiveTypes = append(seenBooleanPrimitiveTypes, matchedPrimitiveNode)
 						case checker.TypeFlagsNumber:
-							seenNumberPrimitiveTypes = append(seenNumberPrimitiveTypes, typeNode)
+							seenNumberPrimitiveTypes = append(seenNumberPrimitiveTypes, matchedPrimitiveNode)
 						case checker.TypeFlagsString:
-							seenStringPrimitiveTypes = append(seenStringPrimitiveTypes, typeNode)
+							seenStringPrimitiveTypes = append(seenStringPrimitiveTypes, matchedPrimitiveNode)
 						}
 					}
 				}

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -556,17 +556,24 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 						// Aliases of primitive types can carry additional checker flags, so use
 						// bit tests here rather than requiring an exact flag match. The alias
 						// reference is still a precise local range for the overriding label.
+						matchedPrimitiveNode := typePart.node
+						if matchedPrimitiveNode == nil {
+							matchedPrimitiveNode = typePart.sourceNode
+						}
+						if matchedPrimitiveNode == nil {
+							matchedPrimitiveNode = typeNode
+						}
 						if typePart.flags&checker.TypeFlagsBigInt != 0 {
-							seenBigIntPrimitiveTypeNodes = append(seenBigIntPrimitiveTypeNodes, typeNode)
+							seenBigIntPrimitiveTypeNodes = append(seenBigIntPrimitiveTypeNodes, matchedPrimitiveNode)
 						}
 						if typePart.flags&checker.TypeFlagsBoolean != 0 {
-							seenBooleanPrimitiveTypeNodes = append(seenBooleanPrimitiveTypeNodes, typeNode)
+							seenBooleanPrimitiveTypeNodes = append(seenBooleanPrimitiveTypeNodes, matchedPrimitiveNode)
 						}
 						if typePart.flags&checker.TypeFlagsNumber != 0 {
-							seenNumberPrimitiveTypeNodes = append(seenNumberPrimitiveTypeNodes, typeNode)
+							seenNumberPrimitiveTypeNodes = append(seenNumberPrimitiveTypeNodes, matchedPrimitiveNode)
 						}
 						if typePart.flags&checker.TypeFlagsString != 0 {
-							seenStringPrimitiveTypeNodes = append(seenStringPrimitiveTypeNodes, typeNode)
+							seenStringPrimitiveTypeNodes = append(seenStringPrimitiveTypeNodes, matchedPrimitiveNode)
 						}
 					}
 				}

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -617,15 +617,17 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 								typeName: renderTypeParts([]typeFlagsWithNodeOrType{t}),
 							}
 						})
-						var primitiveNode *ast.Node
-						if len(primitiveNodes) > 0 {
-							primitiveNode = primitiveNodes[0]
-						}
+						overridingParts := utils.Map(primitiveNodes, func(primitiveNode *ast.Node) labeledTypePart {
+							return labeledTypePart{
+								node:     primitiveNode,
+								typeName: renderTypeNode(primitiveNode, primitiveName),
+							}
+						})
 						reportRelations(
 							buildLiteralOverriddenMessage(typeValuesLiteral, primitiveName),
 							typeNode,
 							redundantParts,
-							[]labeledTypePart{{node: primitiveNode, typeName: primitiveName}},
+							overridingParts,
 						)
 					}
 				}

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -295,21 +295,6 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				LabeledRanges: labels,
 			})
 		}
-		reportRelation := func(
-			message rule.RuleMessage,
-			redundantNode *ast.Node,
-			redundantType string,
-			overridingNode *ast.Node,
-			overridingType string,
-		) {
-			reportRelations(
-				message,
-				redundantNode,
-				[]labeledTypePart{{node: redundantNode, typeName: redundantType}},
-				[]labeledTypePart{{node: overridingNode, typeName: overridingType}},
-			)
-		}
-
 		checkIntersectionBottomAndTopTypes := func(typePart typeFlagsWithNodeOrType, typeNode *ast.Node, typeNodes []*ast.Node) bool {
 			var message rule.RuleMessage
 			var redundantParts, overridingParts []labeledTypePart
@@ -415,24 +400,24 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				if len(seenUnionTypes) > 0 && (len(seenBigIntPrimitiveTypes) > 0 || len(seenBooleanPrimitiveTypes) > 0 || len(seenNumberPrimitiveTypes) > 0 || len(seenStringPrimitiveTypes) > 0) {
 					for _, unionType := range seenUnionTypes {
 						var primitiveName string
-						var primitiveNode *ast.Node
+						var primitiveNodes []*ast.Node
 						for _, typeValue := range unionType.flags {
 							switch {
 							case typeValue.flags == checker.TypeFlagsBigIntLiteral && len(seenBigIntPrimitiveTypes) > 0:
 								primitiveName = "bigint"
-								primitiveNode = seenBigIntPrimitiveTypes[0]
+								primitiveNodes = seenBigIntPrimitiveTypes
 							case typeValue.flags == checker.TypeFlagsBooleanLiteral && len(seenBooleanPrimitiveTypes) > 0:
 								primitiveName = "boolean"
-								primitiveNode = seenBooleanPrimitiveTypes[0]
+								primitiveNodes = seenBooleanPrimitiveTypes
 							case typeValue.flags == checker.TypeFlagsNumberLiteral && len(seenNumberPrimitiveTypes) > 0:
 								primitiveName = "number"
-								primitiveNode = seenNumberPrimitiveTypes[0]
+								primitiveNodes = seenNumberPrimitiveTypes
 							case (typeValue.flags == checker.TypeFlagsStringLiteral || typeValue.flags == checker.TypeFlagsTemplateLiteral) && len(seenStringPrimitiveTypes) > 0:
 								primitiveName = "string"
-								primitiveNode = seenStringPrimitiveTypes[0]
+								primitiveNodes = seenStringPrimitiveTypes
 							default:
 								primitiveName = ""
-								primitiveNode = nil
+								primitiveNodes = nil
 							}
 							if len(primitiveName) == 0 {
 								break
@@ -445,12 +430,17 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 
 						typeValuesLiteral := typePartsToString(unionType.flags)
 						renderedTypeValuesLiteral := renderTypeParts(unionType.flags)
-						reportRelation(
+						redundantParts := utils.Map(primitiveNodes, func(primitiveNode *ast.Node) labeledTypePart {
+							return labeledTypePart{
+								node:     primitiveNode,
+								typeName: renderTypeNode(primitiveNode, primitiveName),
+							}
+						})
+						reportRelations(
 							buildPrimitiveOverriddenMessage(typeValuesLiteral, primitiveName),
-							primitiveNode,
-							primitiveName,
-							unionType.typeNode,
-							renderedTypeValuesLiteral,
+							primitiveNodes[0],
+							redundantParts,
+							[]labeledTypePart{{node: unionType.typeNode, typeName: renderedTypeValuesLiteral}},
 						)
 					}
 				}

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -204,13 +204,14 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 			return typePartsToString(getTypeNodeTypePartFlags(typeNode))
 		}
 
-		firstOtherTypeNode := func(typeNodes []*ast.Node, typeNode *ast.Node) *ast.Node {
+		otherTypeNodes := func(typeNodes []*ast.Node, typeNode *ast.Node) []*ast.Node {
+			otherNodes := make([]*ast.Node, 0, len(typeNodes)-1)
 			for _, candidate := range typeNodes {
 				if candidate != typeNode {
-					return candidate
+					otherNodes = append(otherNodes, candidate)
 				}
 			}
-			return nil
+			return otherNodes
 		}
 
 		renderTypeNode := func(typeNode *ast.Node, fallback string) string {
@@ -222,6 +223,14 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				return fallback
 			}
 			return rendered
+		}
+		labeledTypeNodes := func(typeNodes []*ast.Node) []labeledTypePart {
+			return utils.Map(typeNodes, func(typeNode *ast.Node) labeledTypePart {
+				return labeledTypePart{
+					node:     typeNode,
+					typeName: renderTypeNode(typeNode, typeNodeToString(typeNode)),
+				}
+			})
 		}
 
 		reportRelations := func(
@@ -286,8 +295,7 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 
 		checkIntersectionBottomAndTopTypes := func(typePart typeFlagsWithNodeOrType, typeNode *ast.Node, typeNodes []*ast.Node) bool {
 			var message rule.RuleMessage
-			var redundantNode, overridingNode *ast.Node
-			var redundantType, overridingType string
+			var redundantParts, overridingParts []labeledTypePart
 
 			switch typePart.flags {
 			case checker.TypeFlagsAny:
@@ -297,28 +305,23 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				} else {
 					message = buildErrorTypeOverridesMessage(typeName, "intersection")
 				}
-				redundantNode = firstOtherTypeNode(typeNodes, typeNode)
-				redundantType = renderTypeNode(redundantNode, typeNodeToString(redundantNode))
-				overridingNode = typeNode
-				overridingType = renderTypeNode(overridingNode, typeName)
+				redundantParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
+				overridingParts = []labeledTypePart{{node: typeNode, typeName: renderTypeNode(typeNode, typeName)}}
 			case checker.TypeFlagsNever:
 				typeName := typePart.ToString(ctx.TypeChecker)
 				message = buildOverridesMessage(typeName, "intersection")
-				redundantNode = firstOtherTypeNode(typeNodes, typeNode)
-				redundantType = renderTypeNode(redundantNode, typeNodeToString(redundantNode))
-				overridingNode = typeNode
-				overridingType = renderTypeNode(overridingNode, typeName)
+				redundantParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
+				overridingParts = []labeledTypePart{{node: typeNode, typeName: renderTypeNode(typeNode, typeName)}}
 			case checker.TypeFlagsUnknown:
-				redundantNode = typeNode
-				redundantType = renderTypeNode(redundantNode, typePart.ToString(ctx.TypeChecker))
-				overridingNode = firstOtherTypeNode(typeNodes, typeNode)
-				overridingType = renderTypeNode(overridingNode, typeNodeToString(overridingNode))
+				redundantType := renderTypeNode(typeNode, typePart.ToString(ctx.TypeChecker))
+				redundantParts = []labeledTypePart{{node: typeNode, typeName: redundantType}}
+				overridingParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
 				message = buildOverriddenMessage(redundantType, "intersection")
 			default:
 				return false
 			}
 
-			reportRelation(message, redundantNode, redundantType, overridingNode, overridingType)
+			reportRelations(message, nil, redundantParts, overridingParts)
 			return true
 		}
 
@@ -480,8 +483,7 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				typeNodes := node.AsUnionTypeNode().Types.Nodes
 				checkUnionBottomAndTopTypes := func(typePart typeFlagsWithNodeOrType, typeNode *ast.Node) bool {
 					var message rule.RuleMessage
-					var redundantNode, overridingNode *ast.Node
-					var redundantType, overridingType string
+					var redundantParts, overridingParts []labeledTypePart
 
 					switch typePart.flags {
 					case checker.TypeFlagsAny:
@@ -491,31 +493,25 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 						} else {
 							message = buildErrorTypeOverridesMessage(typeName, "union")
 						}
-						redundantNode = firstOtherTypeNode(typeNodes, typeNode)
-						redundantType = renderTypeNode(redundantNode, typeNodeToString(redundantNode))
-						overridingNode = typeNode
-						overridingType = renderTypeNode(overridingNode, typeName)
+						redundantParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
+						overridingParts = []labeledTypePart{{node: typeNode, typeName: renderTypeNode(typeNode, typeName)}}
 					case checker.TypeFlagsUnknown:
 						typeName := typePart.ToString(ctx.TypeChecker)
 						message = buildOverridesMessage(typeName, "union")
-						redundantNode = firstOtherTypeNode(typeNodes, typeNode)
-						redundantType = renderTypeNode(redundantNode, typeNodeToString(redundantNode))
-						overridingNode = typeNode
-						overridingType = renderTypeNode(overridingNode, typeName)
+						redundantParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
+						overridingParts = []labeledTypePart{{node: typeNode, typeName: renderTypeNode(typeNode, typeName)}}
 					case checker.TypeFlagsNever:
 						if isNodeInsideReturnType(node) {
 							return false
 						}
-						redundantNode = typeNode
-						redundantType = renderTypeNode(redundantNode, "never")
-						overridingNode = firstOtherTypeNode(typeNodes, typeNode)
-						overridingType = renderTypeNode(overridingNode, typeNodeToString(overridingNode))
+						redundantParts = []labeledTypePart{{node: typeNode, typeName: renderTypeNode(typeNode, "never")}}
+						overridingParts = labeledTypeNodes(otherTypeNodes(typeNodes, typeNode))
 						message = buildOverriddenMessage("never", "union")
 					default:
 						return false
 					}
 
-					reportRelation(message, redundantNode, redundantType, overridingNode, overridingType)
+					reportRelations(message, nil, redundantParts, overridingParts)
 					return true
 				}
 

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -62,6 +62,11 @@ type seenTypePart struct {
 	typeNode *ast.Node
 }
 
+type labeledTypePart struct {
+	node     *ast.Node
+	typeName string
+}
+
 func (t *typeFlagsWithNodeOrType) ToString(typeChecker *checker.Checker) string {
 	if t.node != nil {
 		switch t.node.Kind {
@@ -102,6 +107,9 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 		var getTypeNodeTypePartFlags func(node *ast.Node) []typeFlagsWithNodeOrType
 		getTypeNodeTypePartFlags = func(node *ast.Node) []typeFlagsWithNodeOrType {
 			node = ast.SkipParentheses(node)
+			for node.Kind == ast.KindParenthesizedType {
+				node = node.AsParenthesizedTypeNode().Type
+			}
 
 			flags := checker.TypeFlagsNone
 			switch node.Kind {
@@ -216,35 +224,42 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 			return rendered
 		}
 
-		reportRelation := func(
+		reportRelations := func(
 			message rule.RuleMessage,
-			redundantNode *ast.Node,
-			redundantType string,
-			overridingNode *ast.Node,
-			overridingType string,
+			primaryNode *ast.Node,
+			redundantParts []labeledTypePart,
+			overridingParts []labeledTypePart,
 		) {
 			// Some error and aliased types do not have a distinct local syntax node for
 			// both sides of the relationship. Keep the diagnostic useful in those
 			// cases, but only attach labels to ranges that are actually available.
-			primaryNode := redundantNode
-			if primaryNode == nil {
-				primaryNode = overridingNode
+			if primaryNode == nil && len(redundantParts) > 0 {
+				primaryNode = redundantParts[0].node
+			}
+			if primaryNode == nil && len(overridingParts) > 0 {
+				primaryNode = overridingParts[0].node
 			}
 			if primaryNode == nil {
 				return
 			}
 
-			labels := make([]rule.RuleLabeledRange, 0, 2)
-			if redundantNode != nil {
+			labels := make([]rule.RuleLabeledRange, 0, len(redundantParts)+len(overridingParts))
+			for _, part := range redundantParts {
+				if part.node == nil {
+					continue
+				}
 				labels = append(labels, rule.RuleLabeledRange{
-					Label: fmt.Sprintf("Redundant type: `%s`", redundantType),
-					Range: utils.TrimNodeTextRange(ctx.SourceFile, redundantNode),
+					Label: fmt.Sprintf("Redundant type: `%s`", part.typeName),
+					Range: utils.TrimNodeTextRange(ctx.SourceFile, part.node),
 				})
 			}
-			if overridingNode != nil {
+			for _, part := range overridingParts {
+				if part.node == nil {
+					continue
+				}
 				labels = append(labels, rule.RuleLabeledRange{
-					Label: fmt.Sprintf("Overriding type: `%s`", overridingType),
-					Range: utils.TrimNodeTextRange(ctx.SourceFile, overridingNode),
+					Label: fmt.Sprintf("Overriding type: `%s`", part.typeName),
+					Range: utils.TrimNodeTextRange(ctx.SourceFile, part.node),
 				})
 			}
 
@@ -253,6 +268,20 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				Message:       message,
 				LabeledRanges: labels,
 			})
+		}
+		reportRelation := func(
+			message rule.RuleMessage,
+			redundantNode *ast.Node,
+			redundantType string,
+			overridingNode *ast.Node,
+			overridingType string,
+		) {
+			reportRelations(
+				message,
+				redundantNode,
+				[]labeledTypePart{{node: redundantNode, typeName: redundantType}},
+				[]labeledTypePart{{node: overridingNode, typeName: overridingType}},
+			)
 		}
 
 		checkIntersectionBottomAndTopTypes := func(typePart typeFlagsWithNodeOrType, typeNode *ast.Node, typeNodes []*ast.Node) bool {
@@ -412,16 +441,18 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 					typeValuesLiteral := strings.Join(utils.Map(literalTypes, func(t seenTypePart) string {
 						return t.part.ToString(ctx.TypeChecker)
 					}), " | ")
-					renderedTypeValuesLiteral := strings.Join(utils.Map(literalTypes, func(t seenTypePart) string {
-						return renderTypeParts([]typeFlagsWithNodeOrType{t.part})
-					}), " | ")
+					overridingParts := utils.Map(literalTypes, func(t seenTypePart) labeledTypePart {
+						return labeledTypePart{
+							node:     t.typeNode,
+							typeName: renderTypeParts([]typeFlagsWithNodeOrType{t.part}),
+						}
+					})
 					for _, typeNode := range primitiveTypes {
-						reportRelation(
+						reportRelations(
 							buildPrimitiveOverriddenMessage(typeValuesLiteral, primitiveName),
 							typeNode,
-							primitiveName,
-							literalTypes[0].typeNode,
-							renderedTypeValuesLiteral,
+							[]labeledTypePart{{node: typeNode, typeName: primitiveName}},
+							overridingParts,
 						)
 					}
 				}
@@ -542,17 +573,25 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 						typeValuesLiteral := strings.Join(utils.Map(typeFlags, func(t typeFlagsWithNodeOrType) string {
 							return t.ToString(ctx.TypeChecker)
 						}), " | ")
-						renderedTypeValuesLiteral := renderTypeParts(typeFlags)
+						redundantParts := utils.Map(typeFlags, func(t typeFlagsWithNodeOrType) labeledTypePart {
+							redundantNode := t.node
+							if redundantNode == nil {
+								redundantNode = typeNode
+							}
+							return labeledTypePart{
+								node:     redundantNode,
+								typeName: renderTypeParts([]typeFlagsWithNodeOrType{t}),
+							}
+						})
 						var primitiveNode *ast.Node
 						if len(primitiveNodes) > 0 {
 							primitiveNode = primitiveNodes[0]
 						}
-						reportRelation(
+						reportRelations(
 							buildLiteralOverriddenMessage(typeValuesLiteral, primitiveName),
 							typeNode,
-							renderedTypeValuesLiteral,
-							primitiveNode,
-							primitiveName,
+							redundantParts,
+							[]labeledTypePart{{node: primitiveNode, typeName: primitiveName}},
 						)
 					}
 				}

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -300,6 +300,9 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 			var redundantParts, overridingParts []labeledTypePart
 			matchedNode := typePart.node
 			if matchedNode == nil {
+				matchedNode = typePart.sourceNode
+			}
+			if matchedNode == nil {
 				matchedNode = typeNode
 			}
 
@@ -496,6 +499,9 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 					var message rule.RuleMessage
 					var redundantParts, overridingParts []labeledTypePart
 					matchedNode := typePart.node
+					if matchedNode == nil {
+						matchedNode = typePart.sourceNode
+					}
 					if matchedNode == nil {
 						matchedNode = typeNode
 					}

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -48,8 +48,9 @@ func isNodeInsideReturnType(node *ast.Node) bool {
 type typeFlagsWithNodeOrType struct {
 	flags checker.TypeFlags
 	// either node or t must be non-nil
-	node *ast.Node
-	t    *checker.Type
+	node       *ast.Node
+	sourceNode *ast.Node
+	t          *checker.Type
 }
 
 type seenUnionPart struct {
@@ -191,8 +192,9 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 			res := make([]typeFlagsWithNodeOrType, len(typeParts))
 			for i, part := range typeParts {
 				res[i] = typeFlagsWithNodeOrType{
-					flags: checker.Type_flags(part),
-					t:     part,
+					flags:      checker.Type_flags(part),
+					sourceNode: node,
+					t:          part,
 				}
 			}
 			return res
@@ -594,6 +596,9 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 						}), " | ")
 						redundantParts := utils.Map(typeFlags, func(t typeFlagsWithNodeOrType) labeledTypePart {
 							redundantNode := t.node
+							if redundantNode == nil {
+								redundantNode = t.sourceNode
+							}
 							if redundantNode == nil {
 								redundantNode = typeNode
 							}

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -57,6 +57,11 @@ type seenUnionPart struct {
 	typeNode *ast.Node
 }
 
+type seenTypePart struct {
+	part     typeFlagsWithNodeOrType
+	typeNode *ast.Node
+}
+
 func (t *typeFlagsWithNodeOrType) ToString(typeChecker *checker.Checker) string {
 	if t.node != nil {
 		switch t.node.Kind {
@@ -170,8 +175,90 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 			return res
 		}
 
-		checkIntersectionBottomAndTopTypes := func(typePart typeFlagsWithNodeOrType, typeNode *ast.Node) bool {
+		typePartsToString := func(typeParts []typeFlagsWithNodeOrType) string {
+			return strings.Join(utils.Map(typeParts, func(t typeFlagsWithNodeOrType) string {
+				return t.ToString(ctx.TypeChecker)
+			}), " | ")
+		}
+		renderTypeParts := func(typeParts []typeFlagsWithNodeOrType) string {
+			return strings.Join(utils.Map(typeParts, func(typePart typeFlagsWithNodeOrType) string {
+				if typePart.node != nil {
+					return ctx.TypeChecker.TypeToString(ctx.TypeChecker.GetTypeAtLocation(typePart.node))
+				}
+				return ctx.TypeChecker.TypeToString(typePart.t)
+			}), " | ")
+		}
+
+		typeNodeToString := func(typeNode *ast.Node) string {
+			if typeNode == nil {
+				return ""
+			}
+			return typePartsToString(getTypeNodeTypePartFlags(typeNode))
+		}
+
+		firstOtherTypeNode := func(typeNodes []*ast.Node, typeNode *ast.Node) *ast.Node {
+			for _, candidate := range typeNodes {
+				if candidate != typeNode {
+					return candidate
+				}
+			}
+			return nil
+		}
+
+		renderTypeNode := func(typeNode *ast.Node, fallback string) string {
+			if typeNode == nil {
+				return fallback
+			}
+			rendered := renderTypeParts(getTypeNodeTypePartFlags(typeNode))
+			if rendered == "" {
+				return fallback
+			}
+			return rendered
+		}
+
+		reportRelation := func(
+			message rule.RuleMessage,
+			redundantNode *ast.Node,
+			redundantType string,
+			overridingNode *ast.Node,
+			overridingType string,
+		) {
+			// Some error and aliased types do not have a distinct local syntax node for
+			// both sides of the relationship. Keep the diagnostic useful in those
+			// cases, but only attach labels to ranges that are actually available.
+			primaryNode := redundantNode
+			if primaryNode == nil {
+				primaryNode = overridingNode
+			}
+			if primaryNode == nil {
+				return
+			}
+
+			labels := make([]rule.RuleLabeledRange, 0, 2)
+			if redundantNode != nil {
+				labels = append(labels, rule.RuleLabeledRange{
+					Label: fmt.Sprintf("Redundant type: `%s`", redundantType),
+					Range: utils.TrimNodeTextRange(ctx.SourceFile, redundantNode),
+				})
+			}
+			if overridingNode != nil {
+				labels = append(labels, rule.RuleLabeledRange{
+					Label: fmt.Sprintf("Overriding type: `%s`", overridingType),
+					Range: utils.TrimNodeTextRange(ctx.SourceFile, overridingNode),
+				})
+			}
+
+			ctx.ReportDiagnostic(rule.RuleDiagnostic{
+				Range:         utils.TrimNodeTextRange(ctx.SourceFile, primaryNode),
+				Message:       message,
+				LabeledRanges: labels,
+			})
+		}
+
+		checkIntersectionBottomAndTopTypes := func(typePart typeFlagsWithNodeOrType, typeNode *ast.Node, typeNodes []*ast.Node) bool {
 			var message rule.RuleMessage
+			var redundantNode, overridingNode *ast.Node
+			var redundantType, overridingType string
 
 			switch typePart.flags {
 			case checker.TypeFlagsAny:
@@ -181,24 +268,37 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				} else {
 					message = buildErrorTypeOverridesMessage(typeName, "intersection")
 				}
+				redundantNode = firstOtherTypeNode(typeNodes, typeNode)
+				redundantType = renderTypeNode(redundantNode, typeNodeToString(redundantNode))
+				overridingNode = typeNode
+				overridingType = renderTypeNode(overridingNode, typeName)
 			case checker.TypeFlagsNever:
-				message = buildOverridesMessage(typePart.ToString(ctx.TypeChecker), "intersection")
+				typeName := typePart.ToString(ctx.TypeChecker)
+				message = buildOverridesMessage(typeName, "intersection")
+				redundantNode = firstOtherTypeNode(typeNodes, typeNode)
+				redundantType = renderTypeNode(redundantNode, typeNodeToString(redundantNode))
+				overridingNode = typeNode
+				overridingType = renderTypeNode(overridingNode, typeName)
 			case checker.TypeFlagsUnknown:
-				message = buildOverriddenMessage(typePart.ToString(ctx.TypeChecker), "intersection")
+				redundantNode = typeNode
+				redundantType = renderTypeNode(redundantNode, typePart.ToString(ctx.TypeChecker))
+				overridingNode = firstOtherTypeNode(typeNodes, typeNode)
+				overridingType = renderTypeNode(overridingNode, typeNodeToString(overridingNode))
+				message = buildOverriddenMessage(redundantType, "intersection")
 			default:
 				return false
 			}
 
-			ctx.ReportNode(typeNode, message)
+			reportRelation(message, redundantNode, redundantType, overridingNode, overridingType)
 			return true
 		}
 
 		return rule.RuleListeners{
 			ast.KindIntersectionType: func(node *ast.Node) {
-				seenBigIntLiteralTypes := []typeFlagsWithNodeOrType{}
-				seenBooleanLiteralTypes := []typeFlagsWithNodeOrType{}
-				seenNumberLiteralTypes := []typeFlagsWithNodeOrType{}
-				seenStringLiteralTypes := []typeFlagsWithNodeOrType{}
+				seenBigIntLiteralTypes := []seenTypePart{}
+				seenBooleanLiteralTypes := []seenTypePart{}
+				seenNumberLiteralTypes := []seenTypePart{}
+				seenStringLiteralTypes := []seenTypePart{}
 
 				seenBigIntPrimitiveTypes := []*ast.Node{}
 				seenBooleanPrimitiveTypes := []*ast.Node{}
@@ -207,7 +307,8 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 
 				seenUnionTypes := []seenUnionPart{}
 
-				for _, typeNode := range node.AsIntersectionTypeNode().Types.Nodes {
+				typeNodes := node.AsIntersectionTypeNode().Types.Nodes
+				for _, typeNode := range typeNodes {
 					typePartFlags := getTypeNodeTypePartFlags(typeNode)
 
 					// if any typeNode is TSTypeReference and typePartFlags have more than 1 element, than the referenced type is definitely a union.
@@ -219,7 +320,7 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 					}
 
 					for _, typePart := range typePartFlags {
-						if checkIntersectionBottomAndTopTypes(typePart, typeNode) {
+						if checkIntersectionBottomAndTopTypes(typePart, typeNode, typeNodes) {
 							continue
 						}
 
@@ -227,13 +328,13 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 						if len(seenUnionTypes) == 0 {
 							switch typePart.flags {
 							case checker.TypeFlagsBigIntLiteral:
-								seenBigIntLiteralTypes = append(seenBigIntLiteralTypes, typePart)
+								seenBigIntLiteralTypes = append(seenBigIntLiteralTypes, seenTypePart{typePart, typeNode})
 							case checker.TypeFlagsBooleanLiteral:
-								seenBooleanLiteralTypes = append(seenBooleanLiteralTypes, typePart)
+								seenBooleanLiteralTypes = append(seenBooleanLiteralTypes, seenTypePart{typePart, typeNode})
 							case checker.TypeFlagsNumberLiteral:
-								seenNumberLiteralTypes = append(seenNumberLiteralTypes, typePart)
+								seenNumberLiteralTypes = append(seenNumberLiteralTypes, seenTypePart{typePart, typeNode})
 							case checker.TypeFlagsStringLiteral, checker.TypeFlagsTemplateLiteral:
-								seenStringLiteralTypes = append(seenStringLiteralTypes, typePart)
+								seenStringLiteralTypes = append(seenStringLiteralTypes, seenTypePart{typePart, typeNode})
 							}
 						}
 
@@ -259,22 +360,26 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				 * This function checks if all the union members of `F` are assignable to the other member of `I`. If every member is assignable, then its reported else not.
 				 */
 				if len(seenUnionTypes) > 0 && (len(seenBigIntPrimitiveTypes) > 0 || len(seenBooleanPrimitiveTypes) > 0 || len(seenNumberPrimitiveTypes) > 0 || len(seenStringPrimitiveTypes) > 0) {
-					var typeValuesLiteral string
-
 					for _, unionType := range seenUnionTypes {
 						var primitiveName string
+						var primitiveNode *ast.Node
 						for _, typeValue := range unionType.flags {
 							switch {
 							case typeValue.flags == checker.TypeFlagsBigIntLiteral && len(seenBigIntPrimitiveTypes) > 0:
 								primitiveName = "bigint"
+								primitiveNode = seenBigIntPrimitiveTypes[0]
 							case typeValue.flags == checker.TypeFlagsBooleanLiteral && len(seenBooleanPrimitiveTypes) > 0:
 								primitiveName = "boolean"
+								primitiveNode = seenBooleanPrimitiveTypes[0]
 							case typeValue.flags == checker.TypeFlagsNumberLiteral && len(seenNumberPrimitiveTypes) > 0:
 								primitiveName = "number"
+								primitiveNode = seenNumberPrimitiveTypes[0]
 							case (typeValue.flags == checker.TypeFlagsStringLiteral || typeValue.flags == checker.TypeFlagsTemplateLiteral) && len(seenStringPrimitiveTypes) > 0:
 								primitiveName = "string"
+								primitiveNode = seenStringPrimitiveTypes[0]
 							default:
 								primitiveName = ""
+								primitiveNode = nil
 							}
 							if len(primitiveName) == 0 {
 								break
@@ -285,27 +390,39 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 							continue
 						}
 
-						if len(typeValuesLiteral) == 0 {
-							typeValuesLiteral = strings.Join(utils.Map(unionType.flags, func(t typeFlagsWithNodeOrType) string {
-								return t.ToString(ctx.TypeChecker)
-							}), " | ")
-						}
-						ctx.ReportNode(unionType.typeNode, buildPrimitiveOverriddenMessage(primitiveName, typeValuesLiteral))
+						typeValuesLiteral := typePartsToString(unionType.flags)
+						renderedTypeValuesLiteral := renderTypeParts(unionType.flags)
+						reportRelation(
+							buildPrimitiveOverriddenMessage(typeValuesLiteral, primitiveName),
+							primitiveNode,
+							primitiveName,
+							unionType.typeNode,
+							renderedTypeValuesLiteral,
+						)
 					}
 				}
 				if len(seenUnionTypes) > 0 {
 					return
 				}
 
-				checkLiteralTypeOverridesPrimitive := func(literalTypes []typeFlagsWithNodeOrType, primitiveTypes []*ast.Node, primitiveName string) {
+				checkLiteralTypeOverridesPrimitive := func(literalTypes []seenTypePart, primitiveTypes []*ast.Node, primitiveName string) {
 					if len(literalTypes) == 0 {
 						return
 					}
-					typeValuesLiteral := strings.Join(utils.Map(literalTypes, func(t typeFlagsWithNodeOrType) string {
-						return t.ToString(ctx.TypeChecker)
+					typeValuesLiteral := strings.Join(utils.Map(literalTypes, func(t seenTypePart) string {
+						return t.part.ToString(ctx.TypeChecker)
+					}), " | ")
+					renderedTypeValuesLiteral := strings.Join(utils.Map(literalTypes, func(t seenTypePart) string {
+						return renderTypeParts([]typeFlagsWithNodeOrType{t.part})
 					}), " | ")
 					for _, typeNode := range primitiveTypes {
-						ctx.ReportNode(typeNode, buildPrimitiveOverriddenMessage(typeValuesLiteral, primitiveName))
+						reportRelation(
+							buildPrimitiveOverriddenMessage(typeValuesLiteral, primitiveName),
+							typeNode,
+							primitiveName,
+							literalTypes[0].typeNode,
+							renderedTypeValuesLiteral,
+						)
 					}
 				}
 
@@ -324,9 +441,16 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				overriddenStringTypeNodes := map[*ast.Node][]typeFlagsWithNodeOrType{}
 
 				seenPrimitiveTypeFlags := checker.TypeFlagsNone
+				seenBigIntPrimitiveTypeNodes := []*ast.Node{}
+				seenBooleanPrimitiveTypeNodes := []*ast.Node{}
+				seenNumberPrimitiveTypeNodes := []*ast.Node{}
+				seenStringPrimitiveTypeNodes := []*ast.Node{}
 
+				typeNodes := node.AsUnionTypeNode().Types.Nodes
 				checkUnionBottomAndTopTypes := func(typePart typeFlagsWithNodeOrType, typeNode *ast.Node) bool {
 					var message rule.RuleMessage
+					var redundantNode, overridingNode *ast.Node
+					var redundantType, overridingType string
 
 					switch typePart.flags {
 					case checker.TypeFlagsAny:
@@ -336,22 +460,35 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 						} else {
 							message = buildErrorTypeOverridesMessage(typeName, "union")
 						}
+						redundantNode = firstOtherTypeNode(typeNodes, typeNode)
+						redundantType = renderTypeNode(redundantNode, typeNodeToString(redundantNode))
+						overridingNode = typeNode
+						overridingType = renderTypeNode(overridingNode, typeName)
 					case checker.TypeFlagsUnknown:
-						message = buildOverridesMessage(typePart.ToString(ctx.TypeChecker), "union")
+						typeName := typePart.ToString(ctx.TypeChecker)
+						message = buildOverridesMessage(typeName, "union")
+						redundantNode = firstOtherTypeNode(typeNodes, typeNode)
+						redundantType = renderTypeNode(redundantNode, typeNodeToString(redundantNode))
+						overridingNode = typeNode
+						overridingType = renderTypeNode(overridingNode, typeName)
 					case checker.TypeFlagsNever:
 						if isNodeInsideReturnType(node) {
 							return false
 						}
+						redundantNode = typeNode
+						redundantType = renderTypeNode(redundantNode, "never")
+						overridingNode = firstOtherTypeNode(typeNodes, typeNode)
+						overridingType = renderTypeNode(overridingNode, typeNodeToString(overridingNode))
 						message = buildOverriddenMessage("never", "union")
 					default:
 						return false
 					}
 
-					ctx.ReportNode(typeNode, message)
+					reportRelation(message, redundantNode, redundantType, overridingNode, overridingType)
 					return true
 				}
 
-				for _, typeNode := range node.AsUnionTypeNode().Types.Nodes {
+				for _, typeNode := range typeNodes {
 					typePartFlags := getTypeNodeTypePartFlags(typeNode)
 
 					for _, typePart := range typePartFlags {
@@ -374,6 +511,21 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 						}
 
 						seenPrimitiveTypeFlags |= typePart.flags & (checker.TypeFlagsBigInt | checker.TypeFlagsBoolean | checker.TypeFlagsNumber | checker.TypeFlagsString)
+						// Aliases of primitive types can carry additional checker flags, so use
+						// bit tests here rather than requiring an exact flag match. The alias
+						// reference is still a precise local range for the overriding label.
+						if typePart.flags&checker.TypeFlagsBigInt != 0 {
+							seenBigIntPrimitiveTypeNodes = append(seenBigIntPrimitiveTypeNodes, typeNode)
+						}
+						if typePart.flags&checker.TypeFlagsBoolean != 0 {
+							seenBooleanPrimitiveTypeNodes = append(seenBooleanPrimitiveTypeNodes, typeNode)
+						}
+						if typePart.flags&checker.TypeFlagsNumber != 0 {
+							seenNumberPrimitiveTypeNodes = append(seenNumberPrimitiveTypeNodes, typeNode)
+						}
+						if typePart.flags&checker.TypeFlagsString != 0 {
+							seenStringPrimitiveTypeNodes = append(seenStringPrimitiveTypeNodes, typeNode)
+						}
 					}
 				}
 
@@ -381,23 +533,34 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 				// group those literals by their primitive type,
 				// then report each primitive type with all its literals
 
-				checkOverriddenTypes := func(primitiveFlag checker.TypeFlags, overriddenNodes map[*ast.Node][]typeFlagsWithNodeOrType, primitiveName string) {
+				checkOverriddenTypes := func(primitiveFlag checker.TypeFlags, overriddenNodes map[*ast.Node][]typeFlagsWithNodeOrType, primitiveNodes []*ast.Node, primitiveName string) {
 					if seenPrimitiveTypeFlags&primitiveFlag == 0 {
 						return
 					}
 
 					for typeNode, typeFlags := range overriddenNodes {
-						ctx.ReportNode(typeNode, buildLiteralOverriddenMessage(strings.Join(utils.Map(typeFlags, func(t typeFlagsWithNodeOrType) string {
+						typeValuesLiteral := strings.Join(utils.Map(typeFlags, func(t typeFlagsWithNodeOrType) string {
 							return t.ToString(ctx.TypeChecker)
-						}), " | "), primitiveName))
-
+						}), " | ")
+						renderedTypeValuesLiteral := renderTypeParts(typeFlags)
+						var primitiveNode *ast.Node
+						if len(primitiveNodes) > 0 {
+							primitiveNode = primitiveNodes[0]
+						}
+						reportRelation(
+							buildLiteralOverriddenMessage(typeValuesLiteral, primitiveName),
+							typeNode,
+							renderedTypeValuesLiteral,
+							primitiveNode,
+							primitiveName,
+						)
 					}
 				}
 
-				checkOverriddenTypes(checker.TypeFlagsBigInt, overriddenBigIntTypeNodes, "bigint")
-				checkOverriddenTypes(checker.TypeFlagsBoolean, overriddenBooleanTypeNodes, "boolean")
-				checkOverriddenTypes(checker.TypeFlagsNumber, overriddenNumberTypeNodes, "number")
-				checkOverriddenTypes(checker.TypeFlagsString, overriddenStringTypeNodes, "string")
+				checkOverriddenTypes(checker.TypeFlagsBigInt, overriddenBigIntTypeNodes, seenBigIntPrimitiveTypeNodes, "bigint")
+				checkOverriddenTypes(checker.TypeFlagsBoolean, overriddenBooleanTypeNodes, seenBooleanPrimitiveTypeNodes, "boolean")
+				checkOverriddenTypes(checker.TypeFlagsNumber, overriddenNumberTypeNodes, seenNumberPrimitiveTypeNodes, "number")
+				checkOverriddenTypes(checker.TypeFlagsString, overriddenStringTypeNodes, seenStringPrimitiveTypeNodes, "string")
 			},
 		}
 	},

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -89,6 +89,8 @@ func (t *typeFlagsWithNodeOrType) ToString(typeChecker *checker.Checker) string 
 				return "template literal type"
 			case ast.KindStringLiteral, ast.KindNumericLiteral, ast.KindBigIntLiteral:
 				return literal.Text()
+			case ast.KindPrefixUnaryExpression:
+				return typeChecker.TypeToString(typeChecker.GetTypeAtLocation(t.node))
 			}
 		}
 		return "literal type"
@@ -152,6 +154,19 @@ var NoRedundantTypeConstituentsRule = rule.Rule{
 					return []typeFlagsWithNodeOrType{{
 						flags: flags,
 						node:  node,
+					}}
+				}
+
+				// Signed numeric and bigint literal types are represented by prefix
+				// unary expressions. Preserve their syntax node while taking the literal
+				// flags from the checker so diagnostics can label only the signed token.
+				t := ctx.TypeChecker.GetTypeAtLocation(node)
+				flags = checker.Type_flags(t)
+				if flags&(checker.TypeFlagsNumberLiteral|checker.TypeFlagsBigIntLiteral) != 0 {
+					return []typeFlagsWithNodeOrType{{
+						flags: flags,
+						node:  node,
+						t:     t,
 					}}
 				}
 			}

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -756,5 +756,16 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				{MessageId: "literalOverridden"},
 			},
 		},
+		{
+			// Checker-derived top types should label their alias subnode, not its group.
+			Code: `
+        type A = any;
+        type T = (number | A) | string;
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "overrides"},
+				{MessageId: "overrides"},
+			},
+		},
 	})
 }

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -689,5 +689,29 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				},
 			},
 		},
+		{
+			Code: "type T = number | string | any;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "overrides"},
+			},
+		},
+		{
+			Code: "type T = number | string | never;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "overridden"},
+			},
+		},
+		{
+			Code: "type T = number & string & never;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "overrides"},
+			},
+		},
+		{
+			Code: "type T = number & string & unknown;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "overridden"},
+			},
+		},
 	})
 }

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -767,5 +767,12 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				{MessageId: "overrides"},
 			},
 		},
+		{
+			// The redundant primitive label must point at its nested member, not its group.
+			Code: "type T = (number | string) & (0 | 1);",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "primitiveOverridden"},
+			},
+		},
 	})
 }

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -678,5 +678,16 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Each literal that overrides the primitive needs its own labeled range.
+			Code: "type T = 0 & 1 & number;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "primitiveOverridden",
+					Column:    18,
+					EndColumn: 24,
+				},
+			},
+		},
 	})
 }

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -167,7 +167,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    19,
+					Column:    10,
+					EndColumn: 16,
 				},
 			},
 		},
@@ -179,7 +180,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    22,
+					Column:    18,
+					EndColumn: 19,
 				},
 			},
 		},
@@ -188,7 +190,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    10,
+					Column:    16,
+					EndColumn: 22,
 				},
 			},
 		},
@@ -200,7 +203,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    18,
+					Column:    22,
+					EndColumn: 28,
 				},
 			},
 		},
@@ -251,7 +255,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    19,
+					Column:    10,
+					EndColumn: 16,
 				},
 			},
 		},
@@ -260,7 +265,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    10,
+					Column:    20,
+					EndColumn: 26,
 				},
 			},
 		},
@@ -269,7 +275,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "errorTypeOverrides",
-					Column:    19,
+					Column:    30,
+					EndColumn: 31,
 				},
 			},
 		},
@@ -503,7 +510,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    19,
+					Column:    10,
+					EndColumn: 16,
 				},
 			},
 		},
@@ -512,7 +520,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    10,
+					Column:    16,
+					EndColumn: 22,
 				},
 			},
 		},
@@ -521,7 +530,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "errorTypeOverrides",
-					Column:    19,
+					Column:    30,
+					EndColumn: 31,
 				},
 			},
 		},
@@ -530,7 +540,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    19,
+					Column:    10,
+					EndColumn: 16,
 				},
 			},
 		},
@@ -542,7 +553,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    18,
+					Column:    22,
+					EndColumn: 28,
 				},
 			},
 		},
@@ -551,7 +563,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "overrides",
-					Column:    10,
+					Column:    18,
+					EndColumn: 24,
 				},
 			},
 		},
@@ -629,7 +642,8 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "primitiveOverridden",
-					Column:    18,
+					Column:    22,
+					EndColumn: 28,
 				},
 			},
 		},
@@ -642,11 +656,25 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "primitiveOverridden",
-					Column:    18,
+					Column:    35,
+					EndColumn: 41,
 				},
 				{
 					MessageId: "primitiveOverridden",
-					Column:    22,
+					Column:    26,
+					EndColumn: 32,
+				},
+			},
+		},
+		{
+			// Only the numeric member of this constituent is redundant. The string
+			// member must not be included in the redundant-type label.
+			Code: "type T = (2 | 'other') | number;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "literalOverridden",
+					Column:    10,
+					EndColumn: 23,
 				},
 			},
 		},

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -739,5 +739,15 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				{MessageId: "literalOverridden"},
 			},
 		},
+		{
+			// Every matching primitive constituent is redundant in the intersection.
+			Code: `
+        type N = number;
+        type T = (0 | 1) & number & N;
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "primitiveOverridden"},
+			},
+		},
 	})
 }

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -721,5 +721,12 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				{MessageId: "overrides"},
 			},
 		},
+		{
+			// Preserve the signed literal node when only part of a group is redundant.
+			Code: "type T = (-1 | 'other') | number;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalOverridden"},
+			},
+		},
 	})
 }

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -749,5 +749,12 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				{MessageId: "primitiveOverridden"},
 			},
 		},
+		{
+			// The primitive label must point at the matching nested member, not its group.
+			Code: "type T = 0 | (number | string);",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalOverridden"},
+			},
+		},
 	})
 }

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -728,5 +728,16 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				{MessageId: "literalOverridden"},
 			},
 		},
+		{
+			// Checker-derived union parts should fall back to their alias subnode,
+			// not the entire parenthesized constituent.
+			Code: `
+        type B = 0 | 'other';
+        type T = (2 | B) | number;
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalOverridden"},
+			},
+		},
 	})
 }

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -713,5 +713,13 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				{MessageId: "overridden"},
 			},
 		},
+		{
+			// The overriding label must point at the nested top type, not its group.
+			Code: "type T = (number | any) | string;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "overrides"},
+				{MessageId: "overrides"},
+			},
+		},
 	})
 }

--- a/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -774,5 +774,15 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				{MessageId: "primitiveOverridden"},
 			},
 		},
+		{
+			// Every matching primitive constituent overrides the literal.
+			Code: `
+        type N = number;
+        type T = 0 | number | N;
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "literalOverridden"},
+			},
+		},
 	})
 }


### PR DESCRIPTION
## Summary
- label redundant and overriding union/intersection constituents
- preserve precise local syntax ranges for aliases and literal groups
- cover mixed union constituents and update diagnostic snapshots

## Testing
- `go test ./internal/rules/no_redundant_type_constituents/...`
- `just build`
- `cd e2e && pnpm --ignore-workspace run test --run -u`