### PR TITLE
perf(no-unnecessary-type-parameters): memoize property list and return properly in argument loop

### DIFF
--- a/internal/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -330,6 +330,7 @@ func collectTypeParameterUsageCounts(
 	fromClass bool,
 ) int {
 	typeUsages := make(map[*checker.Type]int)
+	visitedSymbolLists := make(map[**ast.Symbol]struct{})
 	visitedConstraints := make(map[*ast.Node]bool)
 	visitedDefault := false
 	functionLikeType := false
@@ -377,7 +378,19 @@ func collectTypeParameterUsageCounts(
 		}
 	}
 
+	// The checker caches the property slice on a type's resolved members, so the
+	// address of its first element identifies the list the same way upstream's
+	// `visitedSymbolLists` uses array identity.
 	visitSymbolsList = func(symbols []*ast.Symbol, assumeMultipleUses bool) {
+		if len(symbols) == 0 {
+			return
+		}
+		listKey := &symbols[0]
+		if _, visited := visitedSymbolLists[listKey]; visited {
+			return
+		}
+		visitedSymbolLists[listKey] = struct{}{}
+
 		for _, symbol := range symbols {
 			if remainingTargets == 0 {
 				return

--- a/internal/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
+++ b/internal/rules/no_unnecessary_type_parameters/no_unnecessary_type_parameters.go
@@ -478,6 +478,10 @@ func collectTypeParameterUsageCounts(
 			return
 		}
 
+		// Tuple types like `[K, V]` and generic type references like `Map<K, V>`.
+		// This is terminal even when there are no type arguments to visit: it has
+		// to run before the object type catch-all below so that we never descend
+		// into every property of a generic interface or class.
 		if checker.Type_flags(typeNode)&checker.TypeFlagsObject != 0 && checker.Type_objectFlags(typeNode)&checker.ObjectFlagsReference != 0 {
 			typeArguments := checker.Checker_getTypeArguments(ctx.TypeChecker, typeNode)
 			if len(typeArguments) != 0 {
@@ -497,8 +501,8 @@ func collectTypeParameterUsageCounts(
 					}
 					visitType(typeArgument, thisAssumeMultipleUses, isReturnType)
 				}
-				return
 			}
+			return
 		}
 
 		if checker.Type_flags(typeNode)&checker.TypeFlagsTemplateLiteral != 0 {


### PR DESCRIPTION
AI Disclosure: This was generated using Claude Code, Opus 5. I have tested this change against vscode, storybook, actual, and sentry's codebases to ensure no regressions, and compared the results also to the upstream `@typescript-eslint` 8.66.0 rule. The changes fix a few weird edge-cases, and improves performance dramatically in cases where a codebase has a lot of generic type usage.

I am extremely confident in the correctness of this changeset. If desired, we can add tests covering the minor behavioral differences that we had when compared to the original eslint rule, to ensure we don't regress again in the future.

----

`no-unnecessary-type-parameters` is the most expensive rule in tsgolint on vscode — **41.9% of all rule CPU**. The Go port diverges from the upstream rule in two independent places, and both make it walk far more of the type graph than upstream does. Fixing both takes the rule from 16.80s to 0.14s of rule CPU, and a full 58-rule run from 10.76s to 6.32s.

Commit 2 is also a correctness fix. It's titled `perf` rather than `fix` because the behavior changes are rare edge cases (two diagnostics across ~28,500 files of real-world TypeScript) while the performance improvement is by far the more notable effect.

The two commits are reviewable independently.

### Change 1: missing property list memo

Upstream guards property-list expansion with [`visitSymbolsListOnce`](https://github.com/typescript-eslint/typescript-eslint/blob/878ec4b24f6935074685f4a28ce096f14d5a2296/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts#L529-L542), keyed on the identity of the array returned by `type.getProperties()`. TypeScript caches that array on the type's resolved members, so the check is effectively *"have I already expanded this type's properties?"*.

The Go port dropped the guard — presumably because Go slices aren't comparable, so the memo had nowhere obvious to live. Without it, every object type's properties get re-expanded up to **9 times** (the `incrementTypeUsages(type) > 9` cap is the only bound).

`typescript-go`'s [`getPropertiesOfType`](https://github.com/microsoft/typescript-go/blob/2bd066d87f5bafd315be9f40889d0a60b9e58e0b/internal/checker/checker.go#L18751) also returns a cached slice, so the address of its first element reproduces upstream's array identity exactly:

```go
visitedSymbolLists := make(map[**ast.Symbol]struct{})

visitSymbolsList = func(symbols []*ast.Symbol, assumeMultipleUses bool) {
	if len(symbols) == 0 {
		return
	}
	listKey := &symbols[0]
	if _, visited := visitedSymbolLists[listKey]; visited {
		return
	}
	visitedSymbolLists[listKey] = struct{}{}
	...
}
```

Behavior-preserving — identical diagnostics on every corpus tested.

### Change 2: the type reference branch was not terminal

Upstream's `visitType` is an `else if` chain, so [every branch is terminal](https://github.com/typescript-eslint/typescript-eslint/blob/878ec4b24f6935074685f4a28ce096f14d5a2296/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts#L413-L450):

```ts
else if (tsutils.isTypeReference(type)) { ... }

// Catch-all: inferred object types like `{ K: V }`.
// These catch-alls should be _after_ more specific checks like
// `isTypeReference` to avoid descending into all the properties of a
// generic interface/class, e.g. `Map<K, V>`.
else if (tsutils.isObjectType(type)) { ... }
```

The port put the `return` **inside** the type-argument guard, so it only returned when the type had type arguments:

```go
if ...Object != 0 && ...Reference != 0 {
	typeArguments := checker.Checker_getTypeArguments(ctx.TypeChecker, typeNode)
	if len(typeArguments) != 0 {
		...
		return
	}
}
// falls through into the object type catch-all below
```

A reference type whose type arguments resolve empty therefore fell into the object type catch-all and expanded **every property of the referenced interface or class** — the exact fan-out upstream's comment exists to prevent — and from there wandered across the whole reachable type graph.

Measured on vscode before the fix: only 2,506 calls reach `collectTypeParameterUsageCounts`, but they accumulate **8.1M** distinct-type map entries, with 177 calls holding ~40,000 types each. `incrementTypeUsages` alone accounted for 22% of whole-process CPU.

The fix is to move the `return` out one level, so the branch is terminal like upstream's.

## Benchmarks

vscode `src` (7,768 `.ts` files), headless, 18 logical cores, `hyperfine -w 1 -r 5`:

| all 58 rules | before | after | |
|---|---|---|---|
| wall | 10.756 s ± 0.654 | **6.320 s ± 0.515** | **1.70×** |
| user CPU | 51.39 s | 34.10 s | −34% |
| total rule CPU | 40.15 s | 21.69 s | −46% |
| this rule | 16.80 s (41.9%) | 0.14 s (0.6%) | 120× |

Where it helps, and where it doesn't:

| corpus | candidate type params | findings | rule time |
|---|---|---|---|
| vscode `src` | 1,290 | 245 | 13.69 s → 0.24 s (57×) |
| storybook `code` | 163 | 40 | 9.05 s → 0.10 s (89×) |
| sentry `static` | 317 | 10 | 2.82 s → 0.37 s (7.6×) |
| actual `packages` | 99 | 23 | 1.36 s → 0.04 s (33×) |
| bluesky social-app | 37 | 12 | 0.03 s → 0.03 s |
| oxc | 55 | 44 | 0.01 s → 0.01 s |

**On plenty of codebases this rule was already free and there is nothing to win here.** A type parameter the pure-AST scan can already see used more than once never touches the type checker, and if a declaration has no surviving candidates the expensive walk is never entered. Cost tracks *candidates × the size of the type graph reachable from their declaration*, not the number of reports — oxc has 55 candidates and 44 findings and costs 0.01 s, while sentry has 317 candidates and 10 findings and cost 2.82 s.

Memory follows the same shape: bytes allocated under the rule **drop from 615 MB to 33 MB** per vscode run (−95%, 8 alloc profiles per binary), but peak heap is unchanged — the high-water mark belongs to the parsed ASTs and the checker's type and symbol tables. This is mostly a GC-pressure win.

Commit 2 is by far the bigger lever and on real code subsumes almost all of commit 1's benefit. Commit 1 still earns its place: it bounds a case commit 2 structurally cannot reach, since a non-generic interface is not a type reference. On a synthetic web of 900 cross-referencing non-generic interfaces, commit 2 alone changes nothing (0.910 s vs 0.907 s on main) while commit 1 is worth 4.7× (0.193 s).

## Parity

Rule test suite and `go test ./internal/...` (62 packages) pass unchanged. Across ~28,500 files of real-world TypeScript, commit 1 changes nothing anywhere and commit 2 changes exactly **two** diagnostics — in both cases the new behavior is the one `@typescript-eslint` 8.66.0 produces.

<details>
<summary>Full parity results, upstream verification, and adversarial suite</summary>

Exact diagnostic-key comparison (`file|pos|end|message`) across ~28,500 files. Commit 1 changes nothing anywhere; commit 2 changes exactly **two** keys:

| corpus | files | before | after |
|---|---|---|---|
| sentry `static` | 8,789 | 10 | 10 |
| vscode `src` | 7,770 | 244 | **245** |
| storybook `code` | 3,565 | 40 | 40 |
| typescript-eslint `packages` | 2,599 | 94 | **93** |
| oxc | 1,790 | 44 | 44 |
| bluesky social-app | 1,782 | 12 | 12 |
| actual `packages` | 1,587 | 23 | 23 |
| microsoft/TypeScript `src` | 601 | 3 | 3 |

Counts are rule diagnostics only — several of these repos don't have dependencies installed, so the runs also surface `tsconfig-error` messages, identical on both sides and excluded here.

**In both cases the new behavior is the one typescript-eslint produces**, verified by running the real `@typescript-eslint/eslint-plugin@8.66.0`:

- [`vscode/.../browserEditor.ts`](https://github.com/microsoft/vscode/blob/e530e14eda999b82b70c8f9b251d02f361410cc7/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts#L398-L403) — against vscode's real `src/tsconfig.json`, upstream flags `Services` as used once on **both** `registerContribution` (L398) and `getContribution` (L403). We reported only `registerContribution`. **False negative on `getContribution`.**
- [`type-arguments1.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/878ec4b24f6935074685f4a28ce096f14d5a2296/packages/scope-manager/tests/fixtures/instantiation-expressions/type-arguments1.ts) — upstream reports only `class Foo<T>`; we additionally reported `class Bar<T>`. **False positive.** (Only appeared inside the 2,599-file combined program.)

The full 58-rule vscode run is otherwise identical: 224,233 → 224,234 keys, **nothing lost**.

### Adversarial suite

I also built a corpus from TypeScript's own conformance tests — 2,369 single-file, generics-heavy cases under one tsconfig — where output changes by **+16 diagnostics, 0 lost**, across 12 files. Running upstream on each divergent file in isolation, the new behavior matches upstream everywhere it produces output:

| file | before | after | typescript-eslint |
|---|---|---|---|
| [`cyclicTypeInstantiation`](https://github.com/microsoft/TypeScript/blob/main/tests/cases/compiler/cyclicTypeInstantiation.ts) | 0 | 2 | **2** |
| [`genericRecursiveImplicitConstructorErrors2`](https://github.com/microsoft/TypeScript/blob/main/tests/cases/compiler/genericRecursiveImplicitConstructorErrors2.ts) | 3 | 6 | **6** |
| [`functionOverloadErrors`](https://github.com/microsoft/TypeScript/blob/main/tests/cases/conformance/functions/functionOverloadErrors.ts) | 8 | 12 | **12** |
| [`bluebirdStaticThis`](https://github.com/microsoft/TypeScript/blob/main/tests/cases/compiler/bluebirdStaticThis.ts) | 0 | 1 | **1** |
| [`genericCallOnMemberReturningClosedOverObject`](https://github.com/microsoft/TypeScript/blob/main/tests/cases/compiler/genericCallOnMemberReturningClosedOverObject.ts) | 0 | 1 | **1** |
| [`instantiationExpressionErrorNoCrash`](https://github.com/microsoft/TypeScript/blob/main/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts) | 1 | 2 | 0 ⚠️ |

`genericRecursiveImplicitConstructorErrors2` also changes the message — we said "used only once" where upstream says "never used".

**Known caveat:** `instantiationExpressionErrorNoCrash.ts` is a deliberate error-recovery fixture with a circular type. Upstream reports 0, tsgolint reported 1 before and 2 after — a **pre-existing** divergence in circular error recovery that this change widens by one. It doesn't reproduce on any non-pathological input above.

</details>

## Notes for reviewers

- Both memos live per `collectTypeParameterUsageCounts` call, matching upstream's scope — no cross-file or cross-goroutine state.
- Keying `visitedSymbolLists` on `&symbols[0]` relies on `getPropertiesOfType` returning the checker's cached slice rather than a fresh one. If that ever changes the memo degrades to a no-op — i.e. back to current behavior — rather than becoming incorrect.
- Worth checking in other ported rules: an upstream `else if` chain is terminal in every branch. Where the Go port turns one into an `if` whose `return` sits under a nested condition, types fall through into a later catch-all. It's invisible in a profile — it looks like legitimate checker work.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
