### PR TITLE
fix(consistent-return): handle never-returning branches

### DIFF
--- a/internal/rule_tester/__snapshots__/consistent-return.snap
+++ b/internal/rule_tester/__snapshots__/consistent-return.snap
@@ -121,3 +121,67 @@ Message: Function 'foo' expected no return value.
      |           ~~~~~~~~~~~~~~~~~~
    8 |         }
 ---
+
+[TestConsistentReturnRule/invalid-12 - 1]
+Diagnostic 1: missingReturnValue (3:9 - 6:9)
+Message: Function 'foo' expected a return value.
+   2 |         declare function log(msg: string): void;
+   3 |         function foo(flag: boolean): number {
+     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |           if (flag) { return 42; }
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 |           log("no return");
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 |         }
+     | ~~~~~~~~~
+---
+
+[TestConsistentReturnRule/invalid-13 - 1]
+Diagnostic 1: missingReturnValue (3:9 - 7:9)
+Message: Function 'foo' expected a return value.
+   2 |         declare function abort(): never;
+   3 |         function foo(flag: boolean): number {
+     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |           if (flag) { return 42; }
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 |           if (Math.random() > 0.5) { abort(); }
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 |           else { console.log("continue"); }
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 |         }
+     | ~~~~~~~~~
+---
+
+[TestConsistentReturnRule/invalid-14 - 1]
+Diagnostic 1: missingReturnValue (3:9 - 9:9)
+Message: Function 'foo' expected a return value.
+   2 |         declare function processExit(code?: number): never;
+   3 |         function foo(flag: boolean): number {
+     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   4 |           try {
+     | ~~~~~~~~~~~~~~~
+   5 |             if (flag) return 1;
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 |           } catch {
+     | ~~~~~~~~~~~~~~~~~~~
+   7 |             processExit(1);
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   8 |           }
+     | ~~~~~~~~~~~
+   9 |         }
+     | ~~~~~~~~~
+---
+
+[TestConsistentReturnRule/invalid-15 - 1]
+Diagnostic 1: missingReturnValue (4:9 - 7:9)
+Message: Function 'foo' expected a return value.
+   3 |         declare function log(msg: string): void;
+   4 |         function foo(flag: boolean): number {
+     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   5 |           if (flag) return 1;
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   6 |           try { log("x"); } catch { abort(); }
+     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   7 |         }
+     | ~~~~~~~~~
+---

--- a/internal/rules/consistent_return/consistent_return.go
+++ b/internal/rules/consistent_return/consistent_return.go
@@ -129,6 +129,71 @@ func getHasReturnValue(ctx rule.RuleContext, node *ast.ReturnStatement, treatUnd
 	return !utils.IsUndefinedLiteral(node.Expression)
 }
 
+func isNeverReturningCall(ctx rule.RuleContext, node *ast.Node) bool {
+	if !ast.IsCallExpression(node) {
+		return false
+	}
+	t := ctx.TypeChecker.GetTypeAtLocation(node)
+	return t != nil && utils.IsTypeFlagSet(t, checker.TypeFlagsNever)
+}
+
+// statementCannotCompleteNormally reports whether control cannot reach the
+// statement that follows node.
+func statementCannotCompleteNormally(ctx rule.RuleContext, node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	if ast.IsReturnStatement(node) || ast.IsThrowStatement(node) {
+		return true
+	}
+	if ast.IsCallExpression(node) {
+		return isNeverReturningCall(ctx, node)
+	}
+	if ast.IsExpressionStatement(node) {
+		return statementCannotCompleteNormally(ctx, node.AsExpressionStatement().Expression)
+	}
+	if ast.IsLabeledStatement(node) {
+		return statementCannotCompleteNormally(ctx, node.AsLabeledStatement().Statement)
+	}
+	if ast.IsIfStatement(node) {
+		ifStmt := node.AsIfStatement()
+		return ifStmt.ElseStatement != nil &&
+			statementCannotCompleteNormally(ctx, ifStmt.ThenStatement) &&
+			statementCannotCompleteNormally(ctx, ifStmt.ElseStatement)
+	}
+	if ast.IsTryStatement(node) {
+		tryStmt := node.AsTryStatement()
+		if tryStmt.FinallyBlock != nil && statementCannotCompleteNormally(ctx, tryStmt.FinallyBlock) {
+			return true
+		}
+
+		tryAbrupt := statementCannotCompleteNormally(ctx, tryStmt.TryBlock)
+		if tryStmt.CatchClause == nil {
+			return tryAbrupt
+		}
+		return tryAbrupt && statementCannotCompleteNormally(ctx, tryStmt.CatchClause.AsCatchClause().Block)
+	}
+	if ast.IsBlock(node) {
+		statements := node.AsBlock().Statements
+		if statements == nil {
+			return false
+		}
+		for _, statement := range statements.Nodes {
+			if statementCannotCompleteNormally(ctx, statement) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func implicitReturnBlocked(ctx rule.RuleContext, functionNode *ast.Node) bool {
+	body := functionNode.Body()
+	return body != nil && ast.IsBlock(body) && statementCannotCompleteNormally(ctx, body)
+}
+
 func reportMismatchedReturnStatement(ctx rule.RuleContext, node *ast.Node, currentFunction *functionState) {
 	switch currentFunction.messageId {
 	case "missingReturnValue":
@@ -170,7 +235,8 @@ var ConsistentReturnRule = rule.Rule{
 					currentFunction.hasReturn &&
 					currentFunction.hasReturnValue &&
 					currentFunction.node.Flags&ast.NodeFlagsHasImplicitReturn != 0 &&
-					!allowsVoidReturn(currentFunction) {
+					!allowsVoidReturn(currentFunction) &&
+					!implicitReturnBlocked(ctx, currentFunction.node) {
 					ctx.ReportNode(currentFunction.node, buildMissingReturnValueMessage(getFunctionNameWithKind(ctx.SourceFile, currentFunction.node)))
 				}
 				currentFunction = currentFunction.upper

--- a/internal/rules/consistent_return/consistent_return_test.go
+++ b/internal/rules/consistent_return/consistent_return_test.go
@@ -176,6 +176,49 @@ func TestConsistentReturnRule(t *testing.T) {
           return;
         }
       `, Options: rule_tester.OptionsFromJSON[ConsistentReturnOptions](`{"treatUndefinedAsUnspecified":true}`)},
+		{Code: `
+        declare function processExit(code?: number): never;
+        function readPackageLock(): unknown {
+          try {
+            return JSON.parse("{}");
+          } catch (error) {
+            console.error(error);
+            processExit(1);
+          }
+        }
+      `},
+		{Code: `
+        declare function abort(): never;
+        function foo(flag: boolean): number {
+          if (flag) { return 42; }
+          abort();
+        }
+      `},
+		{Code: `
+        declare function abort(): never;
+        function foo(flag: boolean): number {
+          if (flag) { return 42; }
+          if (Math.random() > 0.5) { abort(); } else { abort(); }
+        }
+      `},
+		{Code: `
+        declare function abort(): never;
+        function foo(flag: boolean): number {
+          if (flag) { return 42; }
+          {
+            console.log("aborting");
+            abort();
+          }
+        }
+      `},
+		{Code: `
+        declare function abort(): never;
+        declare function log(): void;
+        function foo(flag: boolean): number {
+          if (flag) { return 42; }
+          try { log(); } finally { abort(); }
+        }
+      `},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `
@@ -404,6 +447,79 @@ func TestConsistentReturnRule(t *testing.T) {
 				},
 			},
 			Options: rule_tester.OptionsFromJSON[ConsistentReturnOptions](`{"treatUndefinedAsUnspecified":true}`),
+		},
+		{
+			Code: `
+        declare function log(msg: string): void;
+        function foo(flag: boolean): number {
+          if (flag) { return 42; }
+          log("no return");
+        }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingReturnValue",
+					Line:      3,
+					Column:    9,
+					EndLine:   6,
+					EndColumn: 10,
+				},
+			},
+		},
+		{
+			Code: `
+        declare function abort(): never;
+        function foo(flag: boolean): number {
+          if (flag) { return 42; }
+          if (Math.random() > 0.5) { abort(); }
+          else { console.log("continue"); }
+        }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingReturnValue",
+					Line:      3,
+					Column:    9,
+					EndLine:   7,
+					EndColumn: 10,
+				},
+			},
+		},
+		{
+			Code: `
+        declare function processExit(code?: number): never;
+        function foo(flag: boolean): number {
+          try {
+            if (flag) return 1;
+          } catch {
+            processExit(1);
+          }
+        }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingReturnValue",
+					Line:      3,
+					Column:    9,
+					EndLine:   9,
+					EndColumn: 10,
+				},
+			},
+		},
+		{
+			Code: `
+        declare function abort(): never;
+        declare function log(msg: string): void;
+        function foo(flag: boolean): number {
+          if (flag) return 1;
+          try { log("x"); } catch { abort(); }
+        }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingReturnValue",
+					Line:      4,
+					Column:    9,
+					EndLine:   7,
+					EndColumn: 10,
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- treat calls with a TypeScript `never` result as paths that cannot complete normally
- account for terminating blocks, `if`/`else` branches, and `try`/`catch`/`finally` combinations before reporting an implicit-return mismatch
- add positive and negative regression coverage and update the rule snapshots

## Problem

The type-aware `consistent-return` rule relied on `NodeFlagsHasImplicitReturn` when checking whether a function with value-returning branches could fall through. That syntactic flag does not account for calls whose resolved TypeScript return type is `never`.

As a result, a function that returns a value from a `try` block and terminates from its `catch` block through a call such as `process.exit()` was incorrectly reported as missing a return value.

## Implementation

The exit check now performs a conservative type-aware analysis of the function body before reporting. It recognizes `return`, `throw`, `never`-returning calls, nested blocks, fully terminating `if`/`else` branches, and terminating `try`/`catch`/`finally` combinations.

Unrecognized control-flow constructs continue to use the existing behavior, so the change does not broadly suppress diagnostics.

## Testing

- `go test -count=1 -v ./internal/rules/consistent_return` — 40/40 cases passed
- `just ready` on Ubuntu 24.04 under WSL2
  - formatting passed
  - `golangci-lint run` passed with 0 issues
  - the tsgolint build passed
  - e2e tests passed: 20 passed, 1 skipped
  - `go test ./internal/...` passed in full

## Related issue

https://github.com/oxc-project/oxc/issues/24929

## AI assistance disclosure

OpenAI Codex was used to analyze this issue, implement the patch, add regression tests, and run the validation described above. The submitter selected this specific issue and will be responsible for reviewing the change and responding to maintainer feedback.
