### PR TITLE
POC: reduce binary size with compressed TypeScript libraries

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -33,3 +33,7 @@ runs:
       run: |
         mkdir -p internal/collections
         find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \;
+
+    - name: Generate compressed TypeScript libraries
+      shell: bash
+      run: GOWORK=off go run -mod=readonly ./tools/gen_bundled_libs -input ./typescript-go/internal/bundled/libs -output ./internal/bundled/libs.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Build
-        run: go build -o tsgolint.exe ./cmd/tsgolint
+        run: just build
 
       - name: Run e2e tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 /tsgolint
 internal/collections/
+internal/bundled/libs.zip
 e2e/node_modules/
 node_modules/
 
 *.pprof
 *.out
-

--- a/cmd/tsgolint/headless.go
+++ b/cmd/tsgolint/headless.go
@@ -15,11 +15,11 @@ import (
 	"github.com/go-json-experiment/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/typescript-eslint/tsgolint/internal/bundled"
 	"github.com/typescript-eslint/tsgolint/internal/diagnostic"
 	"github.com/typescript-eslint/tsgolint/internal/linter"
 	"github.com/typescript-eslint/tsgolint/internal/rule"

--- a/cmd/tsgolint/headless_bench_test.go
+++ b/cmd/tsgolint/headless_bench_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/typescript-eslint/tsgolint/internal/bundled"
 	"github.com/typescript-eslint/tsgolint/internal/diagnostic"
 	"github.com/typescript-eslint/tsgolint/internal/linter"
 	"github.com/typescript-eslint/tsgolint/internal/rule"

--- a/cmd/tsgolint/main.go
+++ b/cmd/tsgolint/main.go
@@ -82,11 +82,11 @@ import (
 	"github.com/typescript-eslint/tsgolint/internal/rules/use_unknown_in_catch_callback_variable"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/typescript-eslint/tsgolint/internal/bundled"
 )
 
 func recordTrace(traceOut string) (func(), error) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26
 
 replace (
 	github.com/microsoft/typescript-go/shim/ast => ./shim/ast
-	github.com/microsoft/typescript-go/shim/bundled => ./shim/bundled
 	github.com/microsoft/typescript-go/shim/checker => ./shim/checker
 	github.com/microsoft/typescript-go/shim/compiler => ./shim/compiler
 	github.com/microsoft/typescript-go/shim/core => ./shim/core
@@ -22,7 +21,6 @@ replace (
 
 require (
 	github.com/microsoft/typescript-go/shim/ast v0.0.0
-	github.com/microsoft/typescript-go/shim/bundled v0.0.0
 	github.com/microsoft/typescript-go/shim/checker v0.0.0
 	github.com/microsoft/typescript-go/shim/compiler v0.0.0
 	github.com/microsoft/typescript-go/shim/core v0.0.0

--- a/internal/bundled/bundled.go
+++ b/internal/bundled/bundled.go
@@ -1,0 +1,268 @@
+// Package bundled provides compressed TypeScript standard library declarations.
+package bundled
+
+import (
+	"archive/zip"
+	_ "embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/microsoft/typescript-go/shim/vfs"
+)
+
+const scheme = "bundled:///"
+
+//go:embed libs.zip
+var archive string
+
+type archivedLibrary struct {
+	file     *zip.File
+	contents func() string
+}
+
+var (
+	libraries      map[string]*archivedLibrary
+	libraryNames   []string
+	libraryEntries []fs.DirEntry
+)
+
+func init() {
+	zipReader, err := zip.NewReader(strings.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		panic(fmt.Sprintf("bundled: read embedded archive: %v", err))
+	}
+
+	libraries = make(map[string]*archivedLibrary, len(zipReader.File))
+	libraryNames = make([]string, 0, len(zipReader.File))
+	for _, file := range zipReader.File {
+		name, ok := strings.CutPrefix(file.Name, "libs/")
+		if !ok || name == "" || strings.Contains(name, "/") || !strings.HasSuffix(name, ".d.ts") {
+			panic(fmt.Sprintf("bundled: invalid archive entry %q", file.Name))
+		}
+		if _, exists := libraries[file.Name]; exists {
+			panic(fmt.Sprintf("bundled: duplicate archive entry %q", file.Name))
+		}
+
+		zipFile := file
+		library := &archivedLibrary{file: zipFile}
+		library.contents = sync.OnceValue(func() string {
+			entry, err := zipFile.Open()
+			if err != nil {
+				panic(fmt.Sprintf("bundled: open %q: %v", zipFile.Name, err))
+			}
+			defer entry.Close()
+
+			var contents strings.Builder
+			contents.Grow(int(zipFile.UncompressedSize64))
+			if _, err := io.Copy(&contents, entry); err != nil {
+				panic(fmt.Sprintf("bundled: decompress %q: %v", zipFile.Name, err))
+			}
+			return contents.String()
+		})
+
+		libraries[file.Name] = library
+		libraryNames = append(libraryNames, name)
+	}
+	if len(libraries) == 0 {
+		panic("bundled: embedded archive is empty")
+	}
+
+	slices.Sort(libraryNames)
+	libraryEntries = make([]fs.DirEntry, 0, len(libraryNames))
+	for _, name := range libraryNames {
+		libraryEntries = append(libraryEntries, &fileInfo{
+			name: name,
+			size: int64(libraries["libs/"+name].file.UncompressedSize64),
+		})
+	}
+}
+
+func splitPath(path string) (rest string, ok bool) {
+	return strings.CutPrefix(path, scheme)
+}
+
+// LibPath returns the virtual directory containing the TypeScript libraries.
+func LibPath() string {
+	return scheme + "libs"
+}
+
+// IsBundled reports whether path belongs to the bundled virtual filesystem.
+func IsBundled(path string) bool {
+	_, ok := splitPath(path)
+	return ok
+}
+
+// WrapFS returns a filesystem that resolves bundled paths from the compressed archive.
+func WrapFS(base vfs.FS) vfs.FS {
+	return &wrappedFS{base: base}
+}
+
+type wrappedFS struct {
+	base vfs.FS
+}
+
+var _ vfs.FS = (*wrappedFS)(nil)
+
+func (w *wrappedFS) UseCaseSensitiveFileNames() bool {
+	return w.base.UseCaseSensitiveFileNames()
+}
+
+func (w *wrappedFS) FileExists(path string) bool {
+	if rest, ok := splitPath(path); ok {
+		_, ok := libraries[rest]
+		return ok
+	}
+	return w.base.FileExists(path)
+}
+
+func (w *wrappedFS) ReadFile(path string) (contents string, ok bool) {
+	if rest, ok := splitPath(path); ok {
+		library, ok := libraries[rest]
+		if !ok {
+			return "", false
+		}
+		return library.contents(), true
+	}
+	return w.base.ReadFile(path)
+}
+
+func (w *wrappedFS) DirectoryExists(path string) bool {
+	if rest, ok := splitPath(path); ok {
+		return rest == "libs"
+	}
+	return w.base.DirectoryExists(path)
+}
+
+func (w *wrappedFS) GetAccessibleEntries(path string) (result vfs.Entries) {
+	if rest, ok := splitPath(path); ok {
+		if rest == "" {
+			result.Directories = []string{"libs"}
+		} else if rest == "libs" {
+			result.Files = libraryNames
+		}
+		return result
+	}
+	return w.base.GetAccessibleEntries(path)
+}
+
+var rootEntries = []fs.DirEntry{
+	fs.FileInfoToDirEntry(&fileInfo{name: "libs", mode: fs.ModeDir}),
+}
+
+func (w *wrappedFS) Stat(path string) vfs.FileInfo {
+	if rest, ok := splitPath(path); ok {
+		if rest == "" || rest == "libs" {
+			return &fileInfo{name: rest, mode: fs.ModeDir}
+		}
+		if library, ok := libraries[rest]; ok {
+			name, _ := strings.CutPrefix(rest, "libs/")
+			return &fileInfo{name: name, size: int64(library.file.UncompressedSize64)}
+		}
+		return nil
+	}
+	return w.base.Stat(path)
+}
+
+func (w *wrappedFS) WalkDir(root string, walkFn vfs.WalkDirFunc) error {
+	if rest, ok := splitPath(root); ok {
+		if err := w.walkDir(rest, walkFn); err != nil {
+			if err == fs.SkipAll { //nolint:errorlint
+				return nil
+			}
+			return err
+		}
+		return nil
+	}
+	return w.base.WalkDir(root, walkFn)
+}
+
+func (w *wrappedFS) walkDir(rest string, walkFn vfs.WalkDirFunc) error {
+	var entries []fs.DirEntry
+	switch rest {
+	case "":
+		entries = rootEntries
+	case "libs":
+		entries = libraryEntries
+	default:
+		return nil
+	}
+
+	for _, entry := range entries {
+		name := rest + "/" + entry.Name()
+		if err := walkFn(scheme+name, entry, nil); err != nil {
+			if err == fs.SkipAll { //nolint:errorlint
+				return fs.SkipAll
+			}
+			if err == fs.SkipDir { //nolint:errorlint
+				continue
+			}
+			return err
+		}
+		if entry.IsDir() {
+			if err := w.walkDir(strings.TrimPrefix(name, "/"), walkFn); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (w *wrappedFS) Realpath(path string) string {
+	if _, ok := splitPath(path); ok {
+		return path
+	}
+	return w.base.Realpath(path)
+}
+
+func (w *wrappedFS) WriteFile(path string, data string) error {
+	if _, ok := splitPath(path); ok {
+		panic("cannot write to embedded file system")
+	}
+	return w.base.WriteFile(path, data)
+}
+
+func (w *wrappedFS) AppendFile(path string, data string) error {
+	if _, ok := splitPath(path); ok {
+		panic("cannot write to embedded file system")
+	}
+	return w.base.AppendFile(path, data)
+}
+
+func (w *wrappedFS) Remove(path string) error {
+	if _, ok := splitPath(path); ok {
+		panic("cannot remove from embedded file system")
+	}
+	return w.base.Remove(path)
+}
+
+func (w *wrappedFS) Chtimes(path string, accessTime time.Time, modificationTime time.Time) error {
+	if _, ok := splitPath(path); ok {
+		panic("cannot change times on embedded file system")
+	}
+	return w.base.Chtimes(path, accessTime, modificationTime)
+}
+
+type fileInfo struct {
+	mode fs.FileMode
+	name string
+	size int64
+}
+
+var (
+	_ fs.FileInfo = (*fileInfo)(nil)
+	_ fs.DirEntry = (*fileInfo)(nil)
+)
+
+func (fi *fileInfo) IsDir() bool                { return fi.mode.IsDir() }
+func (fi *fileInfo) ModTime() time.Time         { return time.Time{} }
+func (fi *fileInfo) Mode() fs.FileMode          { return fi.mode }
+func (fi *fileInfo) Name() string               { return fi.name }
+func (fi *fileInfo) Size() int64                { return fi.size }
+func (fi *fileInfo) Sys() any                   { return nil }
+func (fi *fileInfo) Info() (fs.FileInfo, error) { return fi, nil }
+func (fi *fileInfo) Type() fs.FileMode          { return fi.mode.Type() }

--- a/internal/bundled/bundled_test.go
+++ b/internal/bundled/bundled_test.go
@@ -1,0 +1,175 @@
+package bundled
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+)
+
+func TestEmbeddedLibrariesMatchTypescriptGo(t *testing.T) {
+	base := osvfs.FS()
+	wrapped := WrapFS(base)
+	sourceDirectory := sourceLibraryDirectory(t)
+
+	sourceEntries, err := os.ReadDir(sourceDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNames := make([]string, 0, len(sourceEntries))
+	for _, sourceEntry := range sourceEntries {
+		if sourceEntry.IsDir() || filepath.Ext(sourceEntry.Name()) != ".ts" {
+			continue
+		}
+		wantNames = append(wantNames, sourceEntry.Name())
+
+		want, err := os.ReadFile(filepath.Join(sourceDirectory, sourceEntry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := LibPath() + "/" + sourceEntry.Name()
+		got, ok := wrapped.ReadFile(path)
+		if !ok {
+			t.Fatalf("ReadFile(%q) did not find embedded library", path)
+		}
+		if got != string(want) {
+			t.Fatalf("ReadFile(%q) differs from TypeScript-Go source", path)
+		}
+
+		info := wrapped.Stat(path)
+		if info == nil {
+			t.Fatalf("Stat(%q) returned nil", path)
+		}
+		if info.Name() != sourceEntry.Name() || info.Size() != int64(len(want)) || info.IsDir() {
+			t.Fatalf("Stat(%q) = {Name: %q, Size: %d, IsDir: %v}", path, info.Name(), info.Size(), info.IsDir())
+		}
+	}
+	slices.Sort(wantNames)
+
+	entries := wrapped.GetAccessibleEntries(LibPath())
+	if !reflect.DeepEqual(entries.Files, wantNames) {
+		t.Fatalf("GetAccessibleEntries(%q) files differ", LibPath())
+	}
+	if len(entries.Directories) != 0 {
+		t.Fatalf("GetAccessibleEntries(%q) returned unexpected directories: %v", LibPath(), entries.Directories)
+	}
+
+	var walkedNames []string
+	if err := wrapped.WalkDir(LibPath(), func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			walkedNames = append(walkedNames, entry.Name())
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(walkedNames, wantNames) {
+		t.Fatal("WalkDir library names differ")
+	}
+}
+
+func TestBundledFilesystemBehavior(t *testing.T) {
+	base := osvfs.FS()
+	wrapped := WrapFS(base)
+
+	if !IsBundled(LibPath()) || IsBundled(t.TempDir()) {
+		t.Fatal("IsBundled returned an unexpected result")
+	}
+	if !wrapped.DirectoryExists(LibPath()) {
+		t.Fatalf("DirectoryExists(%q) = false", LibPath())
+	}
+	if info := wrapped.Stat(LibPath()); info == nil || !info.IsDir() {
+		t.Fatalf("Stat(%q) did not return a directory", LibPath())
+	}
+	rootEntries := wrapped.GetAccessibleEntries(scheme)
+	if !reflect.DeepEqual(rootEntries.Directories, []string{"libs"}) {
+		t.Fatalf("GetAccessibleEntries(%q) = %v", scheme, rootEntries.Directories)
+	}
+
+	missing := LibPath() + "/missing.d.ts"
+	if wrapped.FileExists(missing) {
+		t.Fatalf("FileExists(%q) = true", missing)
+	}
+	if contents, ok := wrapped.ReadFile(missing); ok || contents != "" {
+		t.Fatalf("ReadFile(%q) = (%q, %v)", missing, contents, ok)
+	}
+	if info := wrapped.Stat(missing); info != nil {
+		t.Fatalf("Stat(%q) returned %v", missing, info)
+	}
+	if got := wrapped.Realpath(missing); got != missing {
+		t.Fatalf("Realpath(%q) = %q", missing, got)
+	}
+
+	delegatedPath := filepath.Join(t.TempDir(), "delegated.ts")
+	if err := os.WriteFile(delegatedPath, []byte("export {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := wrapped.ReadFile(delegatedPath); !ok || got != "export {}" {
+		t.Fatalf("delegated ReadFile(%q) = (%q, %v)", delegatedPath, got, ok)
+	}
+}
+
+func TestBundledLibrariesCanBeReadConcurrently(t *testing.T) {
+	wrapped := WrapFS(osvfs.FS())
+	path := LibPath() + "/lib.dom.d.ts"
+	want, ok := wrapped.ReadFile(path)
+	if !ok {
+		t.Fatalf("ReadFile(%q) failed", path)
+	}
+
+	const readers = 32
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(readers)
+	for range readers {
+		go func() {
+			defer waitGroup.Done()
+			got, ok := wrapped.ReadFile(path)
+			if !ok || got != want {
+				t.Errorf("concurrent ReadFile(%q) returned inconsistent contents", path)
+			}
+		}()
+	}
+	waitGroup.Wait()
+}
+
+func TestBundledFilesystemRejectsMutations(t *testing.T) {
+	wrapped := WrapFS(osvfs.FS())
+	path := LibPath() + "/lib.d.ts"
+	tests := map[string]func() error{
+		"write":  func() error { return wrapped.WriteFile(path, "") },
+		"append": func() error { return wrapped.AppendFile(path, "") },
+		"remove": func() error { return wrapped.Remove(path) },
+		"chtimes": func() error {
+			return wrapped.Chtimes(path, time.Time{}, time.Time{})
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("mutation did not panic")
+				}
+			}()
+			_ = mutate()
+		})
+	}
+}
+
+func sourceLibraryDirectory(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine test source path")
+	}
+	return filepath.Join(filepath.Dir(filename), "..", "..", "typescript-go", "internal", "bundled", "libs")
+}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -14,12 +14,12 @@ import (
 	"github.com/typescript-eslint/tsgolint/internal/utils"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/typescript-eslint/tsgolint/internal/bundled"
 )
 
 type ConfiguredRule struct {

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/typescript-eslint/tsgolint/internal/bundled"
 	"github.com/typescript-eslint/tsgolint/internal/diagnostic"
 	"github.com/typescript-eslint/tsgolint/internal/rule"
 	"github.com/typescript-eslint/tsgolint/internal/rules/fixtures"

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/go-json-experiment/json"
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/typescript-eslint/tsgolint/internal/bundled"
 	"github.com/typescript-eslint/tsgolint/internal/diagnostic"
 	"github.com/typescript-eslint/tsgolint/internal/linter"
 	"github.com/typescript-eslint/tsgolint/internal/rule"

--- a/internal/utils/create_program.go
+++ b/internal/utils/create_program.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tsoptions"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/typescript-eslint/tsgolint/internal/bundled"
 	"github.com/typescript-eslint/tsgolint/internal/diagnostic"
 )
 

--- a/internal/utils/overlay_vfs.go
+++ b/internal/utils/overlay_vfs.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/typescript-eslint/tsgolint/internal/bundled"
 )
 
 type OverlayVFS struct {

--- a/justfile
+++ b/justfile
@@ -15,6 +15,7 @@ init:
   git submodule update --init
   pushd typescript-go && git am --3way --no-gpg-sign ../patches/*.patch && popd
   mkdir -p internal/collections && find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \;
+  GOWORK=off go run -mod=readonly ./tools/gen_bundled_libs -input ./typescript-go/internal/bundled/libs -output ./internal/bundled/libs.zip
   pnpm install
   cd e2e && pnpm --ignore-workspace install && cd ..
 
@@ -24,20 +25,22 @@ init:
   pushd typescript-go; Get-ChildItem ../patches/*.patch | ForEach-Object { git am --3way --no-gpg-sign $_.FullName }; popd
   New-Item -ItemType Directory -Force -Path internal\collections
   Get-ChildItem -Path .\typescript-go\internal\collections\* -File | Where-Object { $_.Name -notlike '*_test.go' } | ForEach-Object { Copy-Item $_.FullName -Destination .\internal\collections\ }
+  $env:GOWORK="off"; go run -mod=readonly ./tools/gen_bundled_libs -input ./typescript-go/internal/bundled/libs -output ./internal/bundled/libs.zip
   pnpm install
   Set-Location e2e; pnpm --ignore-workspace install; Set-Location ..
 
+# The local bundled package replaces typescript-go's uncompressed embedded libraries.
 [unix]
 build:
-  go build -ldflags="-s -w" -trimpath -o tsgolint ./cmd/tsgolint
+  go build -tags=noembed -ldflags="-s -w" -trimpath -o tsgolint ./cmd/tsgolint
 
 [windows]
 build:
-  $env:GOOS="windows"; $env:GOARCH="amd64"; go build -ldflags="-s -w" -trimpath -o tsgolint.exe ./cmd/tsgolint
+  $env:GOOS="windows"; $env:GOARCH="amd64"; go build -tags=noembed -ldflags="-s -w" -trimpath -o tsgolint.exe ./cmd/tsgolint
 
 test: build
   cd e2e && pnpm --ignore-workspace run test --run && cd ..
-  go test ./internal/...
+  go test ./internal/... ./tools/gen_bundled_libs
 
 update-snaps:
   UPDATE_SNAPS=true go test ./internal/...

--- a/tools/gen_bundled_libs/main.go
+++ b/tools/gen_bundled_libs/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/flate"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+var zipEpoch = time.Date(1980, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+func main() {
+	input := flag.String("input", "typescript-go/internal/bundled/libs", "directory containing TypeScript library declarations")
+	output := flag.String("output", "internal/bundled/libs.zip", "generated archive path")
+	flag.Parse()
+
+	if err := generate(*input, *output); err != nil {
+		fmt.Fprintf(os.Stderr, "generate bundled libraries: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func generate(inputDirectory string, outputPath string) error {
+	entries, err := os.ReadDir(inputDirectory)
+	if err != nil {
+		return fmt.Errorf("read input directory: %w", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".d.ts") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	if len(names) == 0 {
+		return fmt.Errorf("no .d.ts files found in %q", inputDirectory)
+	}
+	slices.Sort(names)
+
+	var archive bytes.Buffer
+	zw := zip.NewWriter(&archive)
+	zw.RegisterCompressor(zip.Deflate, func(writer io.Writer) (io.WriteCloser, error) {
+		return flate.NewWriter(writer, flate.BestCompression)
+	})
+
+	for _, name := range names {
+		contents, err := os.ReadFile(filepath.Join(inputDirectory, name))
+		if err != nil {
+			return fmt.Errorf("read %q: %w", name, err)
+		}
+
+		header := &zip.FileHeader{
+			Name:     "libs/" + name,
+			Method:   zip.Deflate,
+			Modified: zipEpoch,
+		}
+		header.SetMode(0o644)
+		writer, err := zw.CreateHeader(header)
+		if err != nil {
+			return fmt.Errorf("create archive entry %q: %w", name, err)
+		}
+		if _, err := writer.Write(contents); err != nil {
+			return fmt.Errorf("write archive entry %q: %w", name, err)
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		return fmt.Errorf("close archive: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	if err := os.WriteFile(outputPath, archive.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("write archive: %w", err)
+	}
+	return nil
+}

--- a/tools/gen_bundled_libs/main_test.go
+++ b/tools/gen_bundled_libs/main_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	inputDirectory := t.TempDir()
+	files := map[string]string{
+		"lib.d.ts":        "/// <reference no-default-lib=\"true\"/>\n",
+		"lib.es2025.d.ts": "interface Example {}\n",
+	}
+	for name, contents := range files {
+		if err := os.WriteFile(filepath.Join(inputDirectory, name), []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(inputDirectory, "ignored.txt"), []byte("ignored"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	firstOutput := filepath.Join(t.TempDir(), "first.zip")
+	secondOutput := filepath.Join(t.TempDir(), "second.zip")
+	if err := generate(inputDirectory, firstOutput); err != nil {
+		t.Fatal(err)
+	}
+	if err := generate(inputDirectory, secondOutput); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := os.ReadFile(firstOutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(secondOutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("generated archives differ")
+	}
+
+	reader, err := zip.NewReader(bytes.NewReader(first), int64(len(first)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reader.File) != len(files) {
+		t.Fatalf("archive contains %d entries, want %d", len(reader.File), len(files))
+	}
+	for _, file := range reader.File {
+		want, ok := files[filepath.Base(file.Name)]
+		if !ok {
+			t.Fatalf("unexpected archive entry %q", file.Name)
+		}
+		entry, err := file.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		contents, err := io.ReadAll(entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := entry.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if string(contents) != want {
+			t.Fatalf("contents of %q differ", file.Name)
+		}
+	}
+}
+
+func TestGenerateRejectsEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	err := generate(t.TempDir(), filepath.Join(t.TempDir(), "libs.zip"))
+	if err == nil {
+		t.Fatal("generate succeeded without any .d.ts files")
+	}
+}


### PR DESCRIPTION
Compresses bundled TypeScript libraries and excludes TypeScript-Go's uncompressed copy from release builds. This reduces release binaries by 13–14% (about 3 MB), with an approximately 5 ms cold-start cost.

Validated across all six release targets and the e2e suite.