### PR TITLE
fix(no-unnecessary-type-assertion): keep assertions that supply a call's type argument

### DIFF
--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -58,6 +58,22 @@ func buildUnnecessaryTypeAssertionDiagnostic(assertion core.TextRange, expressio
 	}
 }
 
+// collectIdentifierNames collects the name of every identifier in a type node so
+// that a type parameter can be looked up by name.
+func collectIdentifierNames(node *ast.Node, names map[string]struct{}) {
+	if node == nil {
+		return
+	}
+	if ast.IsIdentifier(node) {
+		names[node.Text()] = struct{}{}
+		return
+	}
+	node.ForEachChild(func(child *ast.Node) bool {
+		collectIdentifierNames(child, names)
+		return false
+	})
+}
+
 var NoUnnecessaryTypeAssertionRule = rule.Rule{
 	Name: "no-unnecessary-type-assertion",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
@@ -479,6 +495,63 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			}
 
 			return false
+		}
+
+		// A type parameter that appears in no parameter can only be inferred from the
+		// return position, or else fall back to its default. When such a call is the
+		// operand of a type assertion, the assertion is what the type argument gets
+		// inferred from, so the operand ends up with exactly the asserted type and the
+		// assertion looks like it changes nothing.
+		//
+		// It does: dropping the assertion makes the type argument fall back to its
+		// default, which usually stops the code from compiling. `getUncastType` asks for
+		// the context-free type to keep that inference out of the comparison, but the
+		// checker caches the resolved signature per node, so as soon as anything else has
+		// checked the call - reporting type errors alongside lint diagnostics does it for
+		// every call in the file - the context-free type is the contextual one.
+		//
+		// https://github.com/typescript-eslint/typescript-eslint/issues/6951
+		isTypeArgumentInferredFromAssertion := func(expression *ast.Node) bool {
+			call := ast.SkipParentheses(expression)
+			for ast.IsAwaitExpression(call) {
+				call = ast.SkipParentheses(call.Expression())
+			}
+			if !ast.IsCallExpression(call) && !ast.IsNewExpression(call) && !ast.IsTaggedTemplateExpression(call) {
+				return false
+			}
+			// Type arguments that are written out are not inferred from anything.
+			if call.TypeArgumentList() != nil {
+				return false
+			}
+
+			signature := checker.Checker_getResolvedSignature(ctx.TypeChecker, call, nil, checker.CheckModeNormal)
+			if signature == nil {
+				return false
+			}
+			declaration := checker.Signature_declaration(signature)
+			if declaration == nil || declaration.FunctionLikeData() == nil {
+				return false
+			}
+			typeParameters := declaration.TypeParameters()
+			if len(typeParameters) == 0 {
+				return false
+			}
+
+			namesUsedInParameters := make(map[string]struct{})
+			if parameters := declaration.ParameterList(); parameters != nil {
+				for _, parameter := range parameters.Nodes {
+					collectIdentifierNames(parameter.Type(), namesUsedInParameters)
+				}
+			}
+
+			return slices.ContainsFunc(typeParameters, func(typeParameter *ast.Node) bool {
+				name := typeParameter.Name()
+				if name == nil {
+					return false
+				}
+				_, used := namesUsedInParameters[name.Text()]
+				return !used
+			})
 		}
 
 		getUncastType := func(node *ast.Node) *checker.Type {
@@ -1106,6 +1179,9 @@ var NoUnnecessaryTypeAssertionRule = rule.Rule{
 			}
 
 			if typeIsUnchanged && wouldSameTypeBeInferred {
+				if isTypeArgumentInferredFromAssertion(expression) {
+					return
+				}
 				reportUnnecessaryTypeAssertion(node, uncastType, castType)
 				return
 			}

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
@@ -514,6 +514,23 @@ export async function main() {
   return { ...actual };
 }
 		`},
+		{
+			// https://github.com/typescript-eslint/typescript-eslint/issues/6951
+			// `T` can only be inferred from the return position, so it is inferred from
+			// the assertion itself. Dropping the assertion falls back to `T = Base`.
+			Code: `
+interface Base {
+  id: string;
+}
+interface Derived extends Base {
+  extra: number;
+}
+declare function query<T extends Base = Base>(key: string): T;
+export const run = (): number => {
+  const v = query('k') as Derived;
+  return v.extra;
+};
+		`},
 		{Code: `
 declare function load<T = unknown>(): Promise<Promise<T>>;
 

--- a/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_type_errors_test.go
+++ b/internal/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_type_errors_test.go
@@ -1,0 +1,173 @@
+package no_unnecessary_type_assertion
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/typescript-eslint/tsgolint/internal/diagnostic"
+	"github.com/typescript-eslint/tsgolint/internal/linter"
+	"github.com/typescript-eslint/tsgolint/internal/rule"
+	"github.com/typescript-eslint/tsgolint/internal/rules/fixtures"
+	"github.com/typescript-eslint/tsgolint/internal/utils"
+
+	"gotest.tools/v3/assert"
+)
+
+// Reporting TypeScript's own type errors alongside lint diagnostics checks every
+// file before the rules run, which leaves the contextually inferred signature of
+// every call cached on its node. Rules must not report differently because of it.
+func runRuleWithTypeErrors(t *testing.T, code string, reportSemantic bool) []rule.RuleDiagnostic {
+	t.Helper()
+
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir, "type-errors.ts")
+
+	fs := utils.NewOverlayVFS(cachedvfs.From(bundled.WrapFS(osvfs.FS())), map[string]string{filePath: code})
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, _, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.minimal.json", host, false)
+	assert.NilError(t, err, "couldn't create program")
+
+	var mu sync.Mutex
+	diagnostics := make([]rule.RuleDiagnostic, 0, 1)
+
+	err = linter.RunLinterOnProgram(linter.RunLinterOnProgramOptions{
+		LogLevel: utils.LogLevelNormal,
+		Program:  program,
+		Files:    []*ast.SourceFile{program.GetSourceFile(filePath)},
+		Workers:  1,
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name: NoUnnecessaryTypeAssertionRule.Name,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return NoUnnecessaryTypeAssertionRule.Run(ctx, nil)
+				},
+			}}
+		},
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			mu.Lock()
+			defer mu.Unlock()
+			diagnostics = append(diagnostics, d)
+		},
+		OnInternalDiagnostic: func(d diagnostic.Internal) {},
+		Fixes:                linter.Fixes{Fix: true, FixSuggestions: true},
+		TypeErrors:           linter.TypeErrors{ReportSyntactic: false, ReportSemantic: reportSemantic},
+	})
+	assert.NilError(t, err, "error running linter")
+
+	return diagnostics
+}
+
+func TestNoUnnecessaryTypeAssertionWithTypeErrorsReported(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		code     string
+		expected int
+	}{
+		{
+			// https://github.com/typescript-eslint/typescript-eslint/issues/6951
+			// `T` is only inferrable from the return position, so it is inferred from
+			// the assertion. Removing the assertion falls back to `T = Base`, and
+			// `v.extra` stops compiling.
+			name: "type argument inferred from the assertion",
+			code: `
+interface Base {
+  id: string;
+}
+interface Derived extends Base {
+  extra: number;
+}
+declare function query<T extends Base = Base>(key: string): T;
+export const run = (): number => {
+  const v = query('k') as Derived;
+  return v.extra;
+};
+`,
+			expected: 0,
+		},
+		{
+			name: "awaited type argument inferred from the assertion",
+			code: `
+declare const db: { list<T = unknown>(): Promise<Map<string, T>> };
+export async function get(): Promise<Map<string, Uint8Array>> {
+  return (await db.list()) as Map<string, Uint8Array>;
+}
+`,
+			expected: 0,
+		},
+		{
+			name: "tagged template type argument inferred from the assertion",
+			code: `
+interface Element { tagName: string; }
+interface HTMLCanvasElement extends Element { getContext(contextId: string): unknown; }
+declare const query: { <E extends Element = Element>(strings: TemplateStringsArray): E | null };
+export const a = query` + "`" + `.foo` + "`" + ` as HTMLCanvasElement | null;
+`,
+			expected: 0,
+		},
+		{
+			name: "doubly awaited type argument inferred from the assertion",
+			code: `
+declare function load<T = unknown>(): Promise<Promise<T>>;
+export async function main() {
+  const actual = (await await load()) as Record<string, unknown>;
+  return { ...actual };
+}
+`,
+			expected: 0,
+		},
+		{
+			name: "overloaded call with a return-only type argument",
+			code: `
+interface Element { tagName: string; }
+interface HTMLCanvasElement extends Element { getContext(contextId: string): unknown; }
+interface HTMLElementTagNameMap { canvas: HTMLCanvasElement }
+declare const document: {
+  querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
+  querySelector<E extends Element = Element>(selectors: string): E | null;
+};
+export const a = document.querySelector('.foo') as HTMLCanvasElement | null;
+`,
+			expected: 0,
+		},
+		{
+			// Control: the type argument comes from the argument, not the assertion.
+			name: "type argument inferred from an argument",
+			code: `
+declare function identity<T>(value: T): T;
+declare const s: string;
+export const value = identity(s) as string;
+`,
+			expected: 1,
+		},
+		{
+			// Control: nothing generic involved.
+			name: "assertion to the same type",
+			code: `
+declare const s: string;
+export const value = s as string;
+`,
+			expected: 1,
+		},
+	}
+
+	for _, test := range tests {
+		for _, reportSemantic := range []bool{false, true} {
+			name := test.name
+			if reportSemantic {
+				name += " (with type errors)"
+			}
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				diagnostics := runRuleWithTypeErrors(t, test.code, reportSemantic)
+				assert.Equal(t, len(diagnostics), test.expected, "unexpected diagnostic count for:\n%v", test.code)
+			})
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1141.

A type parameter that appears in none of a signature's parameters can only be inferred from the return position, or else fall back to its default. When such a call is the operand of a type assertion, the assertion is what the type argument gets inferred from, so the operand ends up with exactly the asserted type and the assertion looks like it changes nothing. It isn't — removing it drops the type argument back to its default and the code stops compiling, which is what the autofix did.

`getUncastType` already asks for the context-free type to keep that inference out of the comparison (#824), but the checker caches a call's resolved signature per node, so the guard only holds while nothing else has checked the call. Reporting type errors alongside lint diagnostics (`ReportSemantic: true`, oxlint's `--type-check`) checks every file first and defeats it every time; without it, whether the rule fired came down to concurrent scheduling.

## Summary

- don't report an assertion that is what a call's type argument gets inferred from: an (optionally awaited) call / new / tagged template with no type arguments written, whose resolved signature declares a type parameter that none of its parameters mention
- read that shape off the signature declaration instead of the checker's cached state, so the result no longer depends on what has already been checked
- add regression tests that drive the rule through `linter.RunLinterOnProgram` with `ReportSemantic: true`, since the existing rule tester runs with type errors off, where the bug does not reproduce

## Tests

- `go test ./internal/...`
- `cd e2e && pnpm --ignore-workspace run test --run`
- the 20-module reproduction from #1141, run against a build of this branch: 3-9 false positives per run before, 0 on every run after

_AI disclosure: this change was produced with AI assistance (Claude Code) and reviewed by me._
