### PR TITLE
fix(no-implied-eval): split diagnostic help text

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -1110,7 +1110,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-implied-eval/index.ts",
     "kind": 0,
     "message": {
-      "description": "Implied eval. Consider passing a function.",
+      "description": "Implied eval.",
+      "help": "Consider passing a function.",
       "id": "noImpliedEvalError",
     },
     "range": {
@@ -1123,7 +1124,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-implied-eval/index.ts",
     "kind": 0,
     "message": {
-      "description": "Implied eval. Consider passing a function.",
+      "description": "Implied eval.",
+      "help": "Consider passing a function.",
       "id": "noImpliedEvalError",
     },
     "range": {
@@ -1136,7 +1138,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-implied-eval/index.ts",
     "kind": 0,
     "message": {
-      "description": "Implied eval. Consider passing a function.",
+      "description": "Implied eval.",
+      "help": "Consider passing a function.",
       "id": "noImpliedEvalError",
     },
     "range": {
@@ -1149,7 +1152,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
     "file_path": "fixtures/basic/rules/no-implied-eval/index.ts",
     "kind": 0,
     "message": {
-      "description": "Implied eval. Consider passing a function.",
+      "description": "Implied eval.",
+      "help": "Consider passing a function.",
       "id": "noImpliedEvalError",
     },
     "range": {

--- a/internal/rule_tester/__snapshots__/no-implied-eval.snap
+++ b/internal/rule_tester/__snapshots__/no-implied-eval.snap
@@ -1,28 +1,32 @@
 
 [TestNoImpliedEvalRule/invalid-0 - 1]
 Diagnostic 1: noImpliedEvalError (2:12 - 2:18)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    1 | 
    2 | setTimeout('x = 1', 0);
      |            ~~~~~~~
    3 | setInterval('x = 1', 0);
 
 Diagnostic 2: noImpliedEvalError (3:13 - 3:19)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    2 | setTimeout('x = 1', 0);
    3 | setInterval('x = 1', 0);
      |             ~~~~~~~
    4 | setImmediate('x = 1');
 
 Diagnostic 3: noImpliedEvalError (4:14 - 4:20)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    3 | setInterval('x = 1', 0);
    4 | setImmediate('x = 1');
      |              ~~~~~~~
    5 | execScript('x = 1');
 
 Diagnostic 4: noImpliedEvalError (5:12 - 5:18)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | setImmediate('x = 1');
    5 | execScript('x = 1');
      |            ~~~~~~~
@@ -31,28 +35,32 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-1 - 1]
 Diagnostic 1: noImpliedEvalError (2:12 - 2:20)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    1 | 
    2 | setTimeout(undefined, 0);
      |            ~~~~~~~~~
    3 | setInterval(undefined, 0);
 
 Diagnostic 2: noImpliedEvalError (3:13 - 3:21)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    2 | setTimeout(undefined, 0);
    3 | setInterval(undefined, 0);
      |             ~~~~~~~~~
    4 | setImmediate(undefined);
 
 Diagnostic 3: noImpliedEvalError (4:14 - 4:22)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    3 | setInterval(undefined, 0);
    4 | setImmediate(undefined);
      |              ~~~~~~~~~
    5 | execScript(undefined);
 
 Diagnostic 4: noImpliedEvalError (5:12 - 5:20)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | setImmediate(undefined);
    5 | execScript(undefined);
      |            ~~~~~~~~~
@@ -61,28 +69,32 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-2 - 1]
 Diagnostic 1: noImpliedEvalError (2:12 - 2:30)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    1 | 
    2 | setTimeout(1 + '' + (() => {}), 0);
      |            ~~~~~~~~~~~~~~~~~~~
    3 | setInterval(1 + '' + (() => {}), 0);
 
 Diagnostic 2: noImpliedEvalError (3:13 - 3:31)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    2 | setTimeout(1 + '' + (() => {}), 0);
    3 | setInterval(1 + '' + (() => {}), 0);
      |             ~~~~~~~~~~~~~~~~~~~
    4 | setImmediate(1 + '' + (() => {}));
 
 Diagnostic 3: noImpliedEvalError (4:14 - 4:32)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    3 | setInterval(1 + '' + (() => {}), 0);
    4 | setImmediate(1 + '' + (() => {}));
      |              ~~~~~~~~~~~~~~~~~~~
    5 | execScript(1 + '' + (() => {}));
 
 Diagnostic 4: noImpliedEvalError (5:12 - 5:30)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | setImmediate(1 + '' + (() => {}));
    5 | execScript(1 + '' + (() => {}));
      |            ~~~~~~~~~~~~~~~~~~~
@@ -91,28 +103,32 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-3 - 1]
 Diagnostic 1: noImpliedEvalError (4:12 - 4:14)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    3 | 
    4 | setTimeout(foo, 0);
      |            ~~~
    5 | setInterval(foo, 0);
 
 Diagnostic 2: noImpliedEvalError (5:13 - 5:15)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | setTimeout(foo, 0);
    5 | setInterval(foo, 0);
      |             ~~~
    6 | setImmediate(foo);
 
 Diagnostic 3: noImpliedEvalError (6:14 - 6:16)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 | setInterval(foo, 0);
    6 | setImmediate(foo);
      |              ~~~
    7 | execScript(foo);
 
 Diagnostic 4: noImpliedEvalError (7:12 - 7:14)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    6 | setImmediate(foo);
    7 | execScript(foo);
      |            ~~~
@@ -121,28 +137,32 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-4 - 1]
 Diagnostic 1: noImpliedEvalError (6:12 - 6:16)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 | 
    6 | setTimeout(foo(), 0);
      |            ~~~~~
    7 | setInterval(foo(), 0);
 
 Diagnostic 2: noImpliedEvalError (7:13 - 7:17)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    6 | setTimeout(foo(), 0);
    7 | setInterval(foo(), 0);
      |             ~~~~~
    8 | setImmediate(foo());
 
 Diagnostic 3: noImpliedEvalError (8:14 - 8:18)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    7 | setInterval(foo(), 0);
    8 | setImmediate(foo());
      |              ~~~~~
    9 | execScript(foo());
 
 Diagnostic 4: noImpliedEvalError (9:12 - 9:16)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    8 | setImmediate(foo());
    9 | execScript(foo());
      |            ~~~~~
@@ -151,28 +171,32 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-5 - 1]
 Diagnostic 1: noImpliedEvalError (6:12 - 6:18)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 | 
    6 | setTimeout(foo()(), 0);
      |            ~~~~~~~
    7 | setInterval(foo()(), 0);
 
 Diagnostic 2: noImpliedEvalError (7:13 - 7:19)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    6 | setTimeout(foo()(), 0);
    7 | setInterval(foo()(), 0);
      |             ~~~~~~~
    8 | setImmediate(foo()());
 
 Diagnostic 3: noImpliedEvalError (8:14 - 8:20)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    7 | setInterval(foo()(), 0);
    8 | setImmediate(foo()());
      |              ~~~~~~~
    9 | execScript(foo()());
 
 Diagnostic 4: noImpliedEvalError (9:12 - 9:18)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    8 | setImmediate(foo()());
    9 | execScript(foo()());
      |            ~~~~~~~
@@ -181,28 +205,32 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-6 - 1]
 Diagnostic 1: noImpliedEvalError (4:12 - 4:18)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    3 | 
    4 | setTimeout(fn + '', 0);
      |            ~~~~~~~
    5 | setInterval(fn + '', 0);
 
 Diagnostic 2: noImpliedEvalError (5:13 - 5:19)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | setTimeout(fn + '', 0);
    5 | setInterval(fn + '', 0);
      |             ~~~~~~~
    6 | setImmediate(fn + '');
 
 Diagnostic 3: noImpliedEvalError (6:14 - 6:20)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 | setInterval(fn + '', 0);
    6 | setImmediate(fn + '');
      |              ~~~~~~~
    7 | execScript(fn + '');
 
 Diagnostic 4: noImpliedEvalError (7:12 - 7:18)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    6 | setImmediate(fn + '');
    7 | execScript(fn + '');
      |            ~~~~~~~
@@ -211,28 +239,32 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-7 - 1]
 Diagnostic 1: noImpliedEvalError (4:12 - 4:14)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    3 | 
    4 | setTimeout(foo, 0);
      |            ~~~
    5 | setInterval(foo, 0);
 
 Diagnostic 2: noImpliedEvalError (5:13 - 5:15)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | setTimeout(foo, 0);
    5 | setInterval(foo, 0);
      |             ~~~
    6 | setImmediate(foo);
 
 Diagnostic 3: noImpliedEvalError (6:14 - 6:16)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 | setInterval(foo, 0);
    6 | setImmediate(foo);
      |              ~~~
    7 | execScript(foo);
 
 Diagnostic 4: noImpliedEvalError (7:12 - 7:14)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    6 | setImmediate(foo);
    7 | execScript(foo);
      |            ~~~
@@ -241,28 +273,32 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-8 - 1]
 Diagnostic 1: noImpliedEvalError (4:12 - 4:14)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    3 | 
    4 | setTimeout(foo, 0);
      |            ~~~
    5 | setInterval(foo, 0);
 
 Diagnostic 2: noImpliedEvalError (5:13 - 5:15)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | setTimeout(foo, 0);
    5 | setInterval(foo, 0);
      |             ~~~
    6 | setImmediate(foo);
 
 Diagnostic 3: noImpliedEvalError (6:14 - 6:16)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 | setInterval(foo, 0);
    6 | setImmediate(foo);
      |              ~~~
    7 | execScript(foo);
 
 Diagnostic 4: noImpliedEvalError (7:12 - 7:14)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    6 | setImmediate(foo);
    7 | execScript(foo);
      |            ~~~
@@ -271,28 +307,32 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-9 - 1]
 Diagnostic 1: noImpliedEvalError (4:12 - 4:21)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    3 | 
    4 | setTimeout(foo as any, 0);
      |            ~~~~~~~~~~
    5 | setInterval(foo as any, 0);
 
 Diagnostic 2: noImpliedEvalError (5:13 - 5:22)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | setTimeout(foo as any, 0);
    5 | setInterval(foo as any, 0);
      |             ~~~~~~~~~~
    6 | setImmediate(foo as any);
 
 Diagnostic 3: noImpliedEvalError (6:14 - 6:23)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 | setInterval(foo as any, 0);
    6 | setImmediate(foo as any);
      |              ~~~~~~~~~~
    7 | execScript(foo as any);
 
 Diagnostic 4: noImpliedEvalError (7:12 - 7:21)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    6 | setImmediate(foo as any);
    7 | execScript(foo as any);
      |            ~~~~~~~~~~
@@ -301,28 +341,32 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-10 - 1]
 Diagnostic 1: noImpliedEvalError (3:14 - 3:16)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    2 | const fn = (foo: string | any) => {
    3 |   setTimeout(foo, 0);
      |              ~~~
    4 |   setInterval(foo, 0);
 
 Diagnostic 2: noImpliedEvalError (4:15 - 4:17)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    3 |   setTimeout(foo, 0);
    4 |   setInterval(foo, 0);
      |               ~~~
    5 |   setImmediate(foo);
 
 Diagnostic 3: noImpliedEvalError (5:16 - 5:18)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 |   setInterval(foo, 0);
    5 |   setImmediate(foo);
      |                ~~~
    6 |   execScript(foo);
 
 Diagnostic 4: noImpliedEvalError (6:14 - 6:16)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 |   setImmediate(foo);
    6 |   execScript(foo);
      |              ~~~
@@ -331,7 +375,8 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-11 - 1]
 Diagnostic 1: noImpliedEvalError (5:12 - 5:41)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | 
    5 | setTimeout(Math.radom() > 0.5 ? foo : bar, 0);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -340,56 +385,64 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-12 - 1]
 Diagnostic 1: noImpliedEvalError (2:19 - 2:20)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    1 | 
    2 | window.setTimeout(``, 0);
      |                   ~~
    3 | window['setTimeout'](``, 0);
 
 Diagnostic 2: noImpliedEvalError (3:22 - 3:23)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    2 | window.setTimeout(``, 0);
    3 | window['setTimeout'](``, 0);
      |                      ~~
    4 | 
 
 Diagnostic 3: noImpliedEvalError (5:20 - 5:21)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | 
    5 | window.setInterval(``, 0);
      |                    ~~
    6 | window['setInterval'](``, 0);
 
 Diagnostic 4: noImpliedEvalError (6:23 - 6:24)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 | window.setInterval(``, 0);
    6 | window['setInterval'](``, 0);
      |                       ~~
    7 | 
 
 Diagnostic 5: noImpliedEvalError (8:21 - 8:22)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    7 | 
    8 | window.setImmediate(``);
      |                     ~~
    9 | window['setImmediate'](``);
 
 Diagnostic 6: noImpliedEvalError (9:24 - 9:25)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    8 | window.setImmediate(``);
    9 | window['setImmediate'](``);
      |                        ~~
   10 | 
 
 Diagnostic 7: noImpliedEvalError (11:19 - 11:20)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
   10 | 
   11 | window.execScript(``);
      |                   ~~
   12 | window['execScript'](``);
 
 Diagnostic 8: noImpliedEvalError (12:22 - 12:23)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
   11 | window.execScript(``);
   12 | window['execScript'](``);
      |                      ~~
@@ -398,56 +451,64 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-13 - 1]
 Diagnostic 1: noImpliedEvalError (2:19 - 2:20)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    1 | 
    2 | global.setTimeout(``, 0);
      |                   ~~
    3 | global['setTimeout'](``, 0);
 
 Diagnostic 2: noImpliedEvalError (3:22 - 3:23)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    2 | global.setTimeout(``, 0);
    3 | global['setTimeout'](``, 0);
      |                      ~~
    4 | 
 
 Diagnostic 3: noImpliedEvalError (5:20 - 5:21)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | 
    5 | global.setInterval(``, 0);
      |                    ~~
    6 | global['setInterval'](``, 0);
 
 Diagnostic 4: noImpliedEvalError (6:23 - 6:24)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 | global.setInterval(``, 0);
    6 | global['setInterval'](``, 0);
      |                       ~~
    7 | 
 
 Diagnostic 5: noImpliedEvalError (8:21 - 8:22)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    7 | 
    8 | global.setImmediate(``);
      |                     ~~
    9 | global['setImmediate'](``);
 
 Diagnostic 6: noImpliedEvalError (9:24 - 9:25)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    8 | global.setImmediate(``);
    9 | global['setImmediate'](``);
      |                        ~~
   10 | 
 
 Diagnostic 7: noImpliedEvalError (11:19 - 11:20)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
   10 | 
   11 | global.execScript(``);
      |                   ~~
   12 | global['execScript'](``);
 
 Diagnostic 8: noImpliedEvalError (12:22 - 12:23)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
   11 | global.execScript(``);
   12 | global['execScript'](``);
      |                      ~~
@@ -456,56 +517,64 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-14 - 1]
 Diagnostic 1: noImpliedEvalError (2:23 - 2:24)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    1 | 
    2 | globalThis.setTimeout(``, 0);
      |                       ~~
    3 | globalThis['setTimeout'](``, 0);
 
 Diagnostic 2: noImpliedEvalError (3:26 - 3:27)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    2 | globalThis.setTimeout(``, 0);
    3 | globalThis['setTimeout'](``, 0);
      |                          ~~
    4 | 
 
 Diagnostic 3: noImpliedEvalError (5:24 - 5:25)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | 
    5 | globalThis.setInterval(``, 0);
      |                        ~~
    6 | globalThis['setInterval'](``, 0);
 
 Diagnostic 4: noImpliedEvalError (6:27 - 6:28)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    5 | globalThis.setInterval(``, 0);
    6 | globalThis['setInterval'](``, 0);
      |                           ~~
    7 | 
 
 Diagnostic 5: noImpliedEvalError (8:25 - 8:26)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    7 | 
    8 | globalThis.setImmediate(``);
      |                         ~~
    9 | globalThis['setImmediate'](``);
 
 Diagnostic 6: noImpliedEvalError (9:28 - 9:29)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    8 | globalThis.setImmediate(``);
    9 | globalThis['setImmediate'](``);
      |                            ~~
   10 | 
 
 Diagnostic 7: noImpliedEvalError (11:23 - 11:24)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
   10 | 
   11 | globalThis.execScript(``);
      |                       ~~
   12 | globalThis['execScript'](``);
 
 Diagnostic 8: noImpliedEvalError (12:26 - 12:27)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
   11 | globalThis.execScript(``);
   12 | globalThis['execScript'](``);
      |                          ~~
@@ -514,7 +583,8 @@ Message: Implied eval. Consider passing a function.
 
 [TestNoImpliedEvalRule/invalid-15 - 1]
 Diagnostic 1: noImpliedEvalError (5:12 - 5:21)
-Message: Implied eval. Consider passing a function.
+Message: Implied eval.
+Help: Consider passing a function.
    4 | 
    5 | setTimeout(foo || bar, 500);
      |            ~~~~~~~~~~

--- a/internal/rules/no_implied_eval/no_implied_eval.go
+++ b/internal/rules/no_implied_eval/no_implied_eval.go
@@ -18,7 +18,8 @@ func buildNoFunctionConstructorMessage() rule.RuleMessage {
 func buildNoImpliedEvalErrorMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "noImpliedEvalError",
-		Description: "Implied eval. Consider passing a function.",
+		Description: "Implied eval.",
+		Help:        "Consider passing a function.",
 	}
 }
 


### PR DESCRIPTION
Moves the function-alternative guidance into the diagnostic Help field.