### PR TITLE
fix(no-unsafe-type-assertion): split diagnostic help text

### DIFF
--- a/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__snapshots__/snapshot.test.ts.snap
@@ -2055,7 +2055,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
       },
     ],
     "message": {
-      "description": "Unsafe assertion to \`any\` detected: consider using a more specific type to ensure safety.",
+      "description": "Unsafe assertion to \`any\` detected.",
+      "help": "Consider using a more specific type to ensure safety.",
       "id": "unsafeToAnyTypeAssertion",
     },
     "range": {
@@ -2084,7 +2085,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
       },
     ],
     "message": {
-      "description": "Unsafe assertion from \`any\` detected: consider using type guards or a safer assertion.",
+      "description": "Unsafe assertion from \`any\` detected.",
+      "help": "Consider using type guards or a safer assertion.",
       "id": "unsafeOfAnyTypeAssertion",
     },
     "range": {
@@ -2759,7 +2761,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
       },
     ],
     "message": {
-      "description": "Unsafe assertion to \`any\` detected: consider using a more specific type to ensure safety.",
+      "description": "Unsafe assertion to \`any\` detected.",
+      "help": "Consider using a more specific type to ensure safety.",
       "id": "unsafeToAnyTypeAssertion",
     },
     "range": {
@@ -2788,7 +2791,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
       },
     ],
     "message": {
-      "description": "Unsafe assertion to \`any\` detected: consider using a more specific type to ensure safety.",
+      "description": "Unsafe assertion to \`any\` detected.",
+      "help": "Consider using a more specific type to ensure safety.",
       "id": "unsafeToAnyTypeAssertion",
     },
     "range": {
@@ -2817,7 +2821,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
       },
     ],
     "message": {
-      "description": "Unsafe assertion from \`any\` detected: consider using type guards or a safer assertion.",
+      "description": "Unsafe assertion from \`any\` detected.",
+      "help": "Consider using type guards or a safer assertion.",
       "id": "unsafeOfAnyTypeAssertion",
     },
     "range": {
@@ -2846,7 +2851,8 @@ exports[`TSGoLint E2E Snapshot Tests > should generate consistent diagnostics sn
       },
     ],
     "message": {
-      "description": "Unsafe assertion to \`any\` detected: consider using a more specific type to ensure safety.",
+      "description": "Unsafe assertion to \`any\` detected.",
+      "help": "Consider using a more specific type to ensure safety.",
       "id": "unsafeToAnyTypeAssertion",
     },
     "range": {

--- a/internal/rule_tester/__snapshots__/no-unsafe-type-assertion.snap
+++ b/internal/rule_tester/__snapshots__/no-unsafe-type-assertion.snap
@@ -1,7 +1,8 @@
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-0 - 1]
 Diagnostic 1: unsafeOfAnyTypeAssertion (3:7 - 3:15)
-Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
+Message: Unsafe assertion from `any` detected.
+Help: Consider using type guards or a safer assertion.
    2 | declare const _any_: any;
    3 | _any_ as string;
      |       ~~~~~~~~~
@@ -20,7 +21,8 @@ Message: Unsafe assertion from `any` detected: consider using type guards or a s
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-1 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (3:11 - 3:16)
-Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to `any` detected.
+Help: Consider using a more specific type to ensure safety.
    2 | declare const _unknown_: unknown;
    3 | _unknown_ as any;
      |           ~~~~~~
@@ -39,7 +41,8 @@ Message: Unsafe assertion to `any` detected: consider using a more specific type
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-2 - 1]
 Diagnostic 1: unsafeOfAnyTypeAssertion (3:7 - 3:17)
-Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
+Message: Unsafe assertion from `any` detected.
+Help: Consider using type guards or a safer assertion.
    2 | declare const _any_: any;
    3 | _any_ as Function;
      |       ~~~~~~~~~~~
@@ -58,7 +61,8 @@ Message: Unsafe assertion from `any` detected: consider using type guards or a s
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-3 - 1]
 Diagnostic 1: unsafeOfAnyTypeAssertion (3:7 - 3:14)
-Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
+Message: Unsafe assertion from `any` detected.
+Help: Consider using type guards or a safer assertion.
    2 | declare const _any_: any;
    3 | _any_ as never;
      |       ~~~~~~~~
@@ -77,7 +81,8 @@ Message: Unsafe assertion from `any` detected: consider using type guards or a s
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-4 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (2:7 - 2:12)
-Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to `any` detected.
+Help: Consider using a more specific type to ensure safety.
    1 | 
    2 | 'foo' as any;
      |       ~~~~~~
@@ -96,7 +101,8 @@ Message: Unsafe assertion to `any` detected: consider using a more specific type
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-5 - 1]
 Diagnostic 1: unsafeOfAnyTypeAssertion (2:17 - 2:25)
-Message: Unsafe assertion from error typed detected: consider using type guards or a safer assertion.
+Message: Unsafe assertion from error typed detected.
+Help: Consider using type guards or a safer assertion.
    1 | 
    2 | const bar = foo as number;
      |                 ~~~~~~~~~
@@ -115,7 +121,8 @@ Message: Unsafe assertion from error typed detected: consider using type guards 
 
 [TestNoUnsafeTypeAssertionRule_AnyAssertions/invalid-6 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (2:19 - 2:30)
-Message: Unsafe assertion to error typed detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to error typed detected.
+Help: Consider using a more specific type to ensure safety.
    1 | 
    2 | const bar = 'foo' as errorType;
      |                   ~~~~~~~~~~~~
@@ -153,7 +160,8 @@ Message: Unsafe type assertion: type 'string[]' is more narrow than the original
 
 [TestNoUnsafeTypeAssertionRule_ArrayAssertions/invalid-1 - 1]
 Diagnostic 1: unsafeOfAnyTypeAssertion (3:3 - 3:13)
-Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
+Message: Unsafe assertion from `any` detected.
+Help: Consider using type guards or a safer assertion.
    2 | declare const a: any[];
    3 | a as number[];
      |   ~~~~~~~~~~~
@@ -172,7 +180,8 @@ Message: Unsafe assertion from `any` detected: consider using type guards or a s
 
 [TestNoUnsafeTypeAssertionRule_ArrayAssertions/invalid-2 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (3:3 - 3:10)
-Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to `any` detected.
+Help: Consider using a more specific type to ensure safety.
    2 | declare const a: number[];
    3 | a as any[];
      |   ~~~~~~~~
@@ -436,7 +445,8 @@ Message: Unsafe type assertion: type '() => void' is more narrow than the origin
 
 [TestNoUnsafeTypeAssertionRule_FunctionAssertions/invalid-1 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (3:12 - 3:17)
-Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to `any` detected.
+Help: Consider using a more specific type to ensure safety.
    2 | declare const _function_: Function;
    3 | _function_ as any;
      |            ~~~~~~
@@ -645,7 +655,8 @@ Message: Unsafe type assertion: type 'T' is more narrow than the original type.
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-9 - 1]
 Diagnostic 1: unsafeOfAnyTypeAssertion (3:5 - 3:8)
-Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
+Message: Unsafe assertion from `any` detected.
+Help: Consider using type guards or a safer assertion.
    2 | function assertFromAny<T extends string | number>(x: T, y: any) {
    3 |   y as T; // banned; just an `any` complaint. Not a generic subtype.
      |     ~~~~
@@ -740,7 +751,8 @@ Message: Unsafe type assertion: type 'string' is more narrow than the original t
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-14 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (3:5 - 3:10)
-Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to `any` detected.
+Help: Consider using a more specific type to ensure safety.
    2 | function unconstrainedToAny<T>(x: T) {
    3 |   x as any;
      |     ~~~~~~
@@ -759,7 +771,8 @@ Message: Unsafe assertion to `any` detected: consider using a more specific type
 
 [TestNoUnsafeTypeAssertionRule_GenericAssertions/invalid-15 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (3:5 - 3:10)
-Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to `any` detected.
+Help: Consider using a more specific type to ensure safety.
    2 | function stringToAny<T extends string>(x: T) {
    3 |   x as any;
      |     ~~~~~~
@@ -797,7 +810,8 @@ Message: Unsafe type assertion: type '"a" | "b"' is more narrow than the origina
 
 [TestNoUnsafeTypeAssertionRule_NeverAssertions/invalid-0 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (3:9 - 3:14)
-Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to `any` detected.
+Help: Consider using a more specific type to ensure safety.
    2 | declare const _never_: never;
    3 | _never_ as any;
      |         ~~~~~~
@@ -923,7 +937,8 @@ Message: Unsafe type assertion: type 'Promise<string>' is more narrow than the o
 
 [TestNoUnsafeTypeAssertionRule_PromiseAssertions/invalid-1 - 1]
 Diagnostic 1: unsafeOfAnyTypeAssertion (3:3 - 3:20)
-Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
+Message: Unsafe assertion from `any` detected.
+Help: Consider using type guards or a safer assertion.
    2 | declare const a: Promise<any>;
    3 | a as Promise<number>;
      |   ~~~~~~~~~~~~~~~~~~
@@ -942,7 +957,8 @@ Message: Unsafe assertion from `any` detected: consider using type guards or a s
 
 [TestNoUnsafeTypeAssertionRule_PromiseAssertions/invalid-2 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (3:3 - 3:17)
-Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to `any` detected.
+Help: Consider using a more specific type to ensure safety.
    2 | declare const a: Promise<number>;
    3 | a as Promise<any>;
      |   ~~~~~~~~~~~~~~~
@@ -961,7 +977,8 @@ Message: Unsafe assertion to `any` detected: consider using a more specific type
 
 [TestNoUnsafeTypeAssertionRule_PromiseAssertions/invalid-3 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (3:3 - 3:19)
-Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to `any` detected.
+Help: Consider using a more specific type to ensure safety.
    2 | declare const a: Promise<number[]>;
    3 | a as Promise<any[]>;
      |   ~~~~~~~~~~~~~~~~~
@@ -1094,7 +1111,8 @@ Message: Unsafe type assertion: type '[string]' is more narrow than the original
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-4 - 1]
 Diagnostic 1: unsafeOfAnyTypeAssertion (3:3 - 3:13)
-Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
+Message: Unsafe assertion from `any` detected.
+Help: Consider using type guards or a safer assertion.
    2 | declare const a: [any];
    3 | a as [number];
      |   ~~~~~~~~~~~
@@ -1113,7 +1131,8 @@ Message: Unsafe assertion from `any` detected: consider using type guards or a s
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-5 - 1]
 Diagnostic 1: unsafeOfAnyTypeAssertion (3:3 - 3:21)
-Message: Unsafe assertion from `any` detected: consider using type guards or a safer assertion.
+Message: Unsafe assertion from `any` detected.
+Help: Consider using type guards or a safer assertion.
    2 | declare const a: [number, any];
    3 | a as [number, number];
      |   ~~~~~~~~~~~~~~~~~~~
@@ -1132,7 +1151,8 @@ Message: Unsafe assertion from `any` detected: consider using type guards or a s
 
 [TestNoUnsafeTypeAssertionRule_TupleAssertions/invalid-6 - 1]
 Diagnostic 1: unsafeToAnyTypeAssertion (3:3 - 3:10)
-Message: Unsafe assertion to `any` detected: consider using a more specific type to ensure safety.
+Message: Unsafe assertion to `any` detected.
+Help: Consider using a more specific type to ensure safety.
    2 | declare const a: [number];
    3 | a as [any];
      |   ~~~~~~~~

--- a/internal/rules/no_unsafe_type_assertion/no_unsafe_type_assertion.go
+++ b/internal/rules/no_unsafe_type_assertion/no_unsafe_type_assertion.go
@@ -14,13 +14,15 @@ import (
 func buildUnsafeOfAnyTypeAssertionMessage(t string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unsafeOfAnyTypeAssertion",
-		Description: fmt.Sprintf("Unsafe assertion from %v detected: consider using type guards or a safer assertion.", t),
+		Description: fmt.Sprintf("Unsafe assertion from %v detected.", t),
+		Help:        "Consider using type guards or a safer assertion.",
 	}
 }
 func buildUnsafeToAnyTypeAssertionMessage(t string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unsafeToAnyTypeAssertion",
-		Description: fmt.Sprintf("Unsafe assertion to %v detected: consider using a more specific type to ensure safety.", t),
+		Description: fmt.Sprintf("Unsafe assertion to %v detected.", t),
+		Help:        "Consider using a more specific type to ensure safety.",
 	}
 }
 func buildUnsafeToUnconstrainedTypeAssertionMessage(t string) rule.RuleMessage {


### PR DESCRIPTION
Moves safer-assertion guidance into the diagnostic Help field.