### PR TITLE
fix(no-unnecessary-boolean-literal-compare): preserve nullable boolean narrowing

### DIFF
--- a/internal/rule_tester/__snapshots__/no-unnecessary-boolean-literal-compare.snap
+++ b/internal/rule_tester/__snapshots__/no-unnecessary-boolean-literal-compare.snap
@@ -242,3 +242,40 @@ Message: This expression unnecessarily compares a boolean value to a boolean ins
 Diagnostic 1: noStrictNullCheck
 Message: This rule requires the `strictNullChecks` compiler option to be turned on to function correctly.
 ---
+
+[TestNoUnnecessaryBooleanLiteralCompareRule/invalid-28 - 1]
+Diagnostic 1: comparingNullableToTrueDirect (3:25 - 3:36)
+Message: This expression unnecessarily compares a nullable boolean value to true instead of using it directly.
+   2 |         function check(foo: boolean | null | undefined, func: (value?: true) => boolean): boolean {
+   3 |           if (func() || foo === true) {}
+     |                         ~~~~~~~~~~~~
+   4 |           const conjunction = foo === true && func(foo);
+
+Diagnostic 2: comparingNullableToTrueDirect (4:31 - 4:42)
+Message: This expression unnecessarily compares a nullable boolean value to true instead of using it directly.
+   3 |           if (func() || foo === true) {}
+   4 |           const conjunction = foo === true && func(foo);
+     |                               ~~~~~~~~~~~~
+   5 |           const negated = !(foo !== true);
+
+Diagnostic 3: comparingNullableToTrueNegated (5:29 - 5:40)
+Message: This expression unnecessarily compares a nullable boolean value to true instead of negating it.
+   4 |           const conjunction = foo === true && func(foo);
+   5 |           const negated = !(foo !== true);
+     |                             ~~~~~~~~~~~~
+   6 |           if ((foo === true) ?? func()) {}
+
+Diagnostic 4: comparingNullableToTrueDirect (6:16 - 6:27)
+Message: This expression unnecessarily compares a nullable boolean value to true instead of using it directly.
+   5 |           const negated = !(foo !== true);
+   6 |           if ((foo === true) ?? func()) {}
+     |                ~~~~~~~~~~~~
+   7 |           return foo === true;
+
+Diagnostic 5: comparingNullableToTrueDirect (7:18 - 7:29)
+Message: This expression unnecessarily compares a nullable boolean value to true instead of using it directly.
+   6 |           if ((foo === true) ?? func()) {}
+   7 |           return foo === true;
+     |                  ~~~~~~~~~~~~
+   8 |         }
+---

--- a/internal/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.go
+++ b/internal/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.go
@@ -1,6 +1,8 @@
 package no_unnecessary_boolean_literal_compare
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
@@ -54,6 +56,35 @@ type booleanComparison struct {
 
 func isBooleanType(t *checker.Type) bool {
 	return utils.IsTypeFlagSet(t, checker.TypeFlagsBooleanLike)
+}
+
+func isConditionalTest(node *ast.Node) bool {
+	for parent := node.Parent; parent != nil; parent = node.Parent {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression:
+		case ast.KindBinaryExpression:
+			operator := parent.AsBinaryExpression().OperatorToken.Kind
+			if operator != ast.KindAmpersandAmpersandToken && operator != ast.KindBarBarToken {
+				return false
+			}
+		case ast.KindIfStatement:
+			return parent.AsIfStatement().Expression == node
+		case ast.KindWhileStatement:
+			return parent.AsWhileStatement().Expression == node
+		case ast.KindDoStatement:
+			return parent.AsDoStatement().Expression == node
+		case ast.KindForStatement:
+			return parent.AsForStatement().Condition == node
+		case ast.KindConditionalExpression:
+			return parent.AsConditionalExpression().Condition == node
+		case ast.KindPrefixUnaryExpression:
+			return parent.AsPrefixUnaryExpression().Operator == ast.KindExclamationToken
+		default:
+			return false
+		}
+		node = parent
+	}
+	return false
 }
 
 var NoUnnecessaryBooleanLiteralCompareRule = rule.Rule{
@@ -169,6 +200,16 @@ var NoUnnecessaryBooleanLiteralCompareRule = rule.Rule{
 					mutatedNode := node
 					if isUnaryNegation {
 						mutatedNode = parent
+					}
+
+					if comparison.expressionIsNullableBoolean && comparison.literalBooleanInComparison &&
+						shouldNegate != isUnaryNegation && !isConditionalTest(mutatedNode) {
+						text := strings.TrimSpace(ctx.SourceFile.Text()[comparison.expression.Pos():comparison.expression.End()])
+						if !utils.IsStrongPrecedenceNode(comparison.expression) {
+							text = "(" + text + ")"
+						}
+						// Coercion preserves both the boolean result and TypeScript's narrowing.
+						return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, mutatedNode, "(!!"+text+")")}
 					}
 
 					fixes := make([]rule.RuleFix, 0, 6)

--- a/internal/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare_test.go
+++ b/internal/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare_test.go
@@ -615,5 +615,33 @@ function foo(): boolean {}
 				},
 			},
 		},
+		{
+			Code: `
+        function check(foo: boolean | null | undefined, func: (value?: true) => boolean): boolean {
+          if (func() || foo === true) {}
+          const conjunction = foo === true && func(foo);
+          const negated = !(foo !== true);
+          if ((foo === true) ?? func()) {}
+          return foo === true;
+        }
+      `,
+			Output: []string{`
+        function check(foo: boolean | null | undefined, func: (value?: true) => boolean): boolean {
+          if (func() ||  foo) {}
+          const conjunction = (!!foo) && func(foo);
+          const negated = (!!foo);
+          if (((!!foo)) ?? func()) {}
+          return (!!foo);
+        }
+      `},
+			Options: rule_tester.OptionsFromJSON[NoUnnecessaryBooleanLiteralCompareOptions](`{"allowComparingNullableBooleansToTrue": false}`),
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "comparingNullableToTrueDirect"},
+				{MessageId: "comparingNullableToTrueDirect"},
+				{MessageId: "comparingNullableToTrueNegated"},
+				{MessageId: "comparingNullableToTrueDirect"},
+				{MessageId: "comparingNullableToTrueDirect"},
+			},
+		},
 	})
 }


### PR DESCRIPTION
When `allowComparingNullableBooleansToTrue` is false, fixing `value === true` can expose `null` or `undefined` where the comparison returned a boolean. Use `!!value` when the result can escape a conditional test, while preserving direct-value simplification inside conditions, including nested `&&` and `||`.

Boolean coercion also preserves TypeScript narrowing. For example, this must still type-check after fixing the comparison:

```ts
declare function acceptsTrue(value: true): boolean;
function check(value: boolean | undefined) {
  return value === true && acceptsTrue(value);
}
```

The fix produces `(!!value) && acceptsTrue(value)`. Using `(value ?? false)` here loses narrowing and produces TS2345. Conditional-context traversal stops at `??` so a fix cannot newly evaluate its fallback.

Related: [typescript-eslint/typescript-eslint#3783](https://github.com/typescript-eslint/typescript-eslint/issues/3783) and its accepted [fix #12365](https://github.com/typescript-eslint/typescript-eslint/pull/12365). Double negation is one of the solutions proposed in the issue and also preserves narrowing.

Validation:

- The existing regression now covers nullable results, narrowing within a conjunction, a nested condition, negation cancellation, and a nullish fallback. It fails with the previous coalescing implementation and passes with coercion.
- Directly applied the native binary's emitted fix and checked original and fixed code with TypeScript 7.0.2: both pass. The coalescing version fails with TS2345.
- `go test ./internal/... -count=1` passes.
- `pnpm --ignore-workspace run test --run` in `e2e`: 20 passed, one existing skip.
- `gofmt` and `git diff --check` pass. Full dprint and golangci-lint checks remain pending CI; the local formatting-plugin download timed out.
