### PR TITLE
fix: report unparsable files instead of panicking

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -168,8 +168,20 @@ func RunLinter(options RunLinterOptions) error {
 	}
 
 	{
+		// A file that belongs to no tsconfig goes into an inferred project, so its extension has to be
+		// one TypeScript itself can parse. Report the rest instead of handing them to the parser, which
+		// has no script kind for them.
+		inferredFiles := make([]string, 0, len(workload.UnmatchedFiles))
+		for _, f := range workload.UnmatchedFiles {
+			if core.GetScriptKindFromFileName(f) == core.ScriptKindUnknown {
+				onInternalDiagnostic(unsupportedFileExtensionDiagnostic(f))
+				continue
+			}
+			inferredFiles = append(inferredFiles, f)
+		}
+
 		host := utils.NewCachedFSCompilerHost(currentDirectory, fs, bundled.LibPath(), nil, nil)
-		program, diagnostics, err := utils.CreateInferredProjectProgram(false, fs, currentDirectory, host, workload.UnmatchedFiles)
+		program, diagnostics, err := utils.CreateInferredProjectProgram(false, fs, currentDirectory, host, inferredFiles)
 
 		if err != nil {
 			return err
@@ -181,8 +193,8 @@ func RunLinter(options RunLinterOptions) error {
 			}
 		}
 
-		files := make([]*ast.SourceFile, 0, len(workload.UnmatchedFiles))
-		for _, f := range workload.UnmatchedFiles {
+		files := make([]*ast.SourceFile, 0, len(inferredFiles))
+		for _, f := range inferredFiles {
 			sf := program.GetSourceFile(f)
 			if sf == nil {
 				panic(fmt.Sprintf("Expected file '%s' to be in inferred program", f))
@@ -209,6 +221,23 @@ func RunLinter(options RunLinterOptions) error {
 
 	return nil
 
+}
+
+// unsupportedFileExtensionDiagnostic reports a file tsgolint was asked to lint but cannot parse. A
+// file only reaches this point when it belongs to no tsconfig, so there is no configuration that
+// could register a parser for it.
+func unsupportedFileExtensionDiagnostic(fileName string) diagnostic.Internal {
+	extension := tspath.GetAnyExtensionFromPath(fileName, nil, false)
+	if extension == "" {
+		extension = "this file"
+	}
+	return diagnostic.Internal{
+		Range:       core.NewTextRange(0, 0),
+		Id:          "unsupported-file-extension",
+		Description: "Unsupported file extension",
+		Help:        "tsgolint cannot type-check " + extension + " files. Only files TypeScript can parse are supported.",
+		FilePath:    &fileName,
+	}
 }
 
 // ruleContextBuilder is a per-worker struct that provides the RuleContext

--- a/internal/linter/unsupported_extension_test.go
+++ b/internal/linter/unsupported_extension_test.go
@@ -1,0 +1,51 @@
+package linter
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/typescript-eslint/tsgolint/internal/diagnostic"
+	"github.com/typescript-eslint/tsgolint/internal/rule"
+	"github.com/typescript-eslint/tsgolint/internal/rules/fixtures"
+	"github.com/typescript-eslint/tsgolint/internal/utils"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestUnsupportedExtensionIsReported covers a file whose extension TypeScript cannot parse. It
+// belongs to no tsconfig, so it reaches the inferred project, where the parser has no script kind for
+// it and used to panic. It has to land on a diagnostic instead.
+func TestUnsupportedExtensionIsReported(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	unparsableFile := tspath.ResolvePath(rootDir, "component.gts")
+
+	fs := utils.NewOverlayVFS(cachedBaseFS, map[string]string{
+		unparsableFile: "const a = 1;\n<template>{{a}}</template>\n",
+	})
+
+	var mu sync.Mutex
+	var internalDiags []diagnostic.Internal
+	err := RunLinter(RunLinterOptions{
+		LogLevel:         utils.LogLevelNormal,
+		CurrentDirectory: rootDir,
+		FS:               fs,
+		Workload:         Workload{Programs: map[string][]string{}, UnmatchedFiles: []string{unparsableFile}},
+		Workers:          1,
+		GetRulesForFile:  func(*ast.SourceFile) []ConfiguredRule { return nil },
+		OnRuleDiagnostic: func(rule.RuleDiagnostic) {},
+		OnInternalDiagnostic: func(d diagnostic.Internal) {
+			mu.Lock()
+			defer mu.Unlock()
+			internalDiags = append(internalDiags, d)
+		},
+	})
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(internalDiags), 1)
+	assert.Equal(t, internalDiags[0].Id, "unsupported-file-extension")
+	assert.Equal(t, *internalDiags[0].FilePath, unparsableFile)
+	assert.Assert(t, strings.Contains(internalDiags[0].Help, ".gts"), "help should name the extension: %v", internalDiags[0].Help)
+}


### PR DESCRIPTION
Passing a file whose extension TypeScript cannot parse to `tsgolint headless` crashes the process:

```
panic: Unknown script kind for file  .../src/component.gts [recovered, repanicked]
  utils.(*compilerHost).GetSourceFile
    internal/utils/host.go:96
```

Such a file matches no tsconfig, so it ends up in the inferred project, and `GetSourceFile` has no
script kind for it. Reproduced on `main` at 3b600f4 with a plain tsconfig and a single `.gts` in the
payload. No unusual configuration is needed.

This is reachable from oxlint. Its type-aware path used to filter candidates through
`SourceType::from_path`, which dropped anything it could not classify before tsgolint saw it. Once a
`languageOptions.parser` override makes a file eligible, oxlint forwards the original path, and a
crash is a worse outcome than the silence users got before.

## Change

Partition the unmatched files before building the inferred program. Anything
`core.GetScriptKindFromFileName` cannot classify gets an internal diagnostic instead of going to the
parser:

```json
{"kind": 1,
 "message": {"id": "unsupported-file-extension",
             "description": "Unsupported file extension",
             "help": "tsgolint cannot type-check .gts files. Only files TypeScript can parse are supported."},
 "file_path": ".../src/component.gts"}
```

`kind: 1` is the existing internal-diagnostic variant, so consumers need no changes. tsgolint exits 0.

The range is `[0, 0)`, which renders as a caret on the first character. That reads a little oddly for
a whole-file condition, but the file has no better anchor, and a synthetic full-file span would
misstate where the problem is. Happy to change it if you would rather.

## Testing

`TestUnsupportedExtensionIsReported` drives `RunLinter` with an unparsable file in `UnmatchedFiles`
and asserts the diagnostic rather than a panic. No new dependencies, and it does not need node.

Also ran `go test ./internal/...` and the e2e suite, both green, and confirmed by hand that the same
payload panics before the change and reports cleanly after.

## Context

I hit this while wiring up TypeScript 7 content mappers so type-aware rules can check Ember `.gts`
through a mapper. That work depends on #1143 and is not ready, but this crash stands on its own and
is not specific to content mappers or to any one extension, so I have split it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
